### PR TITLE
Check release pages and release notes with htmlproofer

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -32,7 +32,10 @@ jobs:
           # - rootbnch-grafana-test.cern.ch: Breaks due to SSO
           # - lcgapp-services.cern.ch: Breaks due to SSO
           # - indico.desy.de: Returns frequently error code 403
-          arguments: --empty-alt-ignore --file-ignore "/(releases|page.?/index.html)/" --allow-hash-href --url-ignore "/(https://ph-root-2.cern.ch/.*|https://rootbnch-grafana-test.cern.ch|https://lcgapp-services.cern.ch/root-jenkins|https://indico.desy.de.*)/" --only-4xx --enforce-https --check-favicon
+          # Reasons for file-ignore
+          # - Broken links in historic ROOT v5 release notes
+          # - Broken links on pagination pages, e.g., page2/index.html
+          arguments: --empty-alt-ignore --file-ignore "/(.*root-version-v5.*|page.?/index.html)/" --allow-hash-href --url-ignore "/(https://ph-root-2.cern.ch/.*|https://rootbnch-grafana-test.cern.ch|https://lcgapp-services.cern.ch/root-jenkins|https://indico.desy.de.*)/" --only-4xx --enforce-https --check-favicon
 
       - name: Wait for other deployments
         # wait for other workflows that are deploying the website to finish, (not 100% foolproof, see #240)

--- a/_releases/release-30506.md
+++ b/_releases/release-30506.md
@@ -22,7 +22,7 @@ sidebar:
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| AIX.5 | [root_v3.05.06.AIX.5.tar.gz](https://root.cern.ch/download/root_v3.05.06.AIX.5.tar.gz) |  17M |
+| AIX.5 | root_v3.05.06.AIX.5.tar.gz |  17M |
 | HP UX.B.10.20.aCC | [root_v3.05.06.HP-UX.B.10.20.aCC.tar.gz](https://root.cern.ch/download/root_v3.05.06.HP-UX.B.10.20.aCC.tar.gz) |  23M |
 | IRIX.6.5.cc | [root_v3.05.06.IRIX.6.5.cc.tar.gz](https://root.cern.ch/download/root_v3.05.06.IRIX.6.5.cc.tar.gz) |  16M |
 | IRIX.6.5.gcc | [root_v3.05.06.IRIX.6.5.gcc.tar.gz](https://root.cern.ch/download/root_v3.05.06.IRIX.6.5.gcc.tar.gz) |  18M |

--- a/_releases/release-51904.md
+++ b/_releases/release-51904.md
@@ -52,7 +52,7 @@ git checkout -b v5-19-04 v5-19-04
 Windows 7/Vista/XP/NT/2000 are supported. We offer two packaging types:
 
  * **exe**: a regular Windows installer package also setting up the required environment variables. With uninstall via "Control Panel" / "Add or Remove Programs". Simply download and start, or open directly. You can double-click ROOT to start it, ROOT files get registered with Windows.
- * **tar**: the traditional variant. Unpack e.g. with [7zip](http://www.7-zip.org). Start ROOT in a Microsoft Visual Studio Prompt (in Start / Programs / Microsoft Visual Studio / Tools). If you installed ROOT to C:\root then call C:\root\bin\thisroot.bat before using ROOT to set up required environment variables.
+ * **tar**: the traditional variant. Unpack e.g. with [7zip](https://www.7-zip.org). Start ROOT in a Microsoft Visual Studio Prompt (in Start / Programs / Microsoft Visual Studio / Tools). If you installed ROOT to C:\root then call C:\root\bin\thisroot.bat before using ROOT to set up required environment variables.
 
 ### Important installation notes
  * You must download the binary built with the exact same version of Visual Studio than the one installed on your system.

--- a/_releases/release-52000.md
+++ b/_releases/release-52000.md
@@ -54,7 +54,7 @@ git checkout -b v5-20-00 v5-20-00
 Windows 7/Vista/XP/NT/2000 are supported. We offer two packaging types:
 
  * **exe**: a regular Windows installer package also setting up the required environment variables. With uninstall via "Control Panel" / "Add or Remove Programs". Simply download and start, or open directly. You can double-click ROOT to start it, ROOT files get registered with Windows.
- * **tar**: the traditional variant. Unpack e.g. with [7zip](http://www.7-zip.org). Start ROOT in a Microsoft Visual Studio Prompt (in Start / Programs / Microsoft Visual Studio / Tools). If you installed ROOT to C:\root then call C:\root\bin\thisroot.bat before using ROOT to set up required environment variables.
+ * **tar**: the traditional variant. Unpack e.g. with [7zip](https://www.7-zip.org). Start ROOT in a Microsoft Visual Studio Prompt (in Start / Programs / Microsoft Visual Studio / Tools). If you installed ROOT to C:\root then call C:\root\bin\thisroot.bat before using ROOT to set up required environment variables.
 
 ### Important installation notes
  * You must download the binary built with the exact same version of Visual Studio than the one installed on your system.

--- a/_releases/release-52102.md
+++ b/_releases/release-52102.md
@@ -53,7 +53,7 @@ git checkout -b v5-21-02 v5-21-02
 Windows 7/Vista/XP/NT/2000 are supported. We offer two packaging types:
 
  * **exe**: a regular Windows installer package also setting up the required environment variables. With uninstall via "Control Panel" / "Add or Remove Programs". Simply download and start, or open directly. You can double-click ROOT to start it, ROOT files get registered with Windows.
- * **tar**: the traditional variant. Unpack e.g. with [7zip](http://www.7-zip.org). Start ROOT in a Microsoft Visual Studio Prompt (in Start / Programs / Microsoft Visual Studio / Tools). If you installed ROOT to C:\root then call C:\root\bin\thisroot.bat before using ROOT to set up required environment variables.
+ * **tar**: the traditional variant. Unpack e.g. with [7zip](https://www.7-zip.org). Start ROOT in a Microsoft Visual Studio Prompt (in Start / Programs / Microsoft Visual Studio / Tools). If you installed ROOT to C:\root then call C:\root\bin\thisroot.bat before using ROOT to set up required environment variables.
 
 ### Important installation notes
  * You must download the binary built with the exact same version of Visual Studio than the one installed on your system.

--- a/_releases/release-52104.md
+++ b/_releases/release-52104.md
@@ -53,7 +53,7 @@ git checkout -b v5-21-04 v5-21-04
 Windows 7/Vista/XP/NT/2000 are supported. We offer two packaging types:
 
  * **exe**: a regular Windows installer package also setting up the required environment variables. With uninstall via "Control Panel" / "Add or Remove Programs". Simply download and start, or open directly. You can double-click ROOT to start it, ROOT files get registered with Windows.
- * **tar**: the traditional variant. Unpack e.g. with [7zip](http://www.7-zip.org). Start ROOT in a Microsoft Visual Studio Prompt (in Start / Programs / Microsoft Visual Studio / Tools). If you installed ROOT to C:\root then call C:\root\bin\thisroot.bat before using ROOT to set up required environment variables.
+ * **tar**: the traditional variant. Unpack e.g. with [7zip](https://www.7-zip.org). Start ROOT in a Microsoft Visual Studio Prompt (in Start / Programs / Microsoft Visual Studio / Tools). If you installed ROOT to C:\root then call C:\root\bin\thisroot.bat before using ROOT to set up required environment variables.
 
 ### Important installation notes
  * You must download the binary built with the exact same version of Visual Studio than the one installed on your system.

--- a/_releases/release-52106.md
+++ b/_releases/release-52106.md
@@ -59,7 +59,7 @@ git checkout -b v5-21-06 v5-21-06
 Windows 7/Vista/XP/NT/2000 are supported. We offer two packaging types:
 
  * **exe**: a regular Windows installer package also setting up the required environment variables. With uninstall via "Control Panel" / "Add or Remove Programs". Simply download and start, or open directly. You can double-click ROOT to start it, ROOT files get registered with Windows.
- * **tar**: the traditional variant. Unpack e.g. with [7zip](http://www.7-zip.org). Start ROOT in a Microsoft Visual Studio Prompt (in Start / Programs / Microsoft Visual Studio / Tools). If you installed ROOT to C:\root then call C:\root\bin\thisroot.bat before using ROOT to set up required environment variables.
+ * **tar**: the traditional variant. Unpack e.g. with [7zip](https://www.7-zip.org). Start ROOT in a Microsoft Visual Studio Prompt (in Start / Programs / Microsoft Visual Studio / Tools). If you installed ROOT to C:\root then call C:\root\bin\thisroot.bat before using ROOT to set up required environment variables.
 
 ### Important installation notes
  * You must download the binary built with the exact same version of Visual Studio than the one installed on your system.

--- a/_releases/release-52200.md
+++ b/_releases/release-52200.md
@@ -70,7 +70,7 @@ git checkout -b v5-22-00 v5-22-00
 Windows 7/Vista/XP/NT/2000 are supported. We offer two packaging types:
 
  * **exe**: a regular Windows installer package also setting up the required environment variables. With uninstall via "Control Panel" / "Add or Remove Programs". Simply download and start, or open directly. You can double-click ROOT to start it, ROOT files get registered with Windows.
- * **tar**: the traditional variant. Unpack e.g. with [7zip](http://www.7-zip.org). Start ROOT in a Microsoft Visual Studio Prompt (in Start / Programs / Microsoft Visual Studio / Tools). If you installed ROOT to C:\root then call C:\root\bin\thisroot.bat before using ROOT to set up required environment variables.
+ * **tar**: the traditional variant. Unpack e.g. with [7zip](https://www.7-zip.org). Start ROOT in a Microsoft Visual Studio Prompt (in Start / Programs / Microsoft Visual Studio / Tools). If you installed ROOT to C:\root then call C:\root\bin\thisroot.bat before using ROOT to set up required environment variables.
 
 ### Important installation notes
  * You must download the binary built with the exact same version of Visual Studio than the one installed on your system.

--- a/_releases/release-52400.md
+++ b/_releases/release-52400.md
@@ -92,7 +92,7 @@ git checkout -b v5-24-00 v5-24-00
 Windows 7/Vista/XP/NT/2000 are supported. We offer two packaging types:
 
  * **exe**: a regular Windows installer package also setting up the required environment variables. With uninstall via "Control Panel" / "Add or Remove Programs". Simply download and start, or open directly. You can double-click ROOT to start it, ROOT files get registered with Windows.
- * **tar**: the traditional variant. Unpack e.g. with [7zip](http://www.7-zip.org). Start ROOT in a Microsoft Visual Studio Prompt (in Start / Programs / Microsoft Visual Studio / Tools). If you installed ROOT to C:\root then call C:\root\bin\thisroot.bat before using ROOT to set up required environment variables.
+ * **tar**: the traditional variant. Unpack e.g. with [7zip](https://www.7-zip.org). Start ROOT in a Microsoft Visual Studio Prompt (in Start / Programs / Microsoft Visual Studio / Tools). If you installed ROOT to C:\root then call C:\root\bin\thisroot.bat before using ROOT to set up required environment variables.
 
 ### Important installation notes
  * You must download the binary built with the exact same version of Visual Studio than the one installed on your system.

--- a/_releases/release-52504.md
+++ b/_releases/release-52504.md
@@ -58,7 +58,7 @@ git checkout -b v5-25-04 v5-25-04
 Windows 7/Vista/XP/NT/2000 are supported. We offer two packaging types:
 
  * **exe**: a regular Windows installer package also setting up the required environment variables. With uninstall via "Control Panel" / "Add or Remove Programs". Simply download and start, or open directly. You can double-click ROOT to start it, ROOT files get registered with Windows.
- * **tar**: the traditional variant. Unpack e.g. with [7zip](http://www.7-zip.org). Start ROOT in a Microsoft Visual Studio Prompt (in Start / Programs / Microsoft Visual Studio / Tools). If you installed ROOT to C:\root then call C:\root\bin\thisroot.bat before using ROOT to set up required environment variables.
+ * **tar**: the traditional variant. Unpack e.g. with [7zip](https://www.7-zip.org). Start ROOT in a Microsoft Visual Studio Prompt (in Start / Programs / Microsoft Visual Studio / Tools). If you installed ROOT to C:\root then call C:\root\bin\thisroot.bat before using ROOT to set up required environment variables.
 
 ### Important installation notes
  * You must download the binary built with the exact same version of Visual Studio than the one installed on your system.

--- a/_releases/release-52600c.md
+++ b/_releases/release-52600c.md
@@ -53,7 +53,7 @@ git checkout -b v5-26-00c v5-26-00c
 Windows 7/Vista/XP/NT/2000 are supported. We offer two packaging types:
 
  * **exe**: a regular Windows installer package also setting up the required environment variables. With uninstall via "Control Panel" / "Add or Remove Programs". Simply download and start, or open directly. You can double-click ROOT to start it, ROOT files get registered with Windows.
- * **tar**: the traditional variant. Unpack e.g. with [7zip](http://www.7-zip.org). Start ROOT in a Microsoft Visual Studio Prompt (in Start / Programs / Microsoft Visual Studio / Tools). If you installed ROOT to C:\root then call C:\root\bin\thisroot.bat before using ROOT to set up required environment variables.
+ * **tar**: the traditional variant. Unpack e.g. with [7zip](https://www.7-zip.org). Start ROOT in a Microsoft Visual Studio Prompt (in Start / Programs / Microsoft Visual Studio / Tools). If you installed ROOT to C:\root then call C:\root\bin\thisroot.bat before using ROOT to set up required environment variables.
 
 ### Important installation notes
  * You must download the binary built with the exact same version of Visual Studio than the one installed on your system.

--- a/_releases/release-53400.md
+++ b/_releases/release-53400.md
@@ -13,7 +13,7 @@ sidebar:
 
 ## Release Notes
 
-The release notes for this release can be found [here]({{ '/install/all_releases/root-version-v5-34-00-patch-release-notes#00' | relative_url }}).
+The release notes for this release can be found [here]({{ '/install/all_releases/root-version-v5-34-00-patch-release-notes' | relative_url }}).
 
 ## Source distributions
 

--- a/_releases/release-53406.md
+++ b/_releases/release-53406.md
@@ -13,7 +13,7 @@ sidebar:
 
 ## Release Notes
 
-The release notes for this release can be found [here]({{ '/install/all_releases/root-version-v5-34-00-patch-release-notes#06' | relative_url }}).
+The release notes for this release can be found [here]({{ '/install/all_releases/root-version-v5-34-00-patch-release-notes' | relative_url }}).
 
 ## Source distribution
 

--- a/_releases/release-53412.md
+++ b/_releases/release-53412.md
@@ -13,7 +13,7 @@ sidebar:
 
 ## Release Notes
 
-The release notes for this release can be found [here]({{ '/install/all_releases/root-version-v5-34-00-patch-release-notes#12' | relative_url }}).
+The release notes for this release can be found [here]({{ '/install/all_releases/root-version-v5-34-00-patch-release-notes' | relative_url }}).
 
 ## Source distribution
 

--- a/_releases/release-53425.md
+++ b/_releases/release-53425.md
@@ -91,7 +91,7 @@ git checkout -b v5-34-25 v5-34-25
 Windows 7/Vista/XP/NT/2000 are supported. We offer two packaging types:
 
  * **exe**: a regular Windows installer package also setting up the required environment variables. With uninstall via "Control Panel" / "Add or Remove Programs". Simply download and start, or open directly. You can double-click ROOT to start it, ROOT files get registered with Windows.
- * **tar**: the traditional variant. Unpack e.g. with [7zip](http://www.7-zip.org). Start ROOT in a Microsoft Visual Studio Prompt (in Start / Programs / Microsoft Visual Studio / Tools). If you installed ROOT to C:\root then call C:\root\bin\thisroot.bat before using ROOT to set up required environment variables.
+ * **tar**: the traditional variant. Unpack e.g. with [7zip](https://www.7-zip.org). Start ROOT in a Microsoft Visual Studio Prompt (in Start / Programs / Microsoft Visual Studio / Tools). If you installed ROOT to C:\root then call C:\root\bin\thisroot.bat before using ROOT to set up required environment variables.
 
 ### Important installation notes
  * You must download the binary built with the exact same version of Visual Studio than the one installed on your system.

--- a/_releases/release-53426.md
+++ b/_releases/release-53426.md
@@ -94,7 +94,7 @@ git checkout -b v5-34-26 v5-34-26
 Windows 7/Vista/XP/NT/2000 are supported. We offer two packaging types:
 
  * **exe**: a regular Windows installer package also setting up the required environment variables. With uninstall via "Control Panel" / "Add or Remove Programs". Simply download and start, or open directly. You can double-click ROOT to start it, ROOT files get registered with Windows.
- * **tar**: the traditional variant. Unpack e.g. with [7zip](http://www.7-zip.org). Start ROOT in a Microsoft Visual Studio Prompt (in Start / Programs / Microsoft Visual Studio / Tools). If you installed ROOT to C:\root then call C:\root\bin\thisroot.bat before using ROOT to set up required environment variables.
+ * **tar**: the traditional variant. Unpack e.g. with [7zip](https://www.7-zip.org). Start ROOT in a Microsoft Visual Studio Prompt (in Start / Programs / Microsoft Visual Studio / Tools). If you installed ROOT to C:\root then call C:\root\bin\thisroot.bat before using ROOT to set up required environment variables.
 
 ### Important installation notes
  * You must download the binary built with the exact same version of Visual Studio than the one installed on your system.

--- a/_releases/release-53428.md
+++ b/_releases/release-53428.md
@@ -94,7 +94,7 @@ git checkout -b v5-34-28 v5-34-28
 Windows 7/Vista/XP/NT/2000 are supported. We offer two packaging types:
 
  * **exe**: a regular Windows installer package also setting up the required environment variables. With uninstall via "Control Panel" / "Add or Remove Programs". Simply download and start, or open directly. You can double-click ROOT to start it, ROOT files get registered with Windows.
- * **tar**: the traditional variant. Unpack e.g. with [7zip](http://www.7-zip.org). Start ROOT in a Microsoft Visual Studio Prompt (in Start / Programs / Microsoft Visual Studio / Tools). If you installed ROOT to C:\root then call C:\root\bin\thisroot.bat before using ROOT to set up required environment variables.
+ * **tar**: the traditional variant. Unpack e.g. with [7zip](https://www.7-zip.org). Start ROOT in a Microsoft Visual Studio Prompt (in Start / Programs / Microsoft Visual Studio / Tools). If you installed ROOT to C:\root then call C:\root\bin\thisroot.bat before using ROOT to set up required environment variables.
 
 ### Important installation notes
  * You must download the binary built with the exact same version of Visual Studio than the one installed on your system.

--- a/_releases/release-53430.md
+++ b/_releases/release-53430.md
@@ -98,7 +98,7 @@ git checkout -b v5-34-30 v5-34-30
 Windows 7/Vista/XP/NT/2000 are supported. We offer two packaging types:
 
  * **exe**: a regular Windows installer package also setting up the required environment variables. With uninstall via "Control Panel" / "Add or Remove Programs". Simply download and start, or open directly. You can double-click ROOT to start it, ROOT files get registered with Windows.
- * **tar**: the traditional variant. Unpack e.g. with [7zip](http://www.7-zip.org). Start ROOT in a Microsoft Visual Studio Prompt (in Start / Programs / Microsoft Visual Studio / Tools). If you installed ROOT to C:\root then call C:\root\bin\thisroot.bat before using ROOT to set up required environment variables.
+ * **tar**: the traditional variant. Unpack e.g. with [7zip](https://www.7-zip.org). Start ROOT in a Microsoft Visual Studio Prompt (in Start / Programs / Microsoft Visual Studio / Tools). If you installed ROOT to C:\root then call C:\root\bin\thisroot.bat before using ROOT to set up required environment variables.
 
 ### Important installation notes
  * You must download the binary built with the exact same version of Visual Studio than the one installed on your system.

--- a/_releases/release-53432.md
+++ b/_releases/release-53432.md
@@ -95,7 +95,7 @@ git checkout -b v5-34-32 v5-34-32
 Windows 7/Vista/XP/NT/2000 are supported. We offer two packaging types:
 
  * **exe**: a regular Windows installer package also setting up the required environment variables. With uninstall via "Control Panel" / "Add or Remove Programs". Simply download and start, or open directly. You can double-click ROOT to start it, ROOT files get registered with Windows.
- * **tar**: the traditional variant. Unpack e.g. with [7zip](http://www.7-zip.org). Start ROOT in a Microsoft Visual Studio Prompt (in Start / Programs / Microsoft Visual Studio / Tools). If you installed ROOT to C:\root then call C:\root\bin\thisroot.bat before using ROOT to set up required environment variables.
+ * **tar**: the traditional variant. Unpack e.g. with [7zip](https://www.7-zip.org). Start ROOT in a Microsoft Visual Studio Prompt (in Start / Programs / Microsoft Visual Studio / Tools). If you installed ROOT to C:\root then call C:\root\bin\thisroot.bat before using ROOT to set up required environment variables.
 
 ### Important installation notes
  * You must download the binary built with the exact same version of Visual Studio than the one installed on your system.

--- a/_releases/release-53434.md
+++ b/_releases/release-53434.md
@@ -95,7 +95,7 @@ git checkout -b v5-34-34 v5-34-34
 Windows 7/Vista/XP/NT/2000 are supported. We offer two packaging types:
 
  * **exe**: a regular Windows installer package also setting up the required environment variables. With uninstall via "Control Panel" / "Add or Remove Programs". Simply download and start, or open directly. You can double-click ROOT to start it, ROOT files get registered with Windows.
- * **tar**: the traditional variant. Unpack e.g. with [7zip](http://www.7-zip.org). Start ROOT in a Microsoft Visual Studio Prompt (in Start / Programs / Microsoft Visual Studio / Tools). If you installed ROOT to C:\root then call C:\root\bin\thisroot.bat before using ROOT to set up required environment variables.
+ * **tar**: the traditional variant. Unpack e.g. with [7zip](https://www.7-zip.org). Start ROOT in a Microsoft Visual Studio Prompt (in Start / Programs / Microsoft Visual Studio / Tools). If you installed ROOT to C:\root then call C:\root\bin\thisroot.bat before using ROOT to set up required environment variables.
 
 ### Important installation notes
  * You must download the binary built with the exact same version of Visual Studio than the one installed on your system.

--- a/_releases/release-53436.md
+++ b/_releases/release-53436.md
@@ -119,7 +119,7 @@ git checkout -b v5-34-36 v5-34-36
 Windows 7/Vista/XP/NT/2000 are supported. We offer two packaging types:
 
  * **exe**: a regular Windows installer package also setting up the required environment variables. With uninstall via "Control Panel" / "Add or Remove Programs". Simply download and start, or open directly. You can double-click ROOT to start it, ROOT files get registered with Windows.
- * **tar**: the traditional variant. Unpack e.g. with [7zip](http://www.7-zip.org). Start ROOT in a Microsoft Visual Studio Prompt (in Start / Programs / Microsoft Visual Studio / Tools). If you installed ROOT to C:\root then call C:\root\bin\thisroot.bat before using ROOT to set up required environment variables.
+ * **tar**: the traditional variant. Unpack e.g. with [7zip](https://www.7-zip.org). Start ROOT in a Microsoft Visual Studio Prompt (in Start / Programs / Microsoft Visual Studio / Tools). If you installed ROOT to C:\root then call C:\root\bin\thisroot.bat before using ROOT to set up required environment variables.
 
 ### Important installation notes
  * You must download the binary built with the exact same version of Visual Studio than the one installed on your system.

--- a/_releases/release-53438.md
+++ b/_releases/release-53438.md
@@ -55,7 +55,7 @@ git checkout -b v5-34-38 v5-34-38
 Windows 7/Vista/XP/NT/2000 are supported. We offer two packaging types:
 
  * **exe**: a regular Windows installer package also setting up the required environment variables. With uninstall via "Control Panel" / "Add or Remove Programs". Simply download and start, or open directly. You can double-click ROOT to start it, ROOT files get registered with Windows.
- * **tar**: the traditional variant. Unpack e.g. with [7zip](http://www.7-zip.org). Start ROOT in a Microsoft Visual Studio Prompt (in Start / Programs / Microsoft Visual Studio / Tools). If you installed ROOT to C:\root then call C:\root\bin\thisroot.bat before using ROOT to set up required environment variables.
+ * **tar**: the traditional variant. Unpack e.g. with [7zip](https://www.7-zip.org). Start ROOT in a Microsoft Visual Studio Prompt (in Start / Programs / Microsoft Visual Studio / Tools). If you installed ROOT to C:\root then call C:\root\bin\thisroot.bat before using ROOT to set up required environment variables.
 
 ### Important installation notes
  * You must download the binary built with the exact same version of Visual Studio than the one installed on your system.

--- a/_releases/release-60200.md
+++ b/_releases/release-60200.md
@@ -13,7 +13,7 @@ sidebar:
 
 ## Release Notes
 
-The release notes for this release can be found [here](/root-version-v6-02-00-patch-release-notes)
+The release notes for this release can be found [here]({{ '/install/all_releases/root-version-v6-02-00-patch-release-notes' | relative_url }})
 
 ## Source distribution
 

--- a/_releases/release-60400.md
+++ b/_releases/release-60400.md
@@ -18,8 +18,7 @@ The ROOT team is proud to announce the release of ROOT 6.04/00 featuring many us
 *   a new `TFormula` implementation that uses cling
 *   I/O of C++11 containers
 *   TTreeCache is now enabled by default to accelerate analyses
-*   many new beautiful palettes ([kBird!](https://root.cern/doc/master/classTColor.html#C06)) that are optimized against
-[monotonic perceptual ordering]( {% post_url 2014-05-31-rainbow-color-map %} )
+*   many new beautiful palettes ([kBird!](https://root.cern/doc/master/classTColor.html#C06)) that are optimized against monotonic perceptual ordering
 
 ## Release Notes
 

--- a/_releases/release-60400.md
+++ b/_releases/release-60400.md
@@ -18,7 +18,7 @@ The ROOT team is proud to announce the release of ROOT 6.04/00 featuring many us
 *   a new `TFormula` implementation that uses cling
 *   I/O of C++11 containers
 *   TTreeCache is now enabled by default to accelerate analyses
-*   many new beautiful palettes ([kBird!](https://root.cern/doc/master/classTColor.html#C06)) that are optimized against monotonic perceptual ordering
+*   many new beautiful palettes ([kBird!](https://root.cern/doc/master/classTColor.html#C06)) that are optimized against [monotonic perceptual ordering]( {{ "rainbow-color-map" | relative_url }} )
 
 ## Release Notes
 

--- a/_releases/release-60902.md
+++ b/_releases/release-60902.md
@@ -18,7 +18,7 @@ This is the first ROOT development release of the 6.09 series! It is meant to of
 Some highlights:
 
    * Automatic colouring of plots. How? Check this out [here](https://root.cern/doc/master/classTHistPainter.html#HP061).
-   * The [TDataFrame](https://root.cern/doc/master/classROOT_1_1Experimental_1_1TDataFrame.html) framework landed in ROOT: it is possible to analyse data contained in ROOT trees in a functional manner taking advantage transparently of all cores of your machine
+   * The [TDataFrame](https://root.cern/doc/master/classROOT_1_1RDataFrame.html) framework landed in ROOT: it is possible to analyse data contained in ROOT trees in a functional manner taking advantage transparently of all cores of your machine
    * More building blocks for expressing parallelism: check out our [TThreadExecutor](https://root.cern/doc/master/classROOT_1_1TThreadExecutor.html) class!
    * More parallelism behind the scenes, for example parallel compression when writing to a TTree. Just let ROOT run your code in parallel: invoke [ROOT::EnableImplicitMT()](https://root.cern/doc/master/namespaceROOT.html#ade6e397b327482d267ad54de92db4b89)
    * A faster ROOT: for example lots of symbols are now hidden, TMethodCall is now twice as fast as before.

--- a/_releases/release-61000.md
+++ b/_releases/release-61000.md
@@ -16,7 +16,7 @@ sidebar:
 This is the first release of the 6.10 production series. It includes a number of new features and here are some highlights:
 
    * Automatic colouring of plots. How? Check this out [here](https://root.cern/doc/master/classTHistPainter.html#HP061).
-   * The [TDataFrame](https://root.cern/doc/master/classROOT_1_1Experimental_1_1TDataFrame.html) framework landed in ROOT: it is possible to analyse data contained in ROOT trees in a functional manner taking advantage transparently of all cores of your machine
+   * The [TDataFrame](https://root.cern/doc/master/classROOT_1_1RDataFrame.html) framework landed in ROOT: it is possible to analyse data contained in ROOT trees in a functional manner taking advantage transparently of all cores of your machine
    * More building blocks for expressing parallelism: check out our [TThreadExecutor](https://root.cern/doc/v610/classROOT_1_1TThreadExecutor.html) class!
    * More parallelism behind the scenes, for example parallel compression when writing to a TTree. Just let ROOT run your code in parallel: invoke [ROOT::EnableImplicitMT()](https://root.cern/doc/v610/namespaceROOT.html#ade6e397b327482d267ad54de92db4b89)
    * A faster ROOT: for example lots of symbols are now hidden, TMethodCall is now twice as fast as before.

--- a/_releases/release-61402.md
+++ b/_releases/release-61402.md
@@ -86,7 +86,7 @@ git checkout -b v6-14-02 v6-14-02
 We offer two packaging types:
 
  * **exe**: a regular Windows installer package also setting up the required environment variables. With uninstall via "Control Panel" / "Add or Remove Programs". Simply download and start, or open directly. You can double-click ROOT to start it, ROOT files get registered with Windows.
- * **zip**: the traditional variant. Unpack e.g. with [7zip](http://www.7-zip.org). Start ROOT in a Microsoft Visual Studio Prompt (in Start / Programs / Microsoft Visual Studio / Tools). If you installed ROOT to C:\root then call C:\root\bin\thisroot.bat before using ROOT to set up required environment variables.
+ * **zip**: the traditional variant. Unpack e.g. with [7zip](https://www.7-zip.org). Start ROOT in a Microsoft Visual Studio Prompt (in Start / Programs / Microsoft Visual Studio / Tools). If you installed ROOT to C:\root then call C:\root\bin\thisroot.bat before using ROOT to set up required environment variables.
 
 ### Important installation notes
  * You must download the binary built with the exact same version of Visual Studio than the one installed on your system.

--- a/_releases/release-61404.md
+++ b/_releases/release-61404.md
@@ -86,7 +86,7 @@ git checkout -b v6-14-04 v6-14-04
 We offer two packaging types:
 
  * **exe**: a regular Windows installer package also setting up the required environment variables. With uninstall via "Control Panel" / "Add or Remove Programs". Simply download and start, or open directly. You can double-click ROOT to start it, ROOT files get registered with Windows.
- * **zip**: the traditional variant. Unpack e.g. with [7zip](http://www.7-zip.org). Start ROOT in a Microsoft Visual Studio Prompt (in Start / Programs / Microsoft Visual Studio / Tools). If you installed ROOT to C:\root then call C:\root\bin\thisroot.bat before using ROOT to set up required environment variables.
+ * **zip**: the traditional variant. Unpack e.g. with [7zip](https://www.7-zip.org). Start ROOT in a Microsoft Visual Studio Prompt (in Start / Programs / Microsoft Visual Studio / Tools). If you installed ROOT to C:\root then call C:\root\bin\thisroot.bat before using ROOT to set up required environment variables.
 
 ### Important installation notes
  * You must download the binary built with the exact same version of Visual Studio than the one installed on your system.

--- a/_releases/release-61406.md
+++ b/_releases/release-61406.md
@@ -85,7 +85,7 @@ git checkout -b v6-14-06 v6-14-06
 Windows 7/Vista/XP/NT/2000 are supported. We offer two packaging types:
 
  * **exe**: a regular Windows installer package also setting up the required environment variables. With uninstall via "Control Panel" / "Add or Remove Programs". Simply download and start, or open directly. You can double-click ROOT to start it, ROOT files get registered with Windows.
- * **tar**: the traditional variant. Unpack e.g. with [7zip](http://www.7-zip.org). Start ROOT in a Microsoft Visual Studio Prompt (in Start / Programs / Microsoft Visual Studio / Tools). If you installed ROOT to C:\root then call C:\root\bin\thisroot.bat before using ROOT to set up required environment variables.
+ * **tar**: the traditional variant. Unpack e.g. with [7zip](https://www.7-zip.org). Start ROOT in a Microsoft Visual Studio Prompt (in Start / Programs / Microsoft Visual Studio / Tools). If you installed ROOT to C:\root then call C:\root\bin\thisroot.bat before using ROOT to set up required environment variables.
 
 ### Important installation notes
  * You must download the binary built with the exact same version of Visual Studio than the one installed on your system.

--- a/_releases/release-61600.md
+++ b/_releases/release-61600.md
@@ -97,7 +97,7 @@ git checkout -b v6-16-00 v6-16-00
 Windows 7/Vista/XP/NT/2000 are supported. We offer two packaging types:
 
  * **exe**: a regular Windows installer package also setting up the required environment variables. With uninstall via "Control Panel" / "Add or Remove Programs". Simply download and start, or open directly. You can double-click ROOT to start it, ROOT files get registered with Windows.
- * **tar**: the traditional variant. Unpack e.g. with [7zip](http://www.7-zip.org). Start ROOT in a Microsoft Visual Studio Prompt (in Start / Programs / Microsoft Visual Studio / Tools). If you installed ROOT to C:\root then call C:\root\bin\thisroot.bat before using ROOT to set up required environment variables.
+ * **tar**: the traditional variant. Unpack e.g. with [7zip](https://www.7-zip.org). Start ROOT in a Microsoft Visual Studio Prompt (in Start / Programs / Microsoft Visual Studio / Tools). If you installed ROOT to C:\root then call C:\root\bin\thisroot.bat before using ROOT to set up required environment variables.
 
 ### Important installation notes
  * You must download the binary built with the exact same version of Visual Studio than the one installed on your system.

--- a/_releases/release-61800.md
+++ b/_releases/release-61800.md
@@ -82,7 +82,7 @@ git checkout -b v6-18-00 v6-18-00
 Windows 7/Vista/XP/NT/2000 are supported. We offer two packaging types:
 
  * **exe**: a regular Windows installer package also setting up the required environment variables. With uninstall via "Control Panel" / "Add or Remove Programs". Simply download and start, or open directly. You can double-click ROOT to start it, ROOT files get registered with Windows.
- * **tar**: the traditional variant. Unpack e.g. with [7zip](http://www.7-zip.org). Start ROOT in a Microsoft Visual Studio Prompt (in Start / Programs / Microsoft Visual Studio / Tools). If you installed ROOT to C:\root then call C:\root\bin\thisroot.bat before using ROOT to set up required environment variables.
+ * **tar**: the traditional variant. Unpack e.g. with [7zip](https://www.7-zip.org). Start ROOT in a Microsoft Visual Studio Prompt (in Start / Programs / Microsoft Visual Studio / Tools). If you installed ROOT to C:\root then call C:\root\bin\thisroot.bat before using ROOT to set up required environment variables.
 
 ### Important installation notes
  * You must download the binary built with the exact same version of Visual Studio as the one installed on your system.

--- a/_releases/release-61802.md
+++ b/_releases/release-61802.md
@@ -78,7 +78,7 @@ git checkout -b v6-18-02 v6-18-02
 Windows is supported as a preview. We offer two packaging types:
 
  * **exe**: a regular Windows installer package also setting up the required environment variables. With uninstall via "Control Panel" / "Add or Remove Programs". Simply download and start, or open directly. You can double-click ROOT to start it, ROOT files get registered with Windows.
- * **zip**: the traditional variant. Unpack e.g. with [7zip](http://www.7-zip.org). Start ROOT in a Microsoft Visual Studio Prompt (in Start / Programs / Microsoft Visual Studio / Tools). If you installed ROOT to C:\root then call C:\root\bin\thisroot.bat before using ROOT to set up required environment variables.
+ * **zip**: the traditional variant. Unpack e.g. with [7zip](https://www.7-zip.org). Start ROOT in a Microsoft Visual Studio Prompt (in Start / Programs / Microsoft Visual Studio / Tools). If you installed ROOT to C:\root then call C:\root\bin\thisroot.bat before using ROOT to set up required environment variables.
 
 ### Important installation notes
  * You must download the binary built with the exact same version of Visual Studio than the one installed on your system.

--- a/_releases/release-61804.md
+++ b/_releases/release-61804.md
@@ -78,7 +78,7 @@ git checkout -b v6-18-04 v6-18-04
 Windows 7/Vista/XP/NT/2000 are supported. We offer two packaging types:
 
  * **exe**: a regular Windows installer package also setting up the required environment variables. With uninstall via "Control Panel" / "Add or Remove Programs". Simply download and start, or open directly. You can double-click ROOT to start it, ROOT files get registered with Windows.
- * **tar**: the traditional variant. Unpack e.g. with [7zip](http://www.7-zip.org). Start ROOT in a Microsoft Visual Studio Prompt (in Start / Programs / Microsoft Visual Studio / Tools). If you installed ROOT to C:\root then call C:\root\bin\thisroot.bat before using ROOT to set up required environment variables.
+ * **tar**: the traditional variant. Unpack e.g. with [7zip](https://www.7-zip.org). Start ROOT in a Microsoft Visual Studio Prompt (in Start / Programs / Microsoft Visual Studio / Tools). If you installed ROOT to C:\root then call C:\root\bin\thisroot.bat before using ROOT to set up required environment variables.
 
 ### Important installation notes
  * You must download the binary built with the exact same version of Visual Studio than the one installed on your system.

--- a/_releases/release-62000.md
+++ b/_releases/release-62000.md
@@ -106,7 +106,7 @@ git checkout -b v6-20-00 v6-20-00
 Windows 7/Vista/XP/NT/2000 are supported. We offer two packaging types:
 
  * **exe**: a regular Windows installer package also setting up the required environment variables. With uninstall via "Control Panel" / "Add or Remove Programs". Simply download and start, or open directly. You can double-click ROOT to start it, ROOT files get registered with Windows.
- * **tar**: the traditional variant. Unpack e.g. with [7zip](http://www.7-zip.org). Start ROOT in a Microsoft Visual Studio Prompt (in Start / Programs / Microsoft Visual Studio / Tools). If you installed ROOT to C:\root then call C:\root\bin\thisroot.bat before using ROOT to set up required environment variables.
+ * **tar**: the traditional variant. Unpack e.g. with [7zip](https://www.7-zip.org). Start ROOT in a Microsoft Visual Studio Prompt (in Start / Programs / Microsoft Visual Studio / Tools). If you installed ROOT to C:\root then call C:\root\bin\thisroot.bat before using ROOT to set up required environment variables.
 
 ### Important installation notes
  * You must download the binary built with the exact same version of Visual Studio than the one installed on your system.

--- a/_releases/release-62002.md
+++ b/_releases/release-62002.md
@@ -86,7 +86,7 @@ git checkout -b v6-20-02 v6-20-02
 Windows 7/Vista/XP/NT/2000 are supported. We offer two packaging types:
 
  * **exe**: a regular Windows installer package also setting up the required environment variables. With uninstall via "Control Panel" / "Add or Remove Programs". Simply download and start, or open directly. You can double-click ROOT to start it, ROOT files get registered with Windows.
- * **tar**: the traditional variant. Unpack e.g. with [7zip](http://www.7-zip.org). Start ROOT in a Microsoft Visual Studio Prompt (in Start / Programs / Microsoft Visual Studio / Tools). If you installed ROOT to C:\root then call C:\root\bin\thisroot.bat before using ROOT to set up required environment variables.
+ * **tar**: the traditional variant. Unpack e.g. with [7zip](https://www.7-zip.org). Start ROOT in a Microsoft Visual Studio Prompt (in Start / Programs / Microsoft Visual Studio / Tools). If you installed ROOT to C:\root then call C:\root\bin\thisroot.bat before using ROOT to set up required environment variables.
 
 ### Important installation notes
 

--- a/_releases/release-62004.md
+++ b/_releases/release-62004.md
@@ -89,7 +89,7 @@ git checkout -b v6-20-04 v6-20-04
 Windows 7/Vista/XP/NT/2000 are supported. We offer two packaging types:
 
  * **exe**: a regular Windows installer package also setting up the required environment variables. With uninstall via "Control Panel" / "Add or Remove Programs". Simply download and start, or open directly. You can double-click ROOT to start it, ROOT files get registered with Windows.
- * **tar**: the traditional variant. Unpack e.g. with [7zip](http://www.7-zip.org). Start ROOT in a Microsoft Visual Studio Prompt (in Start / Programs / Microsoft Visual Studio / Tools). If you installed ROOT to C:\root then call C:\root\bin\thisroot.bat before using ROOT to set up required environment variables.
+ * **tar**: the traditional variant. Unpack e.g. with [7zip](https://www.7-zip.org). Start ROOT in a Microsoft Visual Studio Prompt (in Start / Programs / Microsoft Visual Studio / Tools). If you installed ROOT to C:\root then call C:\root\bin\thisroot.bat before using ROOT to set up required environment variables.
 
 ### Important installation notes
 

--- a/install/all_releases/root-version-v5-34-00-patch-release-notes.md
+++ b/install/all_releases/root-version-v5-34-00-patch-release-notes.md
@@ -22,7 +22,7 @@ NOTE: this release exists to backport support for LZ4 compression also to the ol
 * I/O
    * Add support for LZ4 compression.
    * Properly handle 'cycle' number larger than 32767 by rounding to zero rather than a negative number.
-   * Properly propagate errors in OpenExcessFiles in TFileMerger ([ROOT-8167](http://sft.its.cern.ch/jira/browse/ROOT-8167)).
+   * Properly propagate errors in OpenExcessFiles in TFileMerger ([ROOT-8167](https://sft.its.cern.ch/jira/browse/ROOT-8167)).
 * TTree
    * Fix detection of errors that appears in nested TTreeFormula [ROOT-8218]
 * Graphics
@@ -35,13 +35,13 @@ NOTE: this release exists to backport support for LZ4 compression also to the ol
 *  Build system
     * Added option 'builtin_openssl' to build OpenSSL internally. Needed mainly for Mac OS X 10.11 (El Capitan).
 * Core
-    * TObject instances allocated as part of an array and made part of a collection, as for example the TCanvas instances into the global list of instances, are not longer deleted if the content of the collection is deleted.  Technically the element of the array are now treated by collections as if they have been allocated on the stack.  This fixes the issue described at ([ROOT-7846](http://sft.its.cern.ch/jira/browse/ROOT-7846)).
+    * TObject instances allocated as part of an array and made part of a collection, as for example the TCanvas instances into the global list of instances, are not longer deleted if the content of the collection is deleted.  Technically the element of the array are now treated by collections as if they have been allocated on the stack.  This fixes the issue described at ([ROOT-7846](https://sft.its.cern.ch/jira/browse/ROOT-7846)).
 * I/O
-    * Resolve an issue when space is freed in a large `ROOT` file and a TDirectory is updated and stored the lower (less than 2GB) freed portion of the file ([ROOT-8055](http://sft.its.cern.ch/jira/browse/ROOT-8055)).
+    * Resolve an issue when space is freed in a large `ROOT` file and a TDirectory is updated and stored the lower (less than 2GB) freed portion of the file ([ROOT-8055](https://sft.its.cern.ch/jira/browse/ROOT-8055)).
 *  Montecarlo
     * Re-introduced method TPythia6:Pytune()
 *  TTree
-    * Fix ([ROOT-7423](http://sft.its.cern.ch/jira/browse/ROOT-7423)) TTreeCache may not stop the learning phase when asynchronous prefetching is enabled.
+    * Fix ([ROOT-7423](https://sft.its.cern.ch/jira/browse/ROOT-7423)) TTreeCache may not stop the learning phase when asynchronous prefetching is enabled.
     * Fix the issue described in the (following forum post(https://root.cern.ch/phpBB3/viewtopic.php?t=20269)), where a some order of calls to TTree::Scan and TTree::Write resulted in invalid output.
     * Repair setting the branch address of a leaflist style branch taking directly the address of the struct.  (Note that leaflist is nonetheless still deprecated and declaring the struct to the interpreter and passing the object directly to create the branch is much better).
 * Graphics
@@ -55,10 +55,10 @@ NOTE: this release exists to backport support for LZ4 compression also to the ol
   * New version of libpng (1.2.55) as requested [here](https://sft.its.cern.ch/jira/browse/ROOT-8045).
 
 * TNetXNGFileStager
-    *   Fix ([ROOT-7703](http://sft.its.cern.ch/jira/browse/ROOT-7703)) This restores the behavior of Locate() to that found with TXNetFileStager: Rather than return only the xrootd server's reply, the endpoint hostname is looked up and Locate() returns the full url, including the path.
+    *   Fix ([ROOT-7703](https://sft.its.cern.ch/jira/browse/ROOT-7703)) This restores the behavior of Locate() to that found with TXNetFileStager: Rather than return only the xrootd server's reply, the endpoint hostname is looked up and Locate() returns the full url, including the path.
 * TWebFile
-    *   Fix ([ROOT-7809](http://sft.its.cern.ch/jira/browse/ROOT-7809)) Returns an error for a redirect which does not specify the new URI, rather than going into a loop.
-    *   Fix ([ROOT-7817](http://sft.its.cern.ch/jira/browse/ROOT-7817)) Avoid a crash under some circumstances when trying to open an invalid path.
+    *   Fix ([ROOT-7809](https://sft.its.cern.ch/jira/browse/ROOT-7809)) Returns an error for a redirect which does not specify the new URI, rather than going into a loop.
+    *   Fix ([ROOT-7817](https://sft.its.cern.ch/jira/browse/ROOT-7817)) Avoid a crash under some circumstances when trying to open an invalid path.
 * SQL
     *   Fix TPgSQLStatement::SetBinary to actually handle binary data (previous limited to ascii).
 
@@ -67,15 +67,15 @@ NOTE: this release exists to backport support for LZ4 compression also to the ol
 
 
 *   Build
-    *   Support for gcc 5.1 and CMake builds ([ROOT-7440](http://sft.its.cern.ch/jira/browse/ROOT-7440)). To make it work required to disable #define private public for this compiler.
+    *   Support for gcc 5.1 and CMake builds ([ROOT-7440](https://sft.its.cern.ch/jira/browse/ROOT-7440)). To make it work required to disable #define private public for this compiler.
     *   Support for Intel ICC 15.
     *   Fix in the RPATH treatment that is needed for MacOS X 10.11 (El Capitan)
     *   Handle build for the missing OpenSSL ([ROOT-7680](https://sft.its.cern.ch/jira/browse/ROOT-7680))
     *   Implemented the options 'minimal' and 'minimal'
 *   I/O
-    *   Fix the issue described at ([ROOT-7500](http://sft.its.cern.ch/jira/browse/ROOT-7500)): crash due to change in base class which versioned derived class.
+    *   Fix the issue described at ([ROOT-7500](https://sft.its.cern.ch/jira/browse/ROOT-7500)): crash due to change in base class which versioned derived class.
 *  TTree
-    *   Fix ([ROOT-6885](http://sft.its.cern.ch/jira/browse/ROOT-6885)) This affects very large TChain with friend trees.
+    *   Fix ([ROOT-6885](https://sft.its.cern.ch/jira/browse/ROOT-6885)) This affects very large TChain with friend trees.
 *  JSROOT
     *  Upgraded to latest JSROOT version 3.8
 *  RooFit
@@ -88,14 +88,14 @@ NOTE: this release exists to backport support for LZ4 compression also to the ol
 
 
 *   Build
-    *   Pythia6 not found with CMake ([ROOT-7333](http://sft.its.cern.ch/jira/browse/ROOT-7333))
-    *   Fixes in .license and .credits commands ([ROOT-7311](http://sft.its.cern.ch/jira/browse/ROOT-7311))
+    *   Pythia6 not found with CMake ([ROOT-7333](https://sft.its.cern.ch/jira/browse/ROOT-7333))
+    *   Fixes in .license and .credits commands ([ROOT-7311](https://sft.its.cern.ch/jira/browse/ROOT-7311))
     *   bindexplib.exe support for x64
 *   I/O.
-    *   Properly handle the reload/recreate of TClass for STL containers (fixes [ROOT-7239](http://sft.its.cern.ch/jira/browse/ROOT-7239))
+    *   Properly handle the reload/recreate of TClass for STL containers (fixes [ROOT-7239](https://sft.its.cern.ch/jira/browse/ROOT-7239))
     *   Fix the ordering of the keys in a TFile being written; in particular fixing the result of GetKey and FindKey which were no longer returning the lastest cycle for a TFile being written since v5.34/11.
 *   Graphics
-    *   In the animated gif it is now possible to specify the delay between the last image and the fist image in case of infinite loop ([ROOT-7263](http://sft.its.cern.ch/jira/browse/ROOT-7263)).
+    *   In the animated gif it is now possible to specify the delay between the last image and the fist image in case of infinite loop ([ROOT-7263](https://sft.its.cern.ch/jira/browse/ROOT-7263)).
     *   2D stats painting now takes the stats format into account when painting Integral. This problem was mentioned [here](https://root.cern.ch/phpBB3/viewtopic.php?f=3&t=19746).
     *   Fix [ROOT-6703](https://sft.its.cern.ch/jira/browse/ROOT-6703).
 *   Proof
@@ -115,7 +115,7 @@ NOTE: this release exists to backport support for LZ4 compression also to the ol
     *   Fixed build problems with Mac OS X
 *   Core
 
-    *   TextInput: prevent history file clashes from concurrent processes ([ROOT-6539](http://sft.its.cern.ch/jira/browse/ROOT-6539)).
+    *   TextInput: prevent history file clashes from concurrent processes ([ROOT-6539](https://sft.its.cern.ch/jira/browse/ROOT-6539)).
 *   I/O.
     *   Properly skip the content of base class onfile that have been removed from the in-memory class layout.
     *   Properly support TStreamerInfo written by ROOT v4.00.
@@ -130,7 +130,7 @@ NOTE: this release exists to backport support for LZ4 compression also to the ol
 
 
 *   Build system
-    *   Fix problem with libraries starting with the same same ([ROOT-7048](http://sft.its.cern.ch/jira/browse/ROOT-7048))
+    *   Fix problem with libraries starting with the same same ([ROOT-7048](https://sft.its.cern.ch/jira/browse/ROOT-7048))
     *   Support for CMake version > 3.1
 *   Proof
     *   Added support for addition of workers while running to TPacketizer to use in dynamic startups.
@@ -140,11 +140,11 @@ NOTE: this release exists to backport support for LZ4 compression also to the ol
     *   Better adjustment of the tilde accent position in case of Cocoa backend.
     *   When printing a coloured 2D histograms (with option COLZ) into a PDF or PostScript file, the preview on screen using many standard PDF previewer tools showed very thin white lines between the bins as well as in the color palette. This made very ugly the final output. This problem is due to bad implementation of anti-aliasing in these previewers. A way to bypass this issue was to turn off the anti-aliasing in the previewer but then the rest of the document does not look nice. This problem is now bypassed with a fix in both PDF and PostScript output.
 *   Interpreter
-    *   Include <iostream> in CINT also for frameworks ([ROOT-7103](http://sft.its.cern.ch/jira/browse/ROOT-7103)).
+    *   Include <iostream> in CINT also for frameworks ([ROOT-7103](https://sft.its.cern.ch/jira/browse/ROOT-7103)).
 *   NetxNG
-    *   Restore functionality to TNetXNGFile, which is available when access root files by other methods, and allow access to root files within a zip archive ([ROOT-7185](http://sft.its.cern.ch/jira/browse/ROOT-7185))<span class="Apple-tab-span" style="white-space:pre"></span>
+    *   Restore functionality to TNetXNGFile, which is available when access root files by other methods, and allow access to root files within a zip archive ([ROOT-7185](https://sft.its.cern.ch/jira/browse/ROOT-7185))<span class="Apple-tab-span" style="white-space:pre"></span>
 *   Montecarlo
-    *   Support for Pythia8 version > 8.2 ([ROOT-7070](http://sft.its.cern.ch/jira/browse/ROOT-7185))
+    *   Support for Pythia8 version > 8.2 ([ROOT-7070](https://sft.its.cern.ch/jira/browse/ROOT-7185))
 
 <a id='26'></a>
 ## Changes in version v5-34-26 (February 20, 2015)
@@ -157,9 +157,9 @@ NOTE: this release exists to backport support for LZ4 compression also to the ol
     *   In TMathText \mu is now working for Postscript output.
     *   Implement transparent colors in TTeXDump using TiKZ "opacity".
 *   Core
-    *   Fix crash in TClonesArray::ExpandCreateFast [ROOT-7046.](http://sft.its.cern.ch/jira/browse/ROOT-7046)
+    *   Fix crash in TClonesArray::ExpandCreateFast [ROOT-7046.](https://sft.its.cern.ch/jira/browse/ROOT-7046)
 *   I/O
-    *   Prevent crashes when using default constructed TFile and TDirectoryFile ( [ROOT-7005](http://sft.its.cern.ch/jira/browse/ROOT-7005))
+    *   Prevent crashes when using default constructed TFile and TDirectoryFile ( [ROOT-7005](https://sft.its.cern.ch/jira/browse/ROOT-7005))
     *   Better support of TString and std::string in XML/JSON streamers
     *   Solve problem in TBufferXML to support default streamer (no + sign in LinkDef.h file)
     *   Support of STL containers in JSON
@@ -167,8 +167,8 @@ NOTE: this release exists to backport support for LZ4 compression also to the ol
     *   Special handling of std::map in JSON
     *   xml: support all standard symbols in node names
 *   TTree
-    *   Fix memory leak of CollectionProxy for non split branch for an STL collection. ( [ROOT-7019](http://sft.its.cern.ch/jira/browse/ROOT-7019))
-    *   Significantly improve the scheduling of I/O rules in split TTree solving [ROOT-7009.](http://sft.its.cern.ch/jira/browse/ROOT-7009)
+    *   Fix memory leak of CollectionProxy for non split branch for an STL collection. ( [ROOT-7019](https://sft.its.cern.ch/jira/browse/ROOT-7019))
+    *   Significantly improve the scheduling of I/O rules in split TTree solving [ROOT-7009.](https://sft.its.cern.ch/jira/browse/ROOT-7009)
 *   JSROOT
     *   Several files can now be loaded simultaneously
     *   Use d3.time.scale to display time scales
@@ -190,7 +190,7 @@ NOTE: this release exists to backport support for LZ4 compression also to the ol
 
 
 *   Build system
-    *   Changed of the order of libraries in link statement to avoid problems. [ROOT-6855](http://sft.its.cern.ch/jira/browse/ROOT-6855)
+    *   Changed of the order of libraries in link statement to avoid problems. [ROOT-6855](https://sft.its.cern.ch/jira/browse/ROOT-6855)
 *   Core
     *   Correct the order of initialization and thread locking when create the TClass sub list (data members, base, functions) to prevent a thread from using the list before it is completely created.
     *   Implement TDictionary::op=() given that it has a copy ctor (Coverity).
@@ -240,7 +240,7 @@ NOTE: this release exists to backport support for LZ4 compression also to the ol
 *   Vc
     *   Update to the new version, 0.7.4 (the same as in the ROOT 6 branches)
 *   IO
-    *   Set the default for Davix to enable Davix.GSI.GridMode, to be consistent with the comment in the default system rootrc. GridMode is needed to use https with usual grid https endpoints such as SEs. [ROOT-6897](http://sft.its.cern.ch/jira/browse/ROOT-6897)
+    *   Set the default for Davix to enable Davix.GSI.GridMode, to be consistent with the comment in the default system rootrc. GridMode is needed to use https with usual grid https endpoints such as SEs. [ROOT-6897](https://sft.its.cern.ch/jira/browse/ROOT-6897)
 *   Hist
     *   Remove TH1::Clone and use (as before 5.34.23) TObject::Clone for cloning histogram
     *   Use TH1::Copy instead of TH1::Clone in TH1 and TProfile::RebinAxis
@@ -257,14 +257,14 @@ NOTE: this release exists to backport support for LZ4 compression also to the ol
     *   Fix for [ROOT-6812](https://sft.its.cern.ch/jira/browse/ROOT-6812): Can't compile v5-34-22 on MacOS X in "configure mode"
     *   Silence anachronism warning on Windows with Vc.
     *   Add --enable-cxx14 and --cxxflag and --cflags to the configure script. For now --enable-cxx14 uses -std=c++1y. --cxxflag and --cflags should be used when custom configuring ROOT with compiler flags that affects binary compatibility (like -std=c++1y for example). This prevents this kind of important customization, historically done in MyRules.mk, from being 'forgotten' from root-config.
-    *   Fix for [ROOT-6751](http://sft.its.cern.ch/jira/browse/ROOT-6751): etcdir not set
-    *   CMake changes required for Mac OSX10.10 (Yosemite) - [ROOT-6836](http://sft.its.cern.ch/jira/browse/ROOT-6836)
+    *   Fix for [ROOT-6751](https://sft.its.cern.ch/jira/browse/ROOT-6751): etcdir not set
+    *   CMake changes required for Mac OSX10.10 (Yosemite) - [ROOT-6836](https://sft.its.cern.ch/jira/browse/ROOT-6836)
 *   Core
 
     *   Fix thread_local declaration (affecting gcc 4.7)
     *   Many changes to improve thread safety.
 *   Math
-    *   Fix for [ROOT-6879](http://sft.its.cern.ch/jira/browse/ROOT-6879): TMinuit destructor when gROOT has been already deleted
+    *   Fix for [ROOT-6879](https://sft.its.cern.ch/jira/browse/ROOT-6879): TMinuit destructor when gROOT has been already deleted
 *   Histograms
     *   Fix TAxis::Copy function did not correctly handle the case where not all bins had labels.
     *   Implement TH1::Clone()

--- a/install/all_releases/root-version-v6-02-00-patch-release-notes.md
+++ b/install/all_releases/root-version-v6-02-00-patch-release-notes.md
@@ -168,7 +168,7 @@ sidebar:
 	</li>
 	<li>NetxNG
 	<ul>
-		<li>Restore functionality to TNetXNGFile, which is available when access root files by other methods, and allow access to root files within a zip archive (<a href="http://sft.its.cern.ch/jira/browse/ROOT-7185" target="_blank">ROOT-7185</a>)</li>
+		<li>Restore functionality to TNetXNGFile, which is available when access root files by other methods, and allow access to root files within a zip archive (<a href="https://sft.its.cern.ch/jira/browse/ROOT-7185" target="_blank">ROOT-7185</a>)</li>
 	</ul>
 	</li>
 </ul>
@@ -181,7 +181,7 @@ sidebar:
 		<li>Increase robustness of rootcling cli (<a href="https://sft.its.cern.ch/jira/browse/ROOT-6999" target="_blank">ROOT-6999</a>)</li>
 		<li>Support multiple libraries for an autoload key which is a header file name (<a href="https://sft.its.cern.ch/jira/browse/ROOT-7020" target="_blank">ROOT-7020</a>)</li>
 		<li>Propagate to the TClass instances the properties specified in selection rules matching classes via typedef nanames (<a href="https://sft.its.cern.ch/jira/browse/ROOT-6796" target="_blank">ROOT-6796</a>)</li>
-		<li>Fix crash in TClonesArray::ExpandCreateFast <a href="http://sft.its.cern.ch/jira/browse/ROOT-7046" target="_blank">ROOT-7046.</a></li>
+		<li>Fix crash in TClonesArray::ExpandCreateFast <a href="https://sft.its.cern.ch/jira/browse/ROOT-7046" target="_blank">ROOT-7046.</a></li>
 		<li>Add TClass::HasDictionarySelection() to query whether a class has been selected (and if not loaded is available through a rootmap).</li>
 		<li>Optimise code generated for forward declarations in the rootmaps to speed up startup and reduce memory footprint in presence of large sets of selected classes.</li>
 		<li>Avoid duplicates in rootmaps selectively avoiding to use as keys external class names</li>
@@ -220,21 +220,21 @@ sidebar:
 <ul>
 	<li>I/O.
 	<ul>
-		<li>Prevent crashes when using default constructed TFile and TDirectoryFile ( <a href="http://sft.its.cern.ch/jira/browse/ROOT-7005" target="_blank">ROOT-7005</a>)</li>
+		<li>Prevent crashes when using default constructed TFile and TDirectoryFile ( <a href="https://sft.its.cern.ch/jira/browse/ROOT-7005" target="_blank">ROOT-7005</a>)</li>
 	</ul>
 	</li>
 	<li>TTree
 	<ul>
-		<li>Fix memory leak of CollectionProxy for non split branch for an STL collection. ( <a href="http://sft.its.cern.ch/jira/browse/ROOT-7019" target="_blank">ROOT-7019</a>)</li>
-		<li>Significantly improve the scheduling of I/O rules in split TTree solving <a href="http://sft.its.cern.ch/jira/browse/ROOT-7009" target="_blank">ROOT-7009.</a></li>
+		<li>Fix memory leak of CollectionProxy for non split branch for an STL collection. ( <a href="https://sft.its.cern.ch/jira/browse/ROOT-7019" target="_blank">ROOT-7019</a>)</li>
+		<li>Significantly improve the scheduling of I/O rules in split TTree solving <a href="https://sft.its.cern.ch/jira/browse/ROOT-7009" target="_blank">ROOT-7009.</a></li>
 	</ul>
 	</li>
 	<li>Interpreter.
 	<ul>
-		<li>Handle re-emission of referenced weak symbols as real symbols later (<a href="http://sft.its.cern.ch/jira/browse/ROOT-7024" target="_blank">ROOT-7024</a>)</li>
+		<li>Handle re-emission of referenced weak symbols as real symbols later (<a href="https://sft.its.cern.ch/jira/browse/ROOT-7024" target="_blank">ROOT-7024</a>)</li>
 		<li>Simplify creation of pch input header using the __has_include macro</li>
 		<li>Remove system header sys/time.h in favour of ctime</li>
-		<li>Add in the pch all stl headers. On mac, exclude regex to workaround <a href="http://sft.its.cern.ch/jira/browse/ROOT-7004" target="_blank">ROOT-7004</a></li>
+		<li>Add in the pch all stl headers. On mac, exclude regex to workaround <a href="https://sft.its.cern.ch/jira/browse/ROOT-7004" target="_blank">ROOT-7004</a></li>
 		<li>Do not construct a class's interpreter info while its TClass is initialized, and don't refuse to construct it permanently just because autoparsing was suspended when tried first.</li>
 	</ul>
 	</li>
@@ -351,7 +351,7 @@ sidebar:
 	</li>
 	<li>IO
 	<ul>
-		<li>Set the default for Davix to enable Davix.GSI.GridMode, to be consistent with the comment in the default system rootrc. GridMode is needed to use https with usual grid https endpoints such as SEs. <a href="http://sft.its.cern.ch/jira/browse/ROOT-6897" target="_blank">ROOT-6897</a></li>
+		<li>Set the default for Davix to enable Davix.GSI.GridMode, to be consistent with the comment in the default system rootrc. GridMode is needed to use https with usual grid https endpoints such as SEs. <a href="https://sft.its.cern.ch/jira/browse/ROOT-6897" target="_blank">ROOT-6897</a></li>
 	</ul>
 	</li>
 </ul>

--- a/install/all_releases/root-version-v6-02-00-patch-release-notes.md
+++ b/install/all_releases/root-version-v6-02-00-patch-release-notes.md
@@ -299,7 +299,7 @@ sidebar:
 		<li>In some some cases an extra point was drawn when a TGraph2D was drawn with P, P0 or PCOL options.</li>
 		<li>The hollow fill style was not rendered correctly by TTexDump. (<a href="https://sft.its.cern.ch/jira/browse/ROOT-6841" target="_blank">ROOT-6841</a>)</li>
 		<li>It was possible to interactively zoom outside the histograms' limits. Protections have been added.</li>
-		<li>Fix an <a href="http://root.cern.ch/phpBB3/viewtopic.php?f=3&amp;t=18778" target="_blank">issue</a> with E0 option and log scale.</li>
+		<li>Fix an <a href="https://root.cern.ch/phpBB3/viewtopic.php?f=3&amp;t=18778" target="_blank">issue</a> with E0 option and log scale.</li>
 		<li>Better line width matching with screen and pdf output (<a href="https://sft.its.cern.ch/jira/browse/ROOT-6858" target="_blank">ROOT-6858</a>)</li>
 		<li>With the Cocoa backend on Mac, the PDF and PS output produced miss-aligned exponents because the GetTextExtend method behaved differently in batch mode and "screen" mode. This is now fixed.</li>
 		<li>In TTextDump the text color was ignored. It was always black.</li>

--- a/install/all_releases/root-version-v6-02-00-patch-release-notes.md
+++ b/install/all_releases/root-version-v6-02-00-patch-release-notes.md
@@ -10,9 +10,9 @@ sidebar:
 
 <div>
 <p>The first release candidate of the new production version ROOT v6-02-00 has been released Sept 25, 2014.</p>
-<p>Get the source from <a href="/node/92" target="_blank">Git</a> using:</p>
+<p>Get the source from Git using:</p>
 <code>git clone http://root.cern.ch/git/root.git root-v6-02; cd root-v6-02; git checkout -b v6-02-00-patches </code>
-<p>After obtaining the source read the file <a href="/node/103" target="_blank">README/INSTALL</a> (in short just do: cd root; ./configure; make).</p>
+<p>After obtaining the source read the file README/INSTALL (in short just do: cd root; ./configure; make).</p>
 <h2>Note for MaxOsX 10.10 (Yosemite)</h2>
 <p>When installing ROOT from sources the XCode command line tools need to be re-installed with:</p>
 <code> xcode-select --install </code>
@@ -207,7 +207,7 @@ sidebar:
 	</li>
 	<li>Interpreter
 	<ul>
-		<li>Add ability to unload ACLIC'ed sources (<a browse="" ch="" href="&lt;a href=" jira="">ROOT-7027</a>).</li>
+		<li>Add ability to unload ACLIC'ed sources (ROOT-7027).</li>
 		<li>Reduce memory usage trying to update only existing TClass instances in fwd declared or emulated state</li>
 	</ul>
 	</li>


### PR DESCRIPTION
Now we check also the release pages and release notes for dead links and other stuff :)

Especially we check that users can actually download the binaries, which is actually possible down to ROOT v3 :flushed: 

I've not enabled the checker for the ROOT v5 release notes (but the release pages!) since we have tons of dead links there and either we remove them or ignore them.

Only debatable change: There's a missing binary file for ROOT v3 on the AIX.5 platform, I just removed the link.

Note that we now run on 3444 external links per check, which makes potentially considerable noise regarding the network usage in the github actions.