### PR TITLE
Re-order package managers

### DIFF
--- a/install/index.md
+++ b/install/index.md
@@ -39,6 +39,19 @@ Note, however, that sourcing `thisroot.sh` might interfere with ROOT versions in
 
 > **Supported by the community:** these packages are not maintained by the ROOT team, but by helpful members of the community. Please go through each package manager's standard channels to report any related issue. If you package ROOT and would like to be added to the list below, please contact us by clicking the letter icon at the bottom of the page.
 
+## Conda
+
+For any Linux distribution and MacOS, ROOT is available as a [conda package](https://anaconda.org/conda-forge/root/){:target="\_blank"}. To create a new conda environment containing ROOT and activate it, execute
+
+```sh
+$ conda create -c conda-forge --name <my-environment> root
+$ conda activate <my-environment>
+```
+
+More instructions about using the conda package are available in [this blog post](https://iscinumpy.gitlab.io/post/root-conda/).
+
+Please report any issues with the conda package [here](https://github.com/conda-forge/root-feedstock){:target="\_blank"}.
+
 ## Linux package managers
 
 ROOT can be directly installed from the operating system's package manager in the following Linux distributions:
@@ -90,20 +103,9 @@ $ emerge sci-physics/root
 The ROOT team is working on the release of an official `.deb` package. More news on this topic very soon.<br>
 In the meanwhile, ROOT is available on Ubuntu via [conda](#conda) or our [pre-compiled binaries](#download-a-pre-compiled-binary-distribution).
 
-## Conda
+## MacOS package managers
 
-For any Linux distribution and MacOS, ROOT is available as a [conda package](https://anaconda.org/conda-forge/root/){:target="\_blank"}. To create a new conda environment containing ROOT and activate it, execute
-
-```sh
-$ conda create -c conda-forge --name <my-environment> root
-$ conda activate <my-environment>
-```
-
-More instructions about using the conda package are available in [this blog post](https://iscinumpy.gitlab.io/post/root-conda/).
-
-Please report any issues with the conda package [here](https://github.com/conda-forge/root-feedstock){:target="\_blank"}.
-
-## Homebrew for MacOS
+### Homebrew
 
 On Mac, ROOT is also available as a [homebrew formula](https://formulae.brew.sh/formula/root){:target="\_blank"}.
 You can install it with
@@ -112,7 +114,7 @@ You can install it with
 $ brew install root
 ```
 
-## Macports
+### Macports
 
 After [installing macports](https://www.macports.org/install.php), the [ROOT port](https://ports.macports.org/port/root6/summary) can be installed with
 


### PR DESCRIPTION
Put the most generic, conda, upfront. Then divide between linux
packages and macos packages.