### PR TITLE
add about/legal page for attributions

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -203,6 +203,8 @@ about:
    - title: Cite us
      url: https://github.com/root-project/root/#cite
      target: _blank
+   - title: Legal
+     url: about/legal
 
 start:
    - title: Get Started

--- a/about/legal.md
+++ b/about/legal.md
@@ -1,0 +1,14 @@
+---
+layout: single
+title: Legal
+sidebar:
+  nav: "about"
+---
+
+### Icons
+
+The website icons are made by Linearicons from [https://linearicons.com/](https://linearicons.com/).
+
+### Website Generator and Theme
+
+The website is generated with [Jekyll](https://jekyllrb.com/) using an [adapted version](https://github.com/root-project/minimal-mistakes) of the [Minimal Mistakes](https://mmistakes.github.io/minimal-mistakes/) theme.

--- a/about/legal.md
+++ b/about/legal.md
@@ -7,7 +7,7 @@ sidebar:
 
 ### Icons
 
-The website icons are made by Linearicons from [https://linearicons.com/](https://linearicons.com/).
+This website uses icons by Linearicons from [https://linearicons.com/](https://linearicons.com/).
 
 ### Website Generator and Theme
 


### PR DESCRIPTION
Added a page for attributions. Unfortunately, the page does not show up in the navigation thingy on the left. I could not figure out why, see here:

![Screenshot from 2020-06-19 09-32-20](https://user-images.githubusercontent.com/6951222/85108388-ee456400-b20f-11ea-9266-5c54122a0051.png)
