### PR TITLE
Rename "About ..." to just "About"

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -1,7 +1,7 @@
 # main links => top menu bar
 
 main:
-  - title: "About ..."
+  - title: "About"
     url: about
     description: "About ROOT"
   - title: "Download"


### PR DESCRIPTION
On a webpage, three dots make it seem like part of the text was cut.