### PR TITLE
Have links mention what they link to

### DIFF
--- a/get_started/index.md
+++ b/get_started/index.md
@@ -10,12 +10,12 @@ On behalf of the developers, contributors and user community: **welcome to ROOT!
 The [ROOT beginners' guide (aka "Primer")]({{ '/primer' | relative_url }})
 is certainly the first document to read to master the power of ROOT.
 After this introduction,
-[these slides (and video!)](https://indico.cern.ch/event/395198){:target="_blank"} offer a
+[tutorial presentations (and video!)](https://indico.cern.ch/event/395198){:target="_blank"} offer a
 different, more direct approach to the ROOT fundamental
 concepts as well as some hands-on exercise. In order to integrate the information present
-in the aforementioned sources, [these resources](courses){:target="_blank"}
-are definitively useful. Once the fundamental concepts have been acquired, a rich set of
-code examples can be found [here]({{ '/get_started/code_examples' | relative_url }}).
+in the aforementioned sources, [this collection of ROOT courses](courses){:target="_blank"}
+is definitively useful. Once the fundamental concepts have been acquired, a rich set of
+[code examples]({{ '/get_started/code_examples' | relative_url }}) are available to dive into the code.
 
 Remember, you can always resort to the
 [ROOT Forum](https://root-forum.cern.ch){:target="_blank"}


### PR DESCRIPTION
It improves usability: links stand out, and if they say what they link
to, you probably don't have to read the rest of the text.