### PR TITLE
fail html proofer only due to 4xx error codes

### DIFF
--- a/.github/workflows/html-proofer.yml
+++ b/.github/workflows/html-proofer.yml
@@ -23,4 +23,4 @@ jobs:
           # - rootbnch-grafana-test.cern.ch: Breaks due to SSO
           # - lcgapp-services.cern.ch: Breaks due to SSO
           # - indico.desy.de: Returns frequently error code 403
-          arguments: --empty-alt-ignore --file-ignore "/(releases|page.?/index.html)/" --allow-hash-href --url-ignore "/(https://ph-root-2.cern.ch/.*|https://rootbnch-grafana-test.cern.ch|https://lcgapp-services.cern.ch/root-jenkins|https://indico.desy.de.*)/"
+          arguments: --empty-alt-ignore --file-ignore "/(releases|page.?/index.html)/" --allow-hash-href --url-ignore "/(https://ph-root-2.cern.ch/.*|https://rootbnch-grafana-test.cern.ch|https://lcgapp-services.cern.ch/root-jenkins|https://indico.desy.de.*)/" --only-4xx


### PR DESCRIPTION
@eguiraud What do you think? We have spurious failures of the CI, e.g., https://github.com/root-project/web/pull/228, just because another server is not responsive.

![Screenshot from 2020-06-19 08-22-01](https://user-images.githubusercontent.com/6951222/85102945-ff897300-b205-11ea-80ed-93dfe005f19c.png)
