### PR TITLE
Make about section navbar a flat list of useful links

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -208,19 +208,6 @@ contribute:
 about:
    - title: About ROOT
      url: about
-     children:
-      - title: Save data
-        url: about/save_data
-      - title: Access data
-        url: about/access_data
-      - title: Mine data
-        url: about/mine_data
-      - title: Publish Results
-        url: about/publish_results
-      - title: Interactive or Built Applications
-        url: about/interactive_or_built_applications
-      - title: Integration with other languages
-        url: about/integration_with_other_languages
    - title: License
      url: about/license
    - title: Versioning


### PR DESCRIPTION
No need to repeat the page text in the navbar.

Partially addresses #8 