### PR TITLE
Fix apt command with missing python package

### DIFF
--- a/download/building_root/build_prerequisites.md
+++ b/download/building_root/build_prerequisites.md
@@ -115,7 +115,7 @@ Required packages:
 
 ~~~
 sudo apt-get install git dpkg-dev cmake g++ gcc binutils libx11-dev libxpm-dev \
-libxft-dev libxext-dev
+libxft-dev libxext-dev python
 ~~~
 
 Optional packages:


### PR DESCRIPTION
It's mentioned in the list above, but missing in the sample command. I checked this on the new Ubuntu 20.04, so the headline could be updated as well.