### PR TITLE
Add a link to the #cite section in the github readme in /about

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -216,6 +216,9 @@ about:
      url: about/team
    - title: Previous Developers
      url: about/previous_developers
+   - title: Cite us
+     url: https://github.com/root-project/root/#cite
+     target: _blank
 
 start:
    - title: Get Started


### PR DESCRIPTION
On top, https://github.com/root-project/root/pull/5880 clarifies how we want to be cited in the README section we link to.

`target: _blank` does not make the link open in a new window, don't know why, see #166 