### PR TITLE
Switch all root.cern.ch to root.cern, add action that enforces root.cern

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -37,6 +37,11 @@ jobs:
           # - Broken links on pagination pages, e.g., page2/index.html
           arguments: --empty-alt-ignore --file-ignore "/(.*root-version-v5.*|page.?/index.html)/" --allow-hash-href --url-ignore "/(https://ph-root-2.cern.ch/.*|https://rootbnch-grafana-test.cern.ch|https://lcgapp-services.cern.ch/root-jenkins|https://indico.desy.de.*)/" --only-4xx --enforce-https --check-favicon
 
+      - name: Look for root.cern.ch links
+        run: |
+          N_WRONG_LINKS=$(grep -R 'root\.cern\.ch' build | wc -l)
+          exit $N_WRONG_LINKS
+
       - name: Wait for other deployments
         # wait for other workflows that are deploying the website to finish, (not 100% foolproof, see #240)
         if: ${{ env.SHOULD_DEPLOY == 'true' && github.event_name != 'pull_request' }}

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -122,9 +122,6 @@ for_developers:
       - title: Coverity
         url: https://coverity.cern.ch/login/login.htm
         target: _blank
-      - title: GitWeb
-        url: https://root.cern/gitweb/?p=root.git;a=summary
-        target: _blank
       - title: Jira
         url: https://sft.its.cern.ch/jira/projects/ROOT?selectedItem=com.atlassian.jira.jira-projects-plugin%3Asummary-page
         target: _blank

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -123,7 +123,7 @@ for_developers:
         url: https://coverity.cern.ch/login/login.htm
         target: _blank
       - title: GitWeb
-        url: https://root.cern.ch/gitweb/?p=root.git;a=summary
+        url: https://root.cern/gitweb/?p=root.git;a=summary
         target: _blank
       - title: Jira
         url: https://sft.its.cern.ch/jira/projects/ROOT?selectedItem=com.atlassian.jira.jira-projects-plugin%3Asummary-page
@@ -139,7 +139,7 @@ for_developers:
      url: https://rootbnch-grafana-test.cern.ch
      target: _blank
    - title: ROOT Logos
-     url: https://root.cern.ch/img/logos/ROOT_Logo/
+     url: https://root.cern/img/logos/ROOT_Logo/
      target: _blank
 
 releases:

--- a/_posts/2015-06-19-root6-and-backward-compatibility.md
+++ b/_posts/2015-06-19-root6-and-backward-compatibility.md
@@ -6,7 +6,7 @@ author: Axel Naumann
 
 <p>Hi everyone, dear Matt!</p>
 
-<p>Matt Walker has posted an <a href="https://root.cern.ch/blog/do-we-need-yet-another-custom-c-interpreter">
+<p>Matt Walker has posted an <a href="https://root.cern/blog/do-we-need-yet-another-custom-c-interpreter">
 extensive review</a> of ROOT and what he would hope the future of ROOT to be. Because I think
 many of his comments are good ones, and because I have heard some of them from several people
 in the past, I decided to give the answer to an audience that's little bit wider, in a dedicated

--- a/_posts/2015-12-05-root-has-its-jupyter-kernel.md
+++ b/_posts/2015-12-05-root-has-its-jupyter-kernel.md
@@ -6,9 +6,9 @@ author: Enric Tejedor
 
 ROOT has its Jupyter kernel! More information [here](https://github.com/ipython/ipython/wiki/IPython-kernels-for-other-languages).
 
-Yet another milestone of the integration plan of ROOT with the [Jupyter](https://jupyter.org) technology has been reached: ROOT now offers a [Jupyter kernel](https://github.com/root-project/root/tree/master/bindings/jupyroot)! You can [try it](https://root.cern.ch/how/how-create-rootbook) already now.
+Yet another milestone of the integration plan of ROOT with the [Jupyter](https://jupyter.org) technology has been reached: ROOT now offers a [Jupyter kernel](https://github.com/root-project/root/tree/master/bindings/jupyroot)! You can [try it](https://root.cern/how/how-create-rootbook) already now.
 
-ROOT is the 54th entry in [this list](https://github.com/ipython/ipython/wiki/IPython-kernels-for-other-languages) and this is pretty cool. Now not only the PyROOT, the ROOT Python bindings, are [integrated with notebooks](https://github.com/root-project/root/tree/master/bindings/jupyroot#python-rootbook) but it's also possible to express your data mining in C++ within a notebook, taking advantage of all the powerful features of ROOT - plotting (now also interactive thanks to (Javascript ROOT](https://root.cern.ch/js/)), multivariate analysis, linear algebra, I/O and reflection: all available within a notebook.
+ROOT is the 54th entry in [this list](https://github.com/ipython/ipython/wiki/IPython-kernels-for-other-languages) and this is pretty cool. Now not only the PyROOT, the ROOT Python bindings, are [integrated with notebooks](https://github.com/root-project/root/tree/master/bindings/jupyroot#python-rootbook) but it's also possible to express your data mining in C++ within a notebook, taking advantage of all the powerful features of ROOT - plotting (now also interactive thanks to (Javascript ROOT](https://root.cern/js/)), multivariate analysis, linear algebra, I/O and reflection: all available within a notebook.
 
 But this is just the beginning: thanks to the well established and widely PyROOT technology, it is now possible to seamlessly mix C++ and Python in notebooks (of course without the need of writing any binding by hand).
 

--- a/_posts/2015-12-16-try-new-rootbooks-binder-beta-0.md
+++ b/_posts/2015-12-16-try-new-rootbooks-binder-beta-0.md
@@ -6,7 +6,7 @@ author:
 
 Try the new [ROOTbooks on Binder (Beta)](https://mybinder.org/repo/cernphsft/rootbinder)! Use ROOT interactively in notebooks and explore to the examples.
 
-Not even two weeks since the release of the [ROOT Jupyter kernel](https://root.cern.ch/root-has-its-jupyter-kernel) and you can already try ROOT interactively on [Binder (Beta)](https://mybinder.org/repo/cernphsft/rootbinder)! Of course, do not hesitate to use your favourite mobile device...
+Not even two weeks since the release of the [ROOT Jupyter kernel](https://root.cern/root-has-its-jupyter-kernel) and you can already try ROOT interactively on [Binder (Beta)](https://mybinder.org/repo/cernphsft/rootbinder)! Of course, do not hesitate to use your favourite mobile device...
 
 We collected ROOTbooks which illustrate the most striking features of the integration of ROOT with Jupyter technology, using both the C++ and Python languages. Take it as the
 documentation for the most impatient user, read the notebooks, execute them interactively, modify them.

--- a/_posts/2016-09-05-get-most-out-root-tutorials.md
+++ b/_posts/2016-09-05-get-most-out-root-tutorials.md
@@ -4,11 +4,11 @@ layout: archive
 author: Danilo Piparo
 ---
 
-All [ROOT tutorials](https://root.cern.ch/doc/master/group__Tutorials.html) are now available
+All [ROOT tutorials](https://root.cern/doc/master/group__Tutorials.html) are now available
 as ROOTBooks which can be statically visualized via [NBViewer](https://nbviewer.jupyter.org) or
 interactively explored with [SWAN](https://swan.web.cern.ch).
 
-A great amount of knowledge about the usage of ROOT is distilled in the [ROOT tutorials](https://root.cern.ch/doc/master/group__Tutorials.html). Since the early days of the framework, the ROOT team and its collaborators documented the features of the components of ROOT as Tutorials to allow users to "learn by example".
+A great amount of knowledge about the usage of ROOT is distilled in the [ROOT tutorials](https://root.cern/doc/master/group__Tutorials.html). Since the early days of the framework, the ROOT team and its collaborators documented the features of the components of ROOT as Tutorials to allow users to "learn by example".
 Since some weeks the ROOT tutorials are converted to Jupyter Notebooks automatically during the procedure creating the ROOT documentation and can be accessed in two ways: as statically rendered notebooks via [NBViewer](https://nbviewer.jupyter.org) or interactively with [SWAN](https://swan.web.cern.ch).
-Look for the blue and orange badges on the [*Tutorials' Pages*](https://root.cern.ch/doc/master/group__Tutorials.html)!
+Look for the blue and orange badges on the [*Tutorials' Pages*](https://root.cern/doc/master/group__Tutorials.html)!
 ![Badges](https://d35c7d8c.web.cern.ch/sites/d35c7d8c.web.cern.ch/files/badges.png)

--- a/_posts/2020-06-14-new-pyroot-622.md
+++ b/_posts/2020-06-14-new-pyroot-622.md
@@ -19,8 +19,8 @@ for every class.
 
 - **Interoperable**: the new PyROOT is better integrated in the Python data science ecosystem.
 ROOT data can be read into NumPy arrays and pandas dataframes, as shown
-[here](https://root.cern.ch/doc/master/df026__AsNumpyArrays_8py.html).
-[Another example](https://root.cern.ch/doc/master/pyroot004__NumbaDeclare_8py.html)
+[here](https://root.cern/doc/master/df026__AsNumpyArrays_8py.html).
+[Another example](https://root.cern/doc/master/pyroot004__NumbaDeclare_8py.html)
 is the ability to compile Python callables with Numba and use them in e.g.
 RDataFrame computations.
 

--- a/_releases/release-30307.md
+++ b/_releases/release-30307.md
@@ -15,30 +15,30 @@ sidebar:
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v3.02.07.source.tar.gz](https://root.cern.ch/download/root_v3.02.07.source.tar.gz) | 5.0M |
+| source | [root_v3.02.07.source.tar.gz](https://root.cern/download/root_v3.02.07.source.tar.gz) | 5.0M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| AIX.5 | [root_v3.02.07.AIX.5.tar.gz](https://root.cern.ch/download/root_v3.02.07.AIX.5.tar.gz) |  11M |
-| HP UX.B.10.20.aCC | [root_v3.02.07.HP-UX.B.10.20.aCC.tar.gz](https://root.cern.ch/download/root_v3.02.07.HP-UX.B.10.20.aCC.tar.gz) |  13M |
-| IRIX64.6.5.cc | [root_v3.02.07.IRIX64.6.5.cc.tar.gz](https://root.cern.ch/download/root_v3.02.07.IRIX64.6.5.cc.tar.gz) |  10M |
-| IRIX64.6.5.gcc | [root_v3.02.07.IRIX64.6.5.gcc.tar.gz](https://root.cern.ch/download/root_v3.02.07.IRIX64.6.5.gcc.tar.gz) |  11M |
-| IRIX64.6.5.kcc | [root_v3.02.07.IRIX64.6.5.kcc.tar.gz](https://root.cern.ch/download/root_v3.02.07.IRIX64.6.5.kcc.tar.gz) |  10M |
-| Linux.RH5.1.egcs | [root_v3.02.07.Linux.RH5.1.egcs.tar.gz](https://root.cern.ch/download/root_v3.02.07.Linux.RH5.1.egcs.tar.gz) | 8.4M |
-| Linux.RH6.1.egcs | [root_v3.02.07.Linux.RH6.1.egcs.tar.gz](https://root.cern.ch/download/root_v3.02.07.Linux.RH6.1.egcs.tar.gz) | 8.4M |
-| Linux.RH6.1.gcc2952 | [root_v3.02.07.Linux.RH6.1.gcc2952.tar.gz](https://root.cern.ch/download/root_v3.02.07.Linux.RH6.1.gcc2952.tar.gz) | 9.7M |
-| Linux.RH7.1.gcc296 | [root_v3.02.07.Linux.RH7.1.gcc296.tar.gz](https://root.cern.ch/download/root_v3.02.07.Linux.RH7.1.gcc296.tar.gz) | 8.1M |
-| OSF1.V4.0.cxx6 | [root_v3.02.07.OSF1.V4.0.cxx6.tar.gz](https://root.cern.ch/download/root_v3.02.07.OSF1.V4.0.cxx6.tar.gz) | 9.3M |
-| OSF1.V4.0 | [root_v3.02.07.OSF1.V4.0.tar.gz](https://root.cern.ch/download/root_v3.02.07.OSF1.V4.0.tar.gz) |  11M |
-| SunOS.5.7 | [root_v3.02.07.SunOS.5.7.tar.gz](https://root.cern.ch/download/root_v3.02.07.SunOS.5.7.tar.gz) |  10M |
-| SunOS.5.8 | [root_v3.02.07.SunOS.5.8.tar.gz](https://root.cern.ch/download/root_v3.02.07.SunOS.5.8.tar.gz) |  10M |
-| win32 (dbg) | [root_v3.02.07.win32.debug.tar.gz](https://root.cern.ch/download/root_v3.02.07.win32.debug.tar.gz) |  17M |
-| win32 | [root_v3.02.07.win32.tar.gz](https://root.cern.ch/download/root_v3.02.07.win32.tar.gz) | 9.3M |
-| win32gdk | [root_v3.02.07.win32gdk.tar.gz](https://root.cern.ch/download/root_v3.02.07.win32gdk.tar.gz) | 9.9M |
-| root_v3.02.07b.SunOS.5.8 | [root_v3.02.07b.SunOS.5.8.tar.gz](https://root.cern.ch/download/root_v3.02.07b.SunOS.5.8.tar.gz) |  10M |
+| AIX.5 | [root_v3.02.07.AIX.5.tar.gz](https://root.cern/download/root_v3.02.07.AIX.5.tar.gz) |  11M |
+| HP UX.B.10.20.aCC | [root_v3.02.07.HP-UX.B.10.20.aCC.tar.gz](https://root.cern/download/root_v3.02.07.HP-UX.B.10.20.aCC.tar.gz) |  13M |
+| IRIX64.6.5.cc | [root_v3.02.07.IRIX64.6.5.cc.tar.gz](https://root.cern/download/root_v3.02.07.IRIX64.6.5.cc.tar.gz) |  10M |
+| IRIX64.6.5.gcc | [root_v3.02.07.IRIX64.6.5.gcc.tar.gz](https://root.cern/download/root_v3.02.07.IRIX64.6.5.gcc.tar.gz) |  11M |
+| IRIX64.6.5.kcc | [root_v3.02.07.IRIX64.6.5.kcc.tar.gz](https://root.cern/download/root_v3.02.07.IRIX64.6.5.kcc.tar.gz) |  10M |
+| Linux.RH5.1.egcs | [root_v3.02.07.Linux.RH5.1.egcs.tar.gz](https://root.cern/download/root_v3.02.07.Linux.RH5.1.egcs.tar.gz) | 8.4M |
+| Linux.RH6.1.egcs | [root_v3.02.07.Linux.RH6.1.egcs.tar.gz](https://root.cern/download/root_v3.02.07.Linux.RH6.1.egcs.tar.gz) | 8.4M |
+| Linux.RH6.1.gcc2952 | [root_v3.02.07.Linux.RH6.1.gcc2952.tar.gz](https://root.cern/download/root_v3.02.07.Linux.RH6.1.gcc2952.tar.gz) | 9.7M |
+| Linux.RH7.1.gcc296 | [root_v3.02.07.Linux.RH7.1.gcc296.tar.gz](https://root.cern/download/root_v3.02.07.Linux.RH7.1.gcc296.tar.gz) | 8.1M |
+| OSF1.V4.0.cxx6 | [root_v3.02.07.OSF1.V4.0.cxx6.tar.gz](https://root.cern/download/root_v3.02.07.OSF1.V4.0.cxx6.tar.gz) | 9.3M |
+| OSF1.V4.0 | [root_v3.02.07.OSF1.V4.0.tar.gz](https://root.cern/download/root_v3.02.07.OSF1.V4.0.tar.gz) |  11M |
+| SunOS.5.7 | [root_v3.02.07.SunOS.5.7.tar.gz](https://root.cern/download/root_v3.02.07.SunOS.5.7.tar.gz) |  10M |
+| SunOS.5.8 | [root_v3.02.07.SunOS.5.8.tar.gz](https://root.cern/download/root_v3.02.07.SunOS.5.8.tar.gz) |  10M |
+| win32 (dbg) | [root_v3.02.07.win32.debug.tar.gz](https://root.cern/download/root_v3.02.07.win32.debug.tar.gz) |  17M |
+| win32 | [root_v3.02.07.win32.tar.gz](https://root.cern/download/root_v3.02.07.win32.tar.gz) | 9.3M |
+| win32gdk | [root_v3.02.07.win32gdk.tar.gz](https://root.cern/download/root_v3.02.07.win32gdk.tar.gz) | 9.9M |
+| root_v3.02.07b.SunOS.5.8 | [root_v3.02.07b.SunOS.5.8.tar.gz](https://root.cern/download/root_v3.02.07b.SunOS.5.8.tar.gz) |  10M |
 
 
 

--- a/_releases/release-30309.md
+++ b/_releases/release-30309.md
@@ -15,36 +15,36 @@ sidebar:
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v3.03.09.source.tar.gz](https://root.cern.ch/download/root_v3.03.09.source.tar.gz) | 5.9M |
-| root_v3.03.09a.source | [root_v3.03.09a.source.tar.gz](https://root.cern.ch/download/root_v3.03.09a.source.tar.gz) | 6.0M |
-| root_v3.03.09b.source | [root_v3.03.09b.source.tar.gz](https://root.cern.ch/download/root_v3.03.09b.source.tar.gz) | 6.0M |
+| source | [root_v3.03.09.source.tar.gz](https://root.cern/download/root_v3.03.09.source.tar.gz) | 5.9M |
+| root_v3.03.09a.source | [root_v3.03.09a.source.tar.gz](https://root.cern/download/root_v3.03.09a.source.tar.gz) | 6.0M |
+| root_v3.03.09b.source | [root_v3.03.09b.source.tar.gz](https://root.cern/download/root_v3.03.09b.source.tar.gz) | 6.0M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| AIX.5 | [root_v3.03.09.AIX.5.tar.gz](https://root.cern.ch/download/root_v3.03.09.AIX.5.tar.gz) |  13M |
-| HP UX.B.10.20.aCC | [root_v3.03.09.HP-UX.B.10.20.aCC.tar.gz](https://root.cern.ch/download/root_v3.03.09.HP-UX.B.10.20.aCC.tar.gz) |  16M |
-| IRIX64.6.5.cc | [root_v3.03.09.IRIX64.6.5.cc.tar.gz](https://root.cern.ch/download/root_v3.03.09.IRIX64.6.5.cc.tar.gz) |  12M |
-| IRIX64.6.5.gcc | [root_v3.03.09.IRIX64.6.5.gcc.tar.gz](https://root.cern.ch/download/root_v3.03.09.IRIX64.6.5.gcc.tar.gz) |  14M |
-| IRIX64.6.5.kcc | [root_v3.03.09.IRIX64.6.5.kcc.tar.gz](https://root.cern.ch/download/root_v3.03.09.IRIX64.6.5.kcc.tar.gz) |  13M |
-| Linux.RH5.1.egcs | [root_v3.03.09.Linux.RH5.1.egcs.tar.gz](https://root.cern.ch/download/root_v3.03.09.Linux.RH5.1.egcs.tar.gz) |  11M |
-| Linux.RH6.1.egcs | [root_v3.03.09.Linux.RH6.1.egcs.tar.gz](https://root.cern.ch/download/root_v3.03.09.Linux.RH6.1.egcs.tar.gz) |  11M |
-| Linux.RH6.1.gcc2952 | [root_v3.03.09.Linux.RH6.1.gcc2952.tar.gz](https://root.cern.ch/download/root_v3.03.09.Linux.RH6.1.gcc2952.tar.gz) |  12M |
-| Linux.RH7.2.gcc32 | [root_v3.03.09.Linux.RH7.2.gcc32.tar.gz](https://root.cern.ch/download/root_v3.03.09.Linux.RH7.2.gcc32.tar.gz) |  11M |
-| Linux.RH7.2.gcc296 | [root_v3.03.09.Linux.RH7.2.gcc296.tar.gz](https://root.cern.ch/download/root_v3.03.09.Linux.RH7.2.gcc296.tar.gz) |  11M |
-| Linux.RH7.2.gcc2953 | [root_v3.03.09.Linux.RH7.2.gcc2953.tar.gz](https://root.cern.ch/download/root_v3.03.09.Linux.RH7.2.gcc2953.tar.gz) |  11M |
-| OSF1.V4.0.cxx6 | [root_v3.03.09.OSF1.V4.0.cxx6.tar.gz](https://root.cern.ch/download/root_v3.03.09.OSF1.V4.0.cxx6.tar.gz) |  11M |
-| OSF1.V4.0 | [root_v3.03.09.OSF1.V4.0.tar.gz](https://root.cern.ch/download/root_v3.03.09.OSF1.V4.0.tar.gz) |  14M |
-| SunOS.5.7 | [root_v3.03.09.SunOS.5.7.tar.gz](https://root.cern.ch/download/root_v3.03.09.SunOS.5.7.tar.gz) |  14M |
-| SunOS.5.8 | [root_v3.03.09.SunOS.5.8.tar.gz](https://root.cern.ch/download/root_v3.03.09.SunOS.5.8.tar.gz) |  13M |
-| win32 (dbg) | [root_v3.03.09.win32.debug.tar.gz](https://root.cern.ch/download/root_v3.03.09.win32.debug.tar.gz) |  21M |
-| win32 | [root_v3.03.09.win32.tar.gz](https://root.cern.ch/download/root_v3.03.09.win32.tar.gz) |  12M |
-| win32gdk | [root_v3.03.09.win32gdk.tar.gz](https://root.cern.ch/download/root_v3.03.09.win32gdk.tar.gz) |  12M |
-| root_v3.03.09a.win32 | [root_v3.03.09a.win32.tar.gz](https://root.cern.ch/download/root_v3.03.09a.win32.tar.gz) |  11M |
-| root_v3.03.09b.win32 | [root_v3.03.09b.win32.tar.gz](https://root.cern.ch/download/root_v3.03.09b.win32.tar.gz) |  12M |
-| root_v3.03.09c.win32 | [root_v3.03.09c.win32.tar.gz](https://root.cern.ch/download/root_v3.03.09c.win32.tar.gz) |  13M |
+| AIX.5 | [root_v3.03.09.AIX.5.tar.gz](https://root.cern/download/root_v3.03.09.AIX.5.tar.gz) |  13M |
+| HP UX.B.10.20.aCC | [root_v3.03.09.HP-UX.B.10.20.aCC.tar.gz](https://root.cern/download/root_v3.03.09.HP-UX.B.10.20.aCC.tar.gz) |  16M |
+| IRIX64.6.5.cc | [root_v3.03.09.IRIX64.6.5.cc.tar.gz](https://root.cern/download/root_v3.03.09.IRIX64.6.5.cc.tar.gz) |  12M |
+| IRIX64.6.5.gcc | [root_v3.03.09.IRIX64.6.5.gcc.tar.gz](https://root.cern/download/root_v3.03.09.IRIX64.6.5.gcc.tar.gz) |  14M |
+| IRIX64.6.5.kcc | [root_v3.03.09.IRIX64.6.5.kcc.tar.gz](https://root.cern/download/root_v3.03.09.IRIX64.6.5.kcc.tar.gz) |  13M |
+| Linux.RH5.1.egcs | [root_v3.03.09.Linux.RH5.1.egcs.tar.gz](https://root.cern/download/root_v3.03.09.Linux.RH5.1.egcs.tar.gz) |  11M |
+| Linux.RH6.1.egcs | [root_v3.03.09.Linux.RH6.1.egcs.tar.gz](https://root.cern/download/root_v3.03.09.Linux.RH6.1.egcs.tar.gz) |  11M |
+| Linux.RH6.1.gcc2952 | [root_v3.03.09.Linux.RH6.1.gcc2952.tar.gz](https://root.cern/download/root_v3.03.09.Linux.RH6.1.gcc2952.tar.gz) |  12M |
+| Linux.RH7.2.gcc32 | [root_v3.03.09.Linux.RH7.2.gcc32.tar.gz](https://root.cern/download/root_v3.03.09.Linux.RH7.2.gcc32.tar.gz) |  11M |
+| Linux.RH7.2.gcc296 | [root_v3.03.09.Linux.RH7.2.gcc296.tar.gz](https://root.cern/download/root_v3.03.09.Linux.RH7.2.gcc296.tar.gz) |  11M |
+| Linux.RH7.2.gcc2953 | [root_v3.03.09.Linux.RH7.2.gcc2953.tar.gz](https://root.cern/download/root_v3.03.09.Linux.RH7.2.gcc2953.tar.gz) |  11M |
+| OSF1.V4.0.cxx6 | [root_v3.03.09.OSF1.V4.0.cxx6.tar.gz](https://root.cern/download/root_v3.03.09.OSF1.V4.0.cxx6.tar.gz) |  11M |
+| OSF1.V4.0 | [root_v3.03.09.OSF1.V4.0.tar.gz](https://root.cern/download/root_v3.03.09.OSF1.V4.0.tar.gz) |  14M |
+| SunOS.5.7 | [root_v3.03.09.SunOS.5.7.tar.gz](https://root.cern/download/root_v3.03.09.SunOS.5.7.tar.gz) |  14M |
+| SunOS.5.8 | [root_v3.03.09.SunOS.5.8.tar.gz](https://root.cern/download/root_v3.03.09.SunOS.5.8.tar.gz) |  13M |
+| win32 (dbg) | [root_v3.03.09.win32.debug.tar.gz](https://root.cern/download/root_v3.03.09.win32.debug.tar.gz) |  21M |
+| win32 | [root_v3.03.09.win32.tar.gz](https://root.cern/download/root_v3.03.09.win32.tar.gz) |  12M |
+| win32gdk | [root_v3.03.09.win32gdk.tar.gz](https://root.cern/download/root_v3.03.09.win32gdk.tar.gz) |  12M |
+| root_v3.03.09a.win32 | [root_v3.03.09a.win32.tar.gz](https://root.cern/download/root_v3.03.09a.win32.tar.gz) |  11M |
+| root_v3.03.09b.win32 | [root_v3.03.09b.win32.tar.gz](https://root.cern/download/root_v3.03.09b.win32.tar.gz) |  12M |
+| root_v3.03.09c.win32 | [root_v3.03.09c.win32.tar.gz](https://root.cern/download/root_v3.03.09c.win32.tar.gz) |  13M |
 
 
 ## Git

--- a/_releases/release-30309a.md
+++ b/_releases/release-30309a.md
@@ -15,14 +15,14 @@ sidebar:
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v3.03.09a.source.tar.gz](https://root.cern.ch/download/root_v3.03.09a.source.tar.gz) | 6.0M |
+| source | [root_v3.03.09a.source.tar.gz](https://root.cern/download/root_v3.03.09a.source.tar.gz) | 6.0M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| win32 | [root_v3.03.09a.win32.tar.gz](https://root.cern.ch/download/root_v3.03.09a.win32.tar.gz) |  11M |
+| win32 | [root_v3.03.09a.win32.tar.gz](https://root.cern/download/root_v3.03.09a.win32.tar.gz) |  11M |
 
 
 ## Git

--- a/_releases/release-30309b.md
+++ b/_releases/release-30309b.md
@@ -15,14 +15,14 @@ sidebar:
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v3.03.09b.source.tar.gz](https://root.cern.ch/download/root_v3.03.09b.source.tar.gz) | 6.0M |
+| source | [root_v3.03.09b.source.tar.gz](https://root.cern/download/root_v3.03.09b.source.tar.gz) | 6.0M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| win32 | [root_v3.03.09b.win32.tar.gz](https://root.cern.ch/download/root_v3.03.09b.win32.tar.gz) |  12M |
+| win32 | [root_v3.03.09b.win32.tar.gz](https://root.cern/download/root_v3.03.09b.win32.tar.gz) |  12M |
 
 
 ## Git

--- a/_releases/release-30401.md
+++ b/_releases/release-30401.md
@@ -15,7 +15,7 @@ sidebar:
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| LinuxIPAQ | [root_v3.04.01.LinuxIPAQ.tar.gz](https://root.cern.ch/download/root_v3.04.01.LinuxIPAQ.tar.gz) | 7.6M |
+| LinuxIPAQ | [root_v3.04.01.LinuxIPAQ.tar.gz](https://root.cern/download/root_v3.04.01.LinuxIPAQ.tar.gz) | 7.6M |
 
 
 ## Git

--- a/_releases/release-30402.md
+++ b/_releases/release-30402.md
@@ -15,36 +15,36 @@ sidebar:
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v3.04.02.source.tar.gz](https://root.cern.ch/download/root_v3.04.02.source.tar.gz) | 6.0M |
+| source | [root_v3.04.02.source.tar.gz](https://root.cern/download/root_v3.04.02.source.tar.gz) | 6.0M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| AIX.5 | [root_v3.04.02.AIX.5.tar.gz](https://root.cern.ch/download/root_v3.04.02.AIX.5.tar.gz) |  13M |
-| Darwin.6.2 | [root_v3.04.02.Darwin.6.2.tar.gz](https://root.cern.ch/download/root_v3.04.02.Darwin.6.2.tar.gz) |  20M |
-| HP UX.B.10.20.aCC | [root_v3.04.02.HP-UX.B.10.20.aCC.tar.gz](https://root.cern.ch/download/root_v3.04.02.HP-UX.B.10.20.aCC.tar.gz) |  17M |
-| IRIX64.6.5.cc | [root_v3.04.02.IRIX64.6.5.cc.tar.gz](https://root.cern.ch/download/root_v3.04.02.IRIX64.6.5.cc.tar.gz) |  13M |
-| IRIX64.6.5.gcc | [root_v3.04.02.IRIX64.6.5.gcc.tar.gz](https://root.cern.ch/download/root_v3.04.02.IRIX64.6.5.gcc.tar.gz) |  19M |
-| IRIX64.6.5.kcc | [root_v3.04.02.IRIX64.6.5.kcc.tar.gz](https://root.cern.ch/download/root_v3.04.02.IRIX64.6.5.kcc.tar.gz) |  13M |
-| Linux.RH5.1.egcs | [root_v3.04.02.Linux.RH5.1.egcs.tar.gz](https://root.cern.ch/download/root_v3.04.02.Linux.RH5.1.egcs.tar.gz) |  12M |
-| Linux.RH6.1.egcs | [root_v3.04.02.Linux.RH6.1.egcs.tar.gz](https://root.cern.ch/download/root_v3.04.02.Linux.RH6.1.egcs.tar.gz) |  11M |
-| Linux.RH6.1.gcc2952 | [root_v3.04.02.Linux.RH6.1.gcc2952.tar.gz](https://root.cern.ch/download/root_v3.04.02.Linux.RH6.1.gcc2952.tar.gz) |  10M |
-| Linux.RH7.2.gcc32 | [root_v3.04.02.Linux.RH7.2.gcc32.tar.gz](https://root.cern.ch/download/root_v3.04.02.Linux.RH7.2.gcc32.tar.gz) |  11M |
-| Linux.RH7.2.gcc296 | [root_v3.04.02.Linux.RH7.2.gcc296.tar.gz](https://root.cern.ch/download/root_v3.04.02.Linux.RH7.2.gcc296.tar.gz) |  11M |
-| Linux.RH7.2.gcc2953 | [root_v3.04.02.Linux.RH7.2.gcc2953.tar.gz](https://root.cern.ch/download/root_v3.04.02.Linux.RH7.2.gcc2953.tar.gz) |  12M |
-| Linux.RH7.2.ia64.ecc700 | [root_v3.04.02.Linux.RH7.2.ia64.ecc700.tar.gz](https://root.cern.ch/download/root_v3.04.02.Linux.RH7.2.ia64.ecc700.tar.gz) |  27M |
-| Linux.RH7.2.ia64.gcc296 | [root_v3.04.02.Linux.RH7.2.ia64.gcc296.tar.gz](https://root.cern.ch/download/root_v3.04.02.Linux.RH7.2.ia64.gcc296.tar.gz) |  12M |
-| Linux.RH7.2.icc700 | [root_v3.04.02.Linux.RH7.2.icc700.tar.gz](https://root.cern.ch/download/root_v3.04.02.Linux.RH7.2.icc700.tar.gz) |  17M |
-| Linux.RH7.3.gcc32 | [root_v3.04.02.Linux.RH7.3.gcc32.tar.gz](https://root.cern.ch/download/root_v3.04.02.Linux.RH7.3.gcc32.tar.gz) | 9.4M |
-| OSF1.V4.0.cxx6 | [root_v3.04.02.OSF1.V4.0.cxx6.tar.gz](https://root.cern.ch/download/root_v3.04.02.OSF1.V4.0.cxx6.tar.gz) |  12M |
-| OSF1.V4.0 | [root_v3.04.02.OSF1.V4.0.tar.gz](https://root.cern.ch/download/root_v3.04.02.OSF1.V4.0.tar.gz) |  14M |
-| SunOS.5.7 | [root_v3.04.02.SunOS.5.7.tar.gz](https://root.cern.ch/download/root_v3.04.02.SunOS.5.7.tar.gz) |  14M |
-| SunOS.5.8 | [root_v3.04.02.SunOS.5.8.tar.gz](https://root.cern.ch/download/root_v3.04.02.SunOS.5.8.tar.gz) |  12M |
-| win32 (dbg) | [root_v3.04.02.win32.debug.tar.gz](https://root.cern.ch/download/root_v3.04.02.win32.debug.tar.gz) |  23M |
-| win32 | [root_v3.04.02.win32.tar.gz](https://root.cern.ch/download/root_v3.04.02.win32.tar.gz) |  12M |
-| win32gdk | [root_v3.04.02.win32gdk.tar.gz](https://root.cern.ch/download/root_v3.04.02.win32gdk.tar.gz) |  13M |
+| AIX.5 | [root_v3.04.02.AIX.5.tar.gz](https://root.cern/download/root_v3.04.02.AIX.5.tar.gz) |  13M |
+| Darwin.6.2 | [root_v3.04.02.Darwin.6.2.tar.gz](https://root.cern/download/root_v3.04.02.Darwin.6.2.tar.gz) |  20M |
+| HP UX.B.10.20.aCC | [root_v3.04.02.HP-UX.B.10.20.aCC.tar.gz](https://root.cern/download/root_v3.04.02.HP-UX.B.10.20.aCC.tar.gz) |  17M |
+| IRIX64.6.5.cc | [root_v3.04.02.IRIX64.6.5.cc.tar.gz](https://root.cern/download/root_v3.04.02.IRIX64.6.5.cc.tar.gz) |  13M |
+| IRIX64.6.5.gcc | [root_v3.04.02.IRIX64.6.5.gcc.tar.gz](https://root.cern/download/root_v3.04.02.IRIX64.6.5.gcc.tar.gz) |  19M |
+| IRIX64.6.5.kcc | [root_v3.04.02.IRIX64.6.5.kcc.tar.gz](https://root.cern/download/root_v3.04.02.IRIX64.6.5.kcc.tar.gz) |  13M |
+| Linux.RH5.1.egcs | [root_v3.04.02.Linux.RH5.1.egcs.tar.gz](https://root.cern/download/root_v3.04.02.Linux.RH5.1.egcs.tar.gz) |  12M |
+| Linux.RH6.1.egcs | [root_v3.04.02.Linux.RH6.1.egcs.tar.gz](https://root.cern/download/root_v3.04.02.Linux.RH6.1.egcs.tar.gz) |  11M |
+| Linux.RH6.1.gcc2952 | [root_v3.04.02.Linux.RH6.1.gcc2952.tar.gz](https://root.cern/download/root_v3.04.02.Linux.RH6.1.gcc2952.tar.gz) |  10M |
+| Linux.RH7.2.gcc32 | [root_v3.04.02.Linux.RH7.2.gcc32.tar.gz](https://root.cern/download/root_v3.04.02.Linux.RH7.2.gcc32.tar.gz) |  11M |
+| Linux.RH7.2.gcc296 | [root_v3.04.02.Linux.RH7.2.gcc296.tar.gz](https://root.cern/download/root_v3.04.02.Linux.RH7.2.gcc296.tar.gz) |  11M |
+| Linux.RH7.2.gcc2953 | [root_v3.04.02.Linux.RH7.2.gcc2953.tar.gz](https://root.cern/download/root_v3.04.02.Linux.RH7.2.gcc2953.tar.gz) |  12M |
+| Linux.RH7.2.ia64.ecc700 | [root_v3.04.02.Linux.RH7.2.ia64.ecc700.tar.gz](https://root.cern/download/root_v3.04.02.Linux.RH7.2.ia64.ecc700.tar.gz) |  27M |
+| Linux.RH7.2.ia64.gcc296 | [root_v3.04.02.Linux.RH7.2.ia64.gcc296.tar.gz](https://root.cern/download/root_v3.04.02.Linux.RH7.2.ia64.gcc296.tar.gz) |  12M |
+| Linux.RH7.2.icc700 | [root_v3.04.02.Linux.RH7.2.icc700.tar.gz](https://root.cern/download/root_v3.04.02.Linux.RH7.2.icc700.tar.gz) |  17M |
+| Linux.RH7.3.gcc32 | [root_v3.04.02.Linux.RH7.3.gcc32.tar.gz](https://root.cern/download/root_v3.04.02.Linux.RH7.3.gcc32.tar.gz) | 9.4M |
+| OSF1.V4.0.cxx6 | [root_v3.04.02.OSF1.V4.0.cxx6.tar.gz](https://root.cern/download/root_v3.04.02.OSF1.V4.0.cxx6.tar.gz) |  12M |
+| OSF1.V4.0 | [root_v3.04.02.OSF1.V4.0.tar.gz](https://root.cern/download/root_v3.04.02.OSF1.V4.0.tar.gz) |  14M |
+| SunOS.5.7 | [root_v3.04.02.SunOS.5.7.tar.gz](https://root.cern/download/root_v3.04.02.SunOS.5.7.tar.gz) |  14M |
+| SunOS.5.8 | [root_v3.04.02.SunOS.5.8.tar.gz](https://root.cern/download/root_v3.04.02.SunOS.5.8.tar.gz) |  12M |
+| win32 (dbg) | [root_v3.04.02.win32.debug.tar.gz](https://root.cern/download/root_v3.04.02.win32.debug.tar.gz) |  23M |
+| win32 | [root_v3.04.02.win32.tar.gz](https://root.cern/download/root_v3.04.02.win32.tar.gz) |  12M |
+| win32gdk | [root_v3.04.02.win32gdk.tar.gz](https://root.cern/download/root_v3.04.02.win32gdk.tar.gz) |  13M |
 
 
 ## Git

--- a/_releases/release-30502.md
+++ b/_releases/release-30502.md
@@ -15,7 +15,7 @@ sidebar:
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| Linux.RH5.1.egcs | [root_v3.05.02.Linux.RH5.1.egcs.tar.gz](https://root.cern.ch/download/root_v3.05.02.Linux.RH5.1.egcs.tar.gz) |  15M |
+| Linux.RH5.1.egcs | [root_v3.05.02.Linux.RH5.1.egcs.tar.gz](https://root.cern/download/root_v3.05.02.Linux.RH5.1.egcs.tar.gz) |  15M |
 
 
 ## Git

--- a/_releases/release-30503.md
+++ b/_releases/release-30503.md
@@ -15,19 +15,19 @@ sidebar:
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v3.05.03.source.tar.gz](https://root.cern.ch/download/root_v3.05.03.source.tar.gz) | 8.8M |
+| source | [root_v3.05.03.source.tar.gz](https://root.cern/download/root_v3.05.03.source.tar.gz) | 8.8M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| Darwin.6.4 | [root_v3.05.03.Darwin.6.4.tar.gz](https://root.cern.ch/download/root_v3.05.03.Darwin.6.4.tar.gz) |  23M |
-| Linux.RH7.2.icc700 | [root_v3.05.03.Linux.RH7.2.icc700.tar.gz](https://root.cern.ch/download/root_v3.05.03.Linux.RH7.2.icc700.tar.gz) |  20M |
-| Linux.RH7.3.ia64.ecc700 | [root_v3.05.03.Linux.RH7.3.ia64.ecc700.tar.gz](https://root.cern.ch/download/root_v3.05.03.Linux.RH7.3.ia64.ecc700.tar.gz) |  30M |
-| Linux.RH7.3.ia64.gcc296 | [root_v3.05.03.Linux.RH7.3.ia64.gcc296.tar.gz](https://root.cern.ch/download/root_v3.05.03.Linux.RH7.3.ia64.gcc296.tar.gz) |  15M |
-| LinuxIPAQ | [root_v3.05.03.LinuxIPAQ.tar.gz](https://root.cern.ch/download/root_v3.05.03.LinuxIPAQ.tar.gz) |  11M |
-| win32 (dbg) | [root_v3.05.03.win32.debug.tar.gz](https://root.cern.ch/download/root_v3.05.03.win32.debug.tar.gz) |  26M |
+| Darwin.6.4 | [root_v3.05.03.Darwin.6.4.tar.gz](https://root.cern/download/root_v3.05.03.Darwin.6.4.tar.gz) |  23M |
+| Linux.RH7.2.icc700 | [root_v3.05.03.Linux.RH7.2.icc700.tar.gz](https://root.cern/download/root_v3.05.03.Linux.RH7.2.icc700.tar.gz) |  20M |
+| Linux.RH7.3.ia64.ecc700 | [root_v3.05.03.Linux.RH7.3.ia64.ecc700.tar.gz](https://root.cern/download/root_v3.05.03.Linux.RH7.3.ia64.ecc700.tar.gz) |  30M |
+| Linux.RH7.3.ia64.gcc296 | [root_v3.05.03.Linux.RH7.3.ia64.gcc296.tar.gz](https://root.cern/download/root_v3.05.03.Linux.RH7.3.ia64.gcc296.tar.gz) |  15M |
+| LinuxIPAQ | [root_v3.05.03.LinuxIPAQ.tar.gz](https://root.cern/download/root_v3.05.03.LinuxIPAQ.tar.gz) |  11M |
+| win32 (dbg) | [root_v3.05.03.win32.debug.tar.gz](https://root.cern/download/root_v3.05.03.win32.debug.tar.gz) |  26M |
 
 
 ## Git

--- a/_releases/release-30504.md
+++ b/_releases/release-30504.md
@@ -15,15 +15,15 @@ sidebar:
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v3.05.04.source.tar.gz](https://root.cern.ch/download/root_v3.05.04.source.tar.gz) | 9.0M |
+| source | [root_v3.05.04.source.tar.gz](https://root.cern/download/root_v3.05.04.source.tar.gz) | 9.0M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| Linux.RH7.2.icc700 | [root_v3.05.04.Linux.RH7.2.icc700.tar.gz](https://root.cern.ch/download/root_v3.05.04.Linux.RH7.2.icc700.tar.gz) |  20M |
-| win32 (dbg) | [root_v3.05.04.win32.debug.tar.gz](https://root.cern.ch/download/root_v3.05.04.win32.debug.tar.gz) |  26M |
+| Linux.RH7.2.icc700 | [root_v3.05.04.Linux.RH7.2.icc700.tar.gz](https://root.cern/download/root_v3.05.04.Linux.RH7.2.icc700.tar.gz) |  20M |
+| win32 (dbg) | [root_v3.05.04.win32.debug.tar.gz](https://root.cern/download/root_v3.05.04.win32.debug.tar.gz) |  26M |
 
 
 ## Git

--- a/_releases/release-30505.md
+++ b/_releases/release-30505.md
@@ -15,20 +15,20 @@ sidebar:
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v3.05.05.source.tar.gz](https://root.cern.ch/download/root_v3.05.05.source.tar.gz) | 9.0M |
+| source | [root_v3.05.05.source.tar.gz](https://root.cern/download/root_v3.05.05.source.tar.gz) | 9.0M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| Darwin.6.5.macosx | [root_v3.05.05.Darwin.6.5.macosx.tar.gz](https://root.cern.ch/download/root_v3.05.05.Darwin.6.5.macosx.tar.gz) |  25M |
-| Linux RH7.2.linuxia64ecc | [root_v3.05.05.Linux-RH7.2.linuxia64ecc.tar.gz](https://root.cern.ch/download/root_v3.05.05.Linux-RH7.2.linuxia64ecc.tar.gz) |  30M |
-| Linux RH7.2.linuxia64gcc | [root_v3.05.05.Linux-RH7.2.linuxia64gcc.tar.gz](https://root.cern.ch/download/root_v3.05.05.Linux-RH7.2.linuxia64gcc.tar.gz) |  15M |
-| Linux.linuxx8664gcc | [root_v3.05.05.Linux.linuxx8664gcc.tar.gz](https://root.cern.ch/download/root_v3.05.05.Linux.linuxx8664gcc.tar.gz) |  11M |
-| Linux.RH7.2.icc700 | [root_v3.05.05.Linux.RH7.2.icc700.tar.gz](https://root.cern.ch/download/root_v3.05.05.Linux.RH7.2.icc700.tar.gz) |  20M |
-| Linux.RH9.0.gcc32 | [root_v3.05.05.Linux.RH9.0.gcc32.tar.gz](https://root.cern.ch/download/root_v3.05.05.Linux.RH9.0.gcc32.tar.gz) |  11M |
-| win32gdk | [root_v3.05.05.win32gdk.tar.gz](https://root.cern.ch/download/root_v3.05.05.win32gdk.tar.gz) |  20M |
+| Darwin.6.5.macosx | [root_v3.05.05.Darwin.6.5.macosx.tar.gz](https://root.cern/download/root_v3.05.05.Darwin.6.5.macosx.tar.gz) |  25M |
+| Linux RH7.2.linuxia64ecc | [root_v3.05.05.Linux-RH7.2.linuxia64ecc.tar.gz](https://root.cern/download/root_v3.05.05.Linux-RH7.2.linuxia64ecc.tar.gz) |  30M |
+| Linux RH7.2.linuxia64gcc | [root_v3.05.05.Linux-RH7.2.linuxia64gcc.tar.gz](https://root.cern/download/root_v3.05.05.Linux-RH7.2.linuxia64gcc.tar.gz) |  15M |
+| Linux.linuxx8664gcc | [root_v3.05.05.Linux.linuxx8664gcc.tar.gz](https://root.cern/download/root_v3.05.05.Linux.linuxx8664gcc.tar.gz) |  11M |
+| Linux.RH7.2.icc700 | [root_v3.05.05.Linux.RH7.2.icc700.tar.gz](https://root.cern/download/root_v3.05.05.Linux.RH7.2.icc700.tar.gz) |  20M |
+| Linux.RH9.0.gcc32 | [root_v3.05.05.Linux.RH9.0.gcc32.tar.gz](https://root.cern/download/root_v3.05.05.Linux.RH9.0.gcc32.tar.gz) |  11M |
+| win32gdk | [root_v3.05.05.win32gdk.tar.gz](https://root.cern/download/root_v3.05.05.win32gdk.tar.gz) |  20M |
 
 
 ## Git

--- a/_releases/release-30506.md
+++ b/_releases/release-30506.md
@@ -15,7 +15,7 @@ sidebar:
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v3.05.06.source.tar.gz](https://root.cern.ch/download/root_v3.05.06.source.tar.gz) | 9.5M |
+| source | [root_v3.05.06.source.tar.gz](https://root.cern/download/root_v3.05.06.source.tar.gz) | 9.5M |
 
 
 ## Binary distributions
@@ -23,21 +23,21 @@ sidebar:
 | Platform       | Files | Size |
 |-----------|-------|-----|
 | AIX.5 | root_v3.05.06.AIX.5.tar.gz |  17M |
-| HP UX.B.10.20.aCC | [root_v3.05.06.HP-UX.B.10.20.aCC.tar.gz](https://root.cern.ch/download/root_v3.05.06.HP-UX.B.10.20.aCC.tar.gz) |  23M |
-| IRIX.6.5.cc | [root_v3.05.06.IRIX.6.5.cc.tar.gz](https://root.cern.ch/download/root_v3.05.06.IRIX.6.5.cc.tar.gz) |  16M |
-| IRIX.6.5.gcc | [root_v3.05.06.IRIX.6.5.gcc.tar.gz](https://root.cern.ch/download/root_v3.05.06.IRIX.6.5.gcc.tar.gz) |  18M |
-| IRIX.6.5.kcc | [root_v3.05.06.IRIX.6.5.kcc.tar.gz](https://root.cern.ch/download/root_v3.05.06.IRIX.6.5.kcc.tar.gz) |  17M |
-| Linux.RH6.1.gcc2952 | [root_v3.05.06.Linux.RH6.1.gcc2952.tar.gz](https://root.cern.ch/download/root_v3.05.06.Linux.RH6.1.gcc2952.tar.gz) |  14M |
-| Linux.RH7.3.gcc32 | [root_v3.05.06.Linux.RH7.3.gcc32.tar.gz](https://root.cern.ch/download/root_v3.05.06.Linux.RH7.3.gcc32.tar.gz) |  13M |
-| Linux.RH7.3.gcc296 | [root_v3.05.06.Linux.RH7.3.gcc296.tar.gz](https://root.cern.ch/download/root_v3.05.06.Linux.RH7.3.gcc296.tar.gz) |  17M |
-| Linux.RH7.3.gcc2952 | [root_v3.05.06.Linux.RH7.3.gcc2952.tar.gz](https://root.cern.ch/download/root_v3.05.06.Linux.RH7.3.gcc2952.tar.gz) |  15M |
-| OSF1.V4.0.cxx6 | [root_v3.05.06.OSF1.V4.0.cxx6.tar.gz](https://root.cern.ch/download/root_v3.05.06.OSF1.V4.0.cxx6.tar.gz) |  18M |
-| OSF1.V4.0 | [root_v3.05.06.OSF1.V4.0.tar.gz](https://root.cern.ch/download/root_v3.05.06.OSF1.V4.0.tar.gz) |  20M |
-| SunOS.5.7 | [root_v3.05.06.SunOS.5.7.tar.gz](https://root.cern.ch/download/root_v3.05.06.SunOS.5.7.tar.gz) |  19M |
-| SunOS.5.8 | [root_v3.05.06.SunOS.5.8.tar.gz](https://root.cern.ch/download/root_v3.05.06.SunOS.5.8.tar.gz) |  17M |
-| win32 | [root_v3.05.06.win32.tar.gz](https://root.cern.ch/download/root_v3.05.06.win32.tar.gz) |  20M |
-| win32gcc | [root_v3.05.06.win32gcc.tar.gz](https://root.cern.ch/download/root_v3.05.06.win32gcc.tar.gz) |  16M |
-| win32gdk | [root_v3.05.06.win32gdk.tar.gz](https://root.cern.ch/download/root_v3.05.06.win32gdk.tar.gz) |  21M |
+| HP UX.B.10.20.aCC | [root_v3.05.06.HP-UX.B.10.20.aCC.tar.gz](https://root.cern/download/root_v3.05.06.HP-UX.B.10.20.aCC.tar.gz) |  23M |
+| IRIX.6.5.cc | [root_v3.05.06.IRIX.6.5.cc.tar.gz](https://root.cern/download/root_v3.05.06.IRIX.6.5.cc.tar.gz) |  16M |
+| IRIX.6.5.gcc | [root_v3.05.06.IRIX.6.5.gcc.tar.gz](https://root.cern/download/root_v3.05.06.IRIX.6.5.gcc.tar.gz) |  18M |
+| IRIX.6.5.kcc | [root_v3.05.06.IRIX.6.5.kcc.tar.gz](https://root.cern/download/root_v3.05.06.IRIX.6.5.kcc.tar.gz) |  17M |
+| Linux.RH6.1.gcc2952 | [root_v3.05.06.Linux.RH6.1.gcc2952.tar.gz](https://root.cern/download/root_v3.05.06.Linux.RH6.1.gcc2952.tar.gz) |  14M |
+| Linux.RH7.3.gcc32 | [root_v3.05.06.Linux.RH7.3.gcc32.tar.gz](https://root.cern/download/root_v3.05.06.Linux.RH7.3.gcc32.tar.gz) |  13M |
+| Linux.RH7.3.gcc296 | [root_v3.05.06.Linux.RH7.3.gcc296.tar.gz](https://root.cern/download/root_v3.05.06.Linux.RH7.3.gcc296.tar.gz) |  17M |
+| Linux.RH7.3.gcc2952 | [root_v3.05.06.Linux.RH7.3.gcc2952.tar.gz](https://root.cern/download/root_v3.05.06.Linux.RH7.3.gcc2952.tar.gz) |  15M |
+| OSF1.V4.0.cxx6 | [root_v3.05.06.OSF1.V4.0.cxx6.tar.gz](https://root.cern/download/root_v3.05.06.OSF1.V4.0.cxx6.tar.gz) |  18M |
+| OSF1.V4.0 | [root_v3.05.06.OSF1.V4.0.tar.gz](https://root.cern/download/root_v3.05.06.OSF1.V4.0.tar.gz) |  20M |
+| SunOS.5.7 | [root_v3.05.06.SunOS.5.7.tar.gz](https://root.cern/download/root_v3.05.06.SunOS.5.7.tar.gz) |  19M |
+| SunOS.5.8 | [root_v3.05.06.SunOS.5.8.tar.gz](https://root.cern/download/root_v3.05.06.SunOS.5.8.tar.gz) |  17M |
+| win32 | [root_v3.05.06.win32.tar.gz](https://root.cern/download/root_v3.05.06.win32.tar.gz) |  20M |
+| win32gcc | [root_v3.05.06.win32gcc.tar.gz](https://root.cern/download/root_v3.05.06.win32gcc.tar.gz) |  16M |
+| win32gdk | [root_v3.05.06.win32gdk.tar.gz](https://root.cern/download/root_v3.05.06.win32gdk.tar.gz) |  21M |
 
 
 ## Git

--- a/_releases/release-30507.md
+++ b/_releases/release-30507.md
@@ -15,32 +15,32 @@ sidebar:
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v3.05.07.source.tar.gz](https://root.cern.ch/download/root_v3.05.07.source.tar.gz) | 9.5M |
+| source | [root_v3.05.07.source.tar.gz](https://root.cern/download/root_v3.05.07.source.tar.gz) | 9.5M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| AIX.5 | [root_v3.05.07.AIX.5.tar.gz](https://root.cern.ch/download/root_v3.05.07.AIX.5.tar.gz) |  17M |
-| HP UX.B.10.20.aCC | [root_v3.05.07.HP-UX.B.10.20.aCC.tar.gz](https://root.cern.ch/download/root_v3.05.07.HP-UX.B.10.20.aCC.tar.gz) |  23M |
-| IRIX.6.5.cc | [root_v3.05.07.IRIX.6.5.cc.tar.gz](https://root.cern.ch/download/root_v3.05.07.IRIX.6.5.cc.tar.gz) |  16M |
-| IRIX.6.5.gcc | [root_v3.05.07.IRIX.6.5.gcc.tar.gz](https://root.cern.ch/download/root_v3.05.07.IRIX.6.5.gcc.tar.gz) |  18M |
-| IRIX.6.5.kcc | [root_v3.05.07.IRIX.6.5.kcc.tar.gz](https://root.cern.ch/download/root_v3.05.07.IRIX.6.5.kcc.tar.gz) |  17M |
-| Linux.RH6.1.gcc2952 | [root_v3.05.07.Linux.RH6.1.gcc2952.tar.gz](https://root.cern.ch/download/root_v3.05.07.Linux.RH6.1.gcc2952.tar.gz) |  14M |
-| Linux.RH7.3.gcc32 | [root_v3.05.07.Linux.RH7.3.gcc32.tar.gz](https://root.cern.ch/download/root_v3.05.07.Linux.RH7.3.gcc32.tar.gz) |  13M |
-| Linux.RH7.3.gcc296 | [root_v3.05.07.Linux.RH7.3.gcc296.tar.gz](https://root.cern.ch/download/root_v3.05.07.Linux.RH7.3.gcc296.tar.gz) |  17M |
-| Linux.RH7.3.gcc2952 | [root_v3.05.07.Linux.RH7.3.gcc2952.tar.gz](https://root.cern.ch/download/root_v3.05.07.Linux.RH7.3.gcc2952.tar.gz) |  15M |
-| Linux.RH9.0.gcc32 | [root_v3.05.07.Linux.RH9.0.gcc32.tar.gz](https://root.cern.ch/download/root_v3.05.07.Linux.RH9.0.gcc32.tar.gz) |  13M |
-| OSF1.V4.0.cxx6 | [root_v3.05.07.OSF1.V4.0.cxx6.tar.gz](https://root.cern.ch/download/root_v3.05.07.OSF1.V4.0.cxx6.tar.gz) |  18M |
-| OSF1.V4.0 | [root_v3.05.07.OSF1.V4.0.tar.gz](https://root.cern.ch/download/root_v3.05.07.OSF1.V4.0.tar.gz) |  20M |
-| SunOS.5.7 | [root_v3.05.07.SunOS.5.7.tar.gz](https://root.cern.ch/download/root_v3.05.07.SunOS.5.7.tar.gz) |  19M |
-| SunOS.5.8 | [root_v3.05.07.SunOS.5.8.tar.gz](https://root.cern.ch/download/root_v3.05.07.SunOS.5.8.tar.gz) |  17M |
-| win32 | [root_v3.05.07.win32.tar.gz](https://root.cern.ch/download/root_v3.05.07.win32.tar.gz) |  14M |
-| win32gcc | [root_v3.05.07.win32gcc.tar.gz](https://root.cern.ch/download/root_v3.05.07.win32gcc.tar.gz) |  17M |
-| win32gdk | [root_v3.05.07.win32gdk.tar.gz](https://root.cern.ch/download/root_v3.05.07.win32gdk.tar.gz) |  14M |
-| root_v3.05.07a.Linux.RH7.3.gcc32 | [root_v3.05.07a.Linux.RH7.3.gcc32.tar.gz](https://root.cern.ch/download/root_v3.05.07a.Linux.RH7.3.gcc32.tar.gz) |  14M |
-| root_v3.05.07a.Linux.RH7.3.gcc2952 | [root_v3.05.07a.Linux.RH7.3.gcc2952.tar.gz](https://root.cern.ch/download/root_v3.05.07a.Linux.RH7.3.gcc2952.tar.gz) |  15M |
+| AIX.5 | [root_v3.05.07.AIX.5.tar.gz](https://root.cern/download/root_v3.05.07.AIX.5.tar.gz) |  17M |
+| HP UX.B.10.20.aCC | [root_v3.05.07.HP-UX.B.10.20.aCC.tar.gz](https://root.cern/download/root_v3.05.07.HP-UX.B.10.20.aCC.tar.gz) |  23M |
+| IRIX.6.5.cc | [root_v3.05.07.IRIX.6.5.cc.tar.gz](https://root.cern/download/root_v3.05.07.IRIX.6.5.cc.tar.gz) |  16M |
+| IRIX.6.5.gcc | [root_v3.05.07.IRIX.6.5.gcc.tar.gz](https://root.cern/download/root_v3.05.07.IRIX.6.5.gcc.tar.gz) |  18M |
+| IRIX.6.5.kcc | [root_v3.05.07.IRIX.6.5.kcc.tar.gz](https://root.cern/download/root_v3.05.07.IRIX.6.5.kcc.tar.gz) |  17M |
+| Linux.RH6.1.gcc2952 | [root_v3.05.07.Linux.RH6.1.gcc2952.tar.gz](https://root.cern/download/root_v3.05.07.Linux.RH6.1.gcc2952.tar.gz) |  14M |
+| Linux.RH7.3.gcc32 | [root_v3.05.07.Linux.RH7.3.gcc32.tar.gz](https://root.cern/download/root_v3.05.07.Linux.RH7.3.gcc32.tar.gz) |  13M |
+| Linux.RH7.3.gcc296 | [root_v3.05.07.Linux.RH7.3.gcc296.tar.gz](https://root.cern/download/root_v3.05.07.Linux.RH7.3.gcc296.tar.gz) |  17M |
+| Linux.RH7.3.gcc2952 | [root_v3.05.07.Linux.RH7.3.gcc2952.tar.gz](https://root.cern/download/root_v3.05.07.Linux.RH7.3.gcc2952.tar.gz) |  15M |
+| Linux.RH9.0.gcc32 | [root_v3.05.07.Linux.RH9.0.gcc32.tar.gz](https://root.cern/download/root_v3.05.07.Linux.RH9.0.gcc32.tar.gz) |  13M |
+| OSF1.V4.0.cxx6 | [root_v3.05.07.OSF1.V4.0.cxx6.tar.gz](https://root.cern/download/root_v3.05.07.OSF1.V4.0.cxx6.tar.gz) |  18M |
+| OSF1.V4.0 | [root_v3.05.07.OSF1.V4.0.tar.gz](https://root.cern/download/root_v3.05.07.OSF1.V4.0.tar.gz) |  20M |
+| SunOS.5.7 | [root_v3.05.07.SunOS.5.7.tar.gz](https://root.cern/download/root_v3.05.07.SunOS.5.7.tar.gz) |  19M |
+| SunOS.5.8 | [root_v3.05.07.SunOS.5.8.tar.gz](https://root.cern/download/root_v3.05.07.SunOS.5.8.tar.gz) |  17M |
+| win32 | [root_v3.05.07.win32.tar.gz](https://root.cern/download/root_v3.05.07.win32.tar.gz) |  14M |
+| win32gcc | [root_v3.05.07.win32gcc.tar.gz](https://root.cern/download/root_v3.05.07.win32gcc.tar.gz) |  17M |
+| win32gdk | [root_v3.05.07.win32gdk.tar.gz](https://root.cern/download/root_v3.05.07.win32gdk.tar.gz) |  14M |
+| root_v3.05.07a.Linux.RH7.3.gcc32 | [root_v3.05.07a.Linux.RH7.3.gcc32.tar.gz](https://root.cern/download/root_v3.05.07a.Linux.RH7.3.gcc32.tar.gz) |  14M |
+| root_v3.05.07a.Linux.RH7.3.gcc2952 | [root_v3.05.07a.Linux.RH7.3.gcc2952.tar.gz](https://root.cern/download/root_v3.05.07a.Linux.RH7.3.gcc2952.tar.gz) |  15M |
 
 
 ## Git

--- a/_releases/release-30507a.md
+++ b/_releases/release-30507a.md
@@ -15,8 +15,8 @@ sidebar:
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| Linux.RH7.3.gcc32 | [root_v3.05.07a.Linux.RH7.3.gcc32.tar.gz](https://root.cern.ch/download/root_v3.05.07a.Linux.RH7.3.gcc32.tar.gz) |  14M |
-| Linux.RH7.3.gcc2952 | [root_v3.05.07a.Linux.RH7.3.gcc2952.tar.gz](https://root.cern.ch/download/root_v3.05.07a.Linux.RH7.3.gcc2952.tar.gz) |  15M |
+| Linux.RH7.3.gcc32 | [root_v3.05.07a.Linux.RH7.3.gcc32.tar.gz](https://root.cern/download/root_v3.05.07a.Linux.RH7.3.gcc32.tar.gz) |  14M |
+| Linux.RH7.3.gcc2952 | [root_v3.05.07a.Linux.RH7.3.gcc2952.tar.gz](https://root.cern/download/root_v3.05.07a.Linux.RH7.3.gcc2952.tar.gz) |  15M |
 
 
 ## Git

--- a/_releases/release-31001.md
+++ b/_releases/release-31001.md
@@ -15,35 +15,35 @@ sidebar:
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v3.10.01.source.tar.gz](https://root.cern.ch/download/root_v3.10.01.source.tar.gz) | 9.7M |
+| source | [root_v3.10.01.source.tar.gz](https://root.cern/download/root_v3.10.01.source.tar.gz) | 9.7M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| AIX.5 | [root_v3.10.01.AIX.5.tar.gz](https://root.cern.ch/download/root_v3.10.01.AIX.5.tar.gz) |  17M |
-| HP UX.B.10.20.aCC | [root_v3.10.01.HP-UX.B.10.20.aCC.tar.gz](https://root.cern.ch/download/root_v3.10.01.HP-UX.B.10.20.aCC.tar.gz) |  20M |
-| IRIX.6.5.cc | [root_v3.10.01.IRIX.6.5.cc.tar.gz](https://root.cern.ch/download/root_v3.10.01.IRIX.6.5.cc.tar.gz) |  17M |
-| IRIX.6.5.gcc | [root_v3.10.01.IRIX.6.5.gcc.tar.gz](https://root.cern.ch/download/root_v3.10.01.IRIX.6.5.gcc.tar.gz) |  23M |
-| IRIX.6.5.kcc | [root_v3.10.01.IRIX.6.5.kcc.tar.gz](https://root.cern.ch/download/root_v3.10.01.IRIX.6.5.kcc.tar.gz) |  17M |
-| Linux.RH6.1.gcc2952 | [root_v3.10.01.Linux.RH6.1.gcc2952.tar.gz](https://root.cern.ch/download/root_v3.10.01.Linux.RH6.1.gcc2952.tar.gz) |  15M |
-| Linux.RH7.2.icc71 | [root_v3.10.01.Linux.RH7.2.icc71.tar.gz](https://root.cern.ch/download/root_v3.10.01.Linux.RH7.2.icc71.tar.gz) |  23M |
-| Linux.RH7.3.gcc32 | [root_v3.10.01.Linux.RH7.3.gcc32.tar.gz](https://root.cern.ch/download/root_v3.10.01.Linux.RH7.3.gcc32.tar.gz) |  15M |
-| Linux.RH7.3.gcc296 | [root_v3.10.01.Linux.RH7.3.gcc296.tar.gz](https://root.cern.ch/download/root_v3.10.01.Linux.RH7.3.gcc296.tar.gz) |  17M |
-| Linux.RH7.3.gcc2952 | [root_v3.10.01.Linux.RH7.3.gcc2952.tar.gz](https://root.cern.ch/download/root_v3.10.01.Linux.RH7.3.gcc2952.tar.gz) |  16M |
-| Linux.RH9.0.gcc32 | [root_v3.10.01.Linux.RH9.0.gcc32.tar.gz](https://root.cern.ch/download/root_v3.10.01.Linux.RH9.0.gcc32.tar.gz) |  15M |
-| Linux.RH10.0.gcc33 | [root_v3.10.01.Linux.RH10.0.gcc33.tar.gz](https://root.cern.ch/download/root_v3.10.01.Linux.RH10.0.gcc33.tar.gz) |  14M |
-| OSF1.V4.0.cxx6 | [root_v3.10.01.OSF1.V4.0.cxx6.tar.gz](https://root.cern.ch/download/root_v3.10.01.OSF1.V4.0.cxx6.tar.gz) |  18M |
-| OSF1.V4.0 | [root_v3.10.01.OSF1.V4.0.tar.gz](https://root.cern.ch/download/root_v3.10.01.OSF1.V4.0.tar.gz) |  20M |
-| SunOS.5.7 | [root_v3.10.01.SunOS.5.7.tar.gz](https://root.cern.ch/download/root_v3.10.01.SunOS.5.7.tar.gz) |  19M |
-| SunOS.5.8 | [root_v3.10.01.SunOS.5.8.tar.gz](https://root.cern.ch/download/root_v3.10.01.SunOS.5.8.tar.gz) |  18M |
-| SunOS.5.8a | [root_v3.10.01.SunOS.5.8a.tar.gz](https://root.cern.ch/download/root_v3.10.01.SunOS.5.8a.tar.gz) |  17M |
-| win32 | [root_v3.10.01.win32.tar.gz](https://root.cern.ch/download/root_v3.10.01.win32.tar.gz) |  14M |
-| win32gcc | [root_v3.10.01.win32gcc.tar.gz](https://root.cern.ch/download/root_v3.10.01.win32gcc.tar.gz) |  17M |
-| win32gdk (dbg) | [root_v3.10.01.win32gdk.debug.tar.gz](https://root.cern.ch/download/root_v3.10.01.win32gdk.debug.tar.gz) |  24M |
-| win32gdk | [root_v3.10.01.win32gdk.tar.gz](https://root.cern.ch/download/root_v3.10.01.win32gdk.tar.gz) |  15M |
-| root_v3.10.01a.Linux.RH7.3.gcc32 | [root_v3.10.01a.Linux.RH7.3.gcc32.tar.gz](https://root.cern.ch/download/root_v3.10.01a.Linux.RH7.3.gcc32.tar.gz) |  15M |
+| AIX.5 | [root_v3.10.01.AIX.5.tar.gz](https://root.cern/download/root_v3.10.01.AIX.5.tar.gz) |  17M |
+| HP UX.B.10.20.aCC | [root_v3.10.01.HP-UX.B.10.20.aCC.tar.gz](https://root.cern/download/root_v3.10.01.HP-UX.B.10.20.aCC.tar.gz) |  20M |
+| IRIX.6.5.cc | [root_v3.10.01.IRIX.6.5.cc.tar.gz](https://root.cern/download/root_v3.10.01.IRIX.6.5.cc.tar.gz) |  17M |
+| IRIX.6.5.gcc | [root_v3.10.01.IRIX.6.5.gcc.tar.gz](https://root.cern/download/root_v3.10.01.IRIX.6.5.gcc.tar.gz) |  23M |
+| IRIX.6.5.kcc | [root_v3.10.01.IRIX.6.5.kcc.tar.gz](https://root.cern/download/root_v3.10.01.IRIX.6.5.kcc.tar.gz) |  17M |
+| Linux.RH6.1.gcc2952 | [root_v3.10.01.Linux.RH6.1.gcc2952.tar.gz](https://root.cern/download/root_v3.10.01.Linux.RH6.1.gcc2952.tar.gz) |  15M |
+| Linux.RH7.2.icc71 | [root_v3.10.01.Linux.RH7.2.icc71.tar.gz](https://root.cern/download/root_v3.10.01.Linux.RH7.2.icc71.tar.gz) |  23M |
+| Linux.RH7.3.gcc32 | [root_v3.10.01.Linux.RH7.3.gcc32.tar.gz](https://root.cern/download/root_v3.10.01.Linux.RH7.3.gcc32.tar.gz) |  15M |
+| Linux.RH7.3.gcc296 | [root_v3.10.01.Linux.RH7.3.gcc296.tar.gz](https://root.cern/download/root_v3.10.01.Linux.RH7.3.gcc296.tar.gz) |  17M |
+| Linux.RH7.3.gcc2952 | [root_v3.10.01.Linux.RH7.3.gcc2952.tar.gz](https://root.cern/download/root_v3.10.01.Linux.RH7.3.gcc2952.tar.gz) |  16M |
+| Linux.RH9.0.gcc32 | [root_v3.10.01.Linux.RH9.0.gcc32.tar.gz](https://root.cern/download/root_v3.10.01.Linux.RH9.0.gcc32.tar.gz) |  15M |
+| Linux.RH10.0.gcc33 | [root_v3.10.01.Linux.RH10.0.gcc33.tar.gz](https://root.cern/download/root_v3.10.01.Linux.RH10.0.gcc33.tar.gz) |  14M |
+| OSF1.V4.0.cxx6 | [root_v3.10.01.OSF1.V4.0.cxx6.tar.gz](https://root.cern/download/root_v3.10.01.OSF1.V4.0.cxx6.tar.gz) |  18M |
+| OSF1.V4.0 | [root_v3.10.01.OSF1.V4.0.tar.gz](https://root.cern/download/root_v3.10.01.OSF1.V4.0.tar.gz) |  20M |
+| SunOS.5.7 | [root_v3.10.01.SunOS.5.7.tar.gz](https://root.cern/download/root_v3.10.01.SunOS.5.7.tar.gz) |  19M |
+| SunOS.5.8 | [root_v3.10.01.SunOS.5.8.tar.gz](https://root.cern/download/root_v3.10.01.SunOS.5.8.tar.gz) |  18M |
+| SunOS.5.8a | [root_v3.10.01.SunOS.5.8a.tar.gz](https://root.cern/download/root_v3.10.01.SunOS.5.8a.tar.gz) |  17M |
+| win32 | [root_v3.10.01.win32.tar.gz](https://root.cern/download/root_v3.10.01.win32.tar.gz) |  14M |
+| win32gcc | [root_v3.10.01.win32gcc.tar.gz](https://root.cern/download/root_v3.10.01.win32gcc.tar.gz) |  17M |
+| win32gdk (dbg) | [root_v3.10.01.win32gdk.debug.tar.gz](https://root.cern/download/root_v3.10.01.win32gdk.debug.tar.gz) |  24M |
+| win32gdk | [root_v3.10.01.win32gdk.tar.gz](https://root.cern/download/root_v3.10.01.win32gdk.tar.gz) |  15M |
+| root_v3.10.01a.Linux.RH7.3.gcc32 | [root_v3.10.01a.Linux.RH7.3.gcc32.tar.gz](https://root.cern/download/root_v3.10.01a.Linux.RH7.3.gcc32.tar.gz) |  15M |
 
 
 ## Git

--- a/_releases/release-31001a.md
+++ b/_releases/release-31001a.md
@@ -15,7 +15,7 @@ sidebar:
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| Linux.RH7.3.gcc32 | [root_v3.10.01a.Linux.RH7.3.gcc32.tar.gz](https://root.cern.ch/download/root_v3.10.01a.Linux.RH7.3.gcc32.tar.gz) |  15M |
+| Linux.RH7.3.gcc32 | [root_v3.10.01a.Linux.RH7.3.gcc32.tar.gz](https://root.cern/download/root_v3.10.01a.Linux.RH7.3.gcc32.tar.gz) |  15M |
 
 
 ## Git

--- a/_releases/release-31002.md
+++ b/_releases/release-31002.md
@@ -15,33 +15,33 @@ sidebar:
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v3.10.02.source.tar.gz](https://root.cern.ch/download/root_v3.10.02.source.tar.gz) | 9.8M |
+| source | [root_v3.10.02.source.tar.gz](https://root.cern/download/root_v3.10.02.source.tar.gz) | 9.8M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| AIX.5 | [root_v3.10.02.AIX.5.tar.gz](https://root.cern.ch/download/root_v3.10.02.AIX.5.tar.gz) |  17M |
-| HP UX.B.10.20.aCC | [root_v3.10.02.HP-UX.B.10.20.aCC.tar.gz](https://root.cern.ch/download/root_v3.10.02.HP-UX.B.10.20.aCC.tar.gz) |  20M |
-| IRIX.6.5.cc | [root_v3.10.02.IRIX.6.5.cc.tar.gz](https://root.cern.ch/download/root_v3.10.02.IRIX.6.5.cc.tar.gz) |  18M |
-| IRIX.6.5.gcc | [root_v3.10.02.IRIX.6.5.gcc.tar.gz](https://root.cern.ch/download/root_v3.10.02.IRIX.6.5.gcc.tar.gz) |  24M |
-| IRIX.6.5.kcc | [root_v3.10.02.IRIX.6.5.kcc.tar.gz](https://root.cern.ch/download/root_v3.10.02.IRIX.6.5.kcc.tar.gz) |  17M |
-| Linux.RH6.1.gcc2952 | [root_v3.10.02.Linux.RH6.1.gcc2952.tar.gz](https://root.cern.ch/download/root_v3.10.02.Linux.RH6.1.gcc2952.tar.gz) |  15M |
-| Linux.RH7.3.gcc32 | [root_v3.10.02.Linux.RH7.3.gcc32.tar.gz](https://root.cern.ch/download/root_v3.10.02.Linux.RH7.3.gcc32.tar.gz) |  15M |
-| Linux.RH7.3.gcc296 | [root_v3.10.02.Linux.RH7.3.gcc296.tar.gz](https://root.cern.ch/download/root_v3.10.02.Linux.RH7.3.gcc296.tar.gz) |  17M |
-| Linux.RH7.3.gcc2952 | [root_v3.10.02.Linux.RH7.3.gcc2952.tar.gz](https://root.cern.ch/download/root_v3.10.02.Linux.RH7.3.gcc2952.tar.gz) |  16M |
-| Linux.RH9.0.gcc32 | [root_v3.10.02.Linux.RH9.0.gcc32.tar.gz](https://root.cern.ch/download/root_v3.10.02.Linux.RH9.0.gcc32.tar.gz) |  15M |
-| Linux.RH10.0.gcc33 | [root_v3.10.02.Linux.RH10.0.gcc33.tar.gz](https://root.cern.ch/download/root_v3.10.02.Linux.RH10.0.gcc33.tar.gz) |  14M |
-| OSF1.V4.0.cxx6 | [root_v3.10.02.OSF1.V4.0.cxx6.tar.gz](https://root.cern.ch/download/root_v3.10.02.OSF1.V4.0.cxx6.tar.gz) |  18M |
-| OSF1.V4.0 | [root_v3.10.02.OSF1.V4.0.tar.gz](https://root.cern.ch/download/root_v3.10.02.OSF1.V4.0.tar.gz) |  20M |
-| OSF1.V5.1.cxx6 | [root_v3.10.02.OSF1.V5.1.cxx6.tar.gz](https://root.cern.ch/download/root_v3.10.02.OSF1.V5.1.cxx6.tar.gz) |  17M |
-| SunOS.5.7 | [root_v3.10.02.SunOS.5.7.tar.gz](https://root.cern.ch/download/root_v3.10.02.SunOS.5.7.tar.gz) |  19M |
-| SunOS.5.8 | [root_v3.10.02.SunOS.5.8.tar.gz](https://root.cern.ch/download/root_v3.10.02.SunOS.5.8.tar.gz) |  19M |
-| win32 | [root_v3.10.02.win32.tar.gz](https://root.cern.ch/download/root_v3.10.02.win32.tar.gz) |  14M |
-| win32gcc | [root_v3.10.02.win32gcc.tar.gz](https://root.cern.ch/download/root_v3.10.02.win32gcc.tar.gz) |  18M |
-| win32gdk (dbg) | [root_v3.10.02.win32gdk.debug.tar.gz](https://root.cern.ch/download/root_v3.10.02.win32gdk.debug.tar.gz) |  25M |
-| win32gdk | [root_v3.10.02.win32gdk.tar.gz](https://root.cern.ch/download/root_v3.10.02.win32gdk.tar.gz) |  15M |
+| AIX.5 | [root_v3.10.02.AIX.5.tar.gz](https://root.cern/download/root_v3.10.02.AIX.5.tar.gz) |  17M |
+| HP UX.B.10.20.aCC | [root_v3.10.02.HP-UX.B.10.20.aCC.tar.gz](https://root.cern/download/root_v3.10.02.HP-UX.B.10.20.aCC.tar.gz) |  20M |
+| IRIX.6.5.cc | [root_v3.10.02.IRIX.6.5.cc.tar.gz](https://root.cern/download/root_v3.10.02.IRIX.6.5.cc.tar.gz) |  18M |
+| IRIX.6.5.gcc | [root_v3.10.02.IRIX.6.5.gcc.tar.gz](https://root.cern/download/root_v3.10.02.IRIX.6.5.gcc.tar.gz) |  24M |
+| IRIX.6.5.kcc | [root_v3.10.02.IRIX.6.5.kcc.tar.gz](https://root.cern/download/root_v3.10.02.IRIX.6.5.kcc.tar.gz) |  17M |
+| Linux.RH6.1.gcc2952 | [root_v3.10.02.Linux.RH6.1.gcc2952.tar.gz](https://root.cern/download/root_v3.10.02.Linux.RH6.1.gcc2952.tar.gz) |  15M |
+| Linux.RH7.3.gcc32 | [root_v3.10.02.Linux.RH7.3.gcc32.tar.gz](https://root.cern/download/root_v3.10.02.Linux.RH7.3.gcc32.tar.gz) |  15M |
+| Linux.RH7.3.gcc296 | [root_v3.10.02.Linux.RH7.3.gcc296.tar.gz](https://root.cern/download/root_v3.10.02.Linux.RH7.3.gcc296.tar.gz) |  17M |
+| Linux.RH7.3.gcc2952 | [root_v3.10.02.Linux.RH7.3.gcc2952.tar.gz](https://root.cern/download/root_v3.10.02.Linux.RH7.3.gcc2952.tar.gz) |  16M |
+| Linux.RH9.0.gcc32 | [root_v3.10.02.Linux.RH9.0.gcc32.tar.gz](https://root.cern/download/root_v3.10.02.Linux.RH9.0.gcc32.tar.gz) |  15M |
+| Linux.RH10.0.gcc33 | [root_v3.10.02.Linux.RH10.0.gcc33.tar.gz](https://root.cern/download/root_v3.10.02.Linux.RH10.0.gcc33.tar.gz) |  14M |
+| OSF1.V4.0.cxx6 | [root_v3.10.02.OSF1.V4.0.cxx6.tar.gz](https://root.cern/download/root_v3.10.02.OSF1.V4.0.cxx6.tar.gz) |  18M |
+| OSF1.V4.0 | [root_v3.10.02.OSF1.V4.0.tar.gz](https://root.cern/download/root_v3.10.02.OSF1.V4.0.tar.gz) |  20M |
+| OSF1.V5.1.cxx6 | [root_v3.10.02.OSF1.V5.1.cxx6.tar.gz](https://root.cern/download/root_v3.10.02.OSF1.V5.1.cxx6.tar.gz) |  17M |
+| SunOS.5.7 | [root_v3.10.02.SunOS.5.7.tar.gz](https://root.cern/download/root_v3.10.02.SunOS.5.7.tar.gz) |  19M |
+| SunOS.5.8 | [root_v3.10.02.SunOS.5.8.tar.gz](https://root.cern/download/root_v3.10.02.SunOS.5.8.tar.gz) |  19M |
+| win32 | [root_v3.10.02.win32.tar.gz](https://root.cern/download/root_v3.10.02.win32.tar.gz) |  14M |
+| win32gcc | [root_v3.10.02.win32gcc.tar.gz](https://root.cern/download/root_v3.10.02.win32gcc.tar.gz) |  18M |
+| win32gdk (dbg) | [root_v3.10.02.win32gdk.debug.tar.gz](https://root.cern/download/root_v3.10.02.win32gdk.debug.tar.gz) |  25M |
+| win32gdk | [root_v3.10.02.win32gdk.tar.gz](https://root.cern/download/root_v3.10.02.win32gdk.tar.gz) |  15M |
 
 
 ## Git

--- a/_releases/release-40001.md
+++ b/_releases/release-40001.md
@@ -15,32 +15,32 @@ sidebar:
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v4.00.01.source.tar.gz](https://root.cern.ch/download/root_v4.00.01.source.tar.gz) | 9.9M |
+| source | [root_v4.00.01.source.tar.gz](https://root.cern/download/root_v4.00.01.source.tar.gz) | 9.9M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| AIX.5 | [root_v4.00.01.AIX.5.tar.gz](https://root.cern.ch/download/root_v4.00.01.AIX.5.tar.gz) |  19M |
-| HP UX.B.10.20.aCC | [root_v4.00.01.HP-UX.B.10.20.aCC.tar.gz](https://root.cern.ch/download/root_v4.00.01.HP-UX.B.10.20.aCC.tar.gz) |  22M |
-| IRIX.6.5.cc | [root_v4.00.01.IRIX.6.5.cc.tar.gz](https://root.cern.ch/download/root_v4.00.01.IRIX.6.5.cc.tar.gz) |  19M |
-| IRIX.6.5.gcc | [root_v4.00.01.IRIX.6.5.gcc.tar.gz](https://root.cern.ch/download/root_v4.00.01.IRIX.6.5.gcc.tar.gz) |  20M |
-| IRIX.6.5.kcc | [root_v4.00.01.IRIX.6.5.kcc.tar.gz](https://root.cern.ch/download/root_v4.00.01.IRIX.6.5.kcc.tar.gz) |  18M |
-| Linux.RH6.1.gcc2952 | [root_v4.00.01.Linux.RH6.1.gcc2952.tar.gz](https://root.cern.ch/download/root_v4.00.01.Linux.RH6.1.gcc2952.tar.gz) |  16M |
-| Linux.RH7.3.gcc32 | [root_v4.00.01.Linux.RH7.3.gcc32.tar.gz](https://root.cern.ch/download/root_v4.00.01.Linux.RH7.3.gcc32.tar.gz) |  14M |
-| Linux.RH7.3.gcc296 | [root_v4.00.01.Linux.RH7.3.gcc296.tar.gz](https://root.cern.ch/download/root_v4.00.01.Linux.RH7.3.gcc296.tar.gz) |  18M |
-| Linux.RH7.3.gcc2952 | [root_v4.00.01.Linux.RH7.3.gcc2952.tar.gz](https://root.cern.ch/download/root_v4.00.01.Linux.RH7.3.gcc2952.tar.gz) |  15M |
-| Linux.RH9.0.gcc32 | [root_v4.00.01.Linux.RH9.0.gcc32.tar.gz](https://root.cern.ch/download/root_v4.00.01.Linux.RH9.0.gcc32.tar.gz) |  14M |
-| Linux.RH10.0.gcc33 | [root_v4.00.01.Linux.RH10.0.gcc33.tar.gz](https://root.cern.ch/download/root_v4.00.01.Linux.RH10.0.gcc33.tar.gz) |  13M |
-| OSF1.V4.0.cxx6 | [root_v4.00.01.OSF1.V4.0.cxx6.tar.gz](https://root.cern.ch/download/root_v4.00.01.OSF1.V4.0.cxx6.tar.gz) |  18M |
-| OSF1.V4.0 | [root_v4.00.01.OSF1.V4.0.tar.gz](https://root.cern.ch/download/root_v4.00.01.OSF1.V4.0.tar.gz) |  21M |
-| OSF1.V5.1.cxx6 | [root_v4.00.01.OSF1.V5.1.cxx6.tar.gz](https://root.cern.ch/download/root_v4.00.01.OSF1.V5.1.cxx6.tar.gz) |  18M |
-| SunOS.5.7 | [root_v4.00.01.SunOS.5.7.tar.gz](https://root.cern.ch/download/root_v4.00.01.SunOS.5.7.tar.gz) |  20M |
-| SunOS.5.8 | [root_v4.00.01.SunOS.5.8.tar.gz](https://root.cern.ch/download/root_v4.00.01.SunOS.5.8.tar.gz) |  19M |
-| win32 | [root_v4.00.01.win32.tar.gz](https://root.cern.ch/download/root_v4.00.01.win32.tar.gz) |  16M |
-| win32gcc | [root_v4.00.01.win32gcc.tar.gz](https://root.cern.ch/download/root_v4.00.01.win32gcc.tar.gz) |  20M |
-| win32gdk | [root_v4.00.01.win32gdk.tar.gz](https://root.cern.ch/download/root_v4.00.01.win32gdk.tar.gz) |  16M |
+| AIX.5 | [root_v4.00.01.AIX.5.tar.gz](https://root.cern/download/root_v4.00.01.AIX.5.tar.gz) |  19M |
+| HP UX.B.10.20.aCC | [root_v4.00.01.HP-UX.B.10.20.aCC.tar.gz](https://root.cern/download/root_v4.00.01.HP-UX.B.10.20.aCC.tar.gz) |  22M |
+| IRIX.6.5.cc | [root_v4.00.01.IRIX.6.5.cc.tar.gz](https://root.cern/download/root_v4.00.01.IRIX.6.5.cc.tar.gz) |  19M |
+| IRIX.6.5.gcc | [root_v4.00.01.IRIX.6.5.gcc.tar.gz](https://root.cern/download/root_v4.00.01.IRIX.6.5.gcc.tar.gz) |  20M |
+| IRIX.6.5.kcc | [root_v4.00.01.IRIX.6.5.kcc.tar.gz](https://root.cern/download/root_v4.00.01.IRIX.6.5.kcc.tar.gz) |  18M |
+| Linux.RH6.1.gcc2952 | [root_v4.00.01.Linux.RH6.1.gcc2952.tar.gz](https://root.cern/download/root_v4.00.01.Linux.RH6.1.gcc2952.tar.gz) |  16M |
+| Linux.RH7.3.gcc32 | [root_v4.00.01.Linux.RH7.3.gcc32.tar.gz](https://root.cern/download/root_v4.00.01.Linux.RH7.3.gcc32.tar.gz) |  14M |
+| Linux.RH7.3.gcc296 | [root_v4.00.01.Linux.RH7.3.gcc296.tar.gz](https://root.cern/download/root_v4.00.01.Linux.RH7.3.gcc296.tar.gz) |  18M |
+| Linux.RH7.3.gcc2952 | [root_v4.00.01.Linux.RH7.3.gcc2952.tar.gz](https://root.cern/download/root_v4.00.01.Linux.RH7.3.gcc2952.tar.gz) |  15M |
+| Linux.RH9.0.gcc32 | [root_v4.00.01.Linux.RH9.0.gcc32.tar.gz](https://root.cern/download/root_v4.00.01.Linux.RH9.0.gcc32.tar.gz) |  14M |
+| Linux.RH10.0.gcc33 | [root_v4.00.01.Linux.RH10.0.gcc33.tar.gz](https://root.cern/download/root_v4.00.01.Linux.RH10.0.gcc33.tar.gz) |  13M |
+| OSF1.V4.0.cxx6 | [root_v4.00.01.OSF1.V4.0.cxx6.tar.gz](https://root.cern/download/root_v4.00.01.OSF1.V4.0.cxx6.tar.gz) |  18M |
+| OSF1.V4.0 | [root_v4.00.01.OSF1.V4.0.tar.gz](https://root.cern/download/root_v4.00.01.OSF1.V4.0.tar.gz) |  21M |
+| OSF1.V5.1.cxx6 | [root_v4.00.01.OSF1.V5.1.cxx6.tar.gz](https://root.cern/download/root_v4.00.01.OSF1.V5.1.cxx6.tar.gz) |  18M |
+| SunOS.5.7 | [root_v4.00.01.SunOS.5.7.tar.gz](https://root.cern/download/root_v4.00.01.SunOS.5.7.tar.gz) |  20M |
+| SunOS.5.8 | [root_v4.00.01.SunOS.5.8.tar.gz](https://root.cern/download/root_v4.00.01.SunOS.5.8.tar.gz) |  19M |
+| win32 | [root_v4.00.01.win32.tar.gz](https://root.cern/download/root_v4.00.01.win32.tar.gz) |  16M |
+| win32gcc | [root_v4.00.01.win32gcc.tar.gz](https://root.cern/download/root_v4.00.01.win32gcc.tar.gz) |  20M |
+| win32gdk | [root_v4.00.01.win32gdk.tar.gz](https://root.cern/download/root_v4.00.01.win32gdk.tar.gz) |  16M |
 
 
 ## Git

--- a/_releases/release-40002.md
+++ b/_releases/release-40002.md
@@ -15,34 +15,34 @@ sidebar:
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v4.00.02.source.tar.gz](https://root.cern.ch/download/root_v4.00.02.source.tar.gz) |  10M |
+| source | [root_v4.00.02.source.tar.gz](https://root.cern/download/root_v4.00.02.source.tar.gz) |  10M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| AIX.5 | [root_v4.00.02.AIX.5.tar.gz](https://root.cern.ch/download/root_v4.00.02.AIX.5.tar.gz) |  19M |
-| HP UX.B.10.20.aCC | [root_v4.00.02.HP-UX.B.10.20.aCC.tar.gz](https://root.cern.ch/download/root_v4.00.02.HP-UX.B.10.20.aCC.tar.gz) |  22M |
-| IRIX.6.5.cc | [root_v4.00.02.IRIX.6.5.cc.tar.gz](https://root.cern.ch/download/root_v4.00.02.IRIX.6.5.cc.tar.gz) |  19M |
-| IRIX.6.5.gcc | [root_v4.00.02.IRIX.6.5.gcc.tar.gz](https://root.cern.ch/download/root_v4.00.02.IRIX.6.5.gcc.tar.gz) |  20M |
-| IRIX.6.5.kcc | [root_v4.00.02.IRIX.6.5.kcc.tar.gz](https://root.cern.ch/download/root_v4.00.02.IRIX.6.5.kcc.tar.gz) |  18M |
-| Linux.RH6.1.gcc2952 | [root_v4.00.02.Linux.RH6.1.gcc2952.tar.gz](https://root.cern.ch/download/root_v4.00.02.Linux.RH6.1.gcc2952.tar.gz) |  17M |
-| Linux.RH7.3.gcc32 | [root_v4.00.02.Linux.RH7.3.gcc32.tar.gz](https://root.cern.ch/download/root_v4.00.02.Linux.RH7.3.gcc32.tar.gz) |  16M |
-| Linux.RH7.3.gcc296 | [root_v4.00.02.Linux.RH7.3.gcc296.tar.gz](https://root.cern.ch/download/root_v4.00.02.Linux.RH7.3.gcc296.tar.gz) |  18M |
-| Linux.RH7.3.gcc2952 | [root_v4.00.02.Linux.RH7.3.gcc2952.tar.gz](https://root.cern.ch/download/root_v4.00.02.Linux.RH7.3.gcc2952.tar.gz) |  17M |
-| Linux.RH7.3.gcc2953 | [root_v4.00.02.Linux.RH7.3.gcc2953.tar.gz](https://root.cern.ch/download/root_v4.00.02.Linux.RH7.3.gcc2953.tar.gz) |  17M |
-| Linux.RH9.0.gcc32 | [root_v4.00.02.Linux.RH9.0.gcc32.tar.gz](https://root.cern.ch/download/root_v4.00.02.Linux.RH9.0.gcc32.tar.gz) |  14M |
-| Linux.RH10.0.gcc33 | [root_v4.00.02.Linux.RH10.0.gcc33.tar.gz](https://root.cern.ch/download/root_v4.00.02.Linux.RH10.0.gcc33.tar.gz) |  13M |
-| OSF1.V4.0.cxx6 | [root_v4.00.02.OSF1.V4.0.cxx6.tar.gz](https://root.cern.ch/download/root_v4.00.02.OSF1.V4.0.cxx6.tar.gz) |  18M |
-| OSF1.V4.0 | [root_v4.00.02.OSF1.V4.0.tar.gz](https://root.cern.ch/download/root_v4.00.02.OSF1.V4.0.tar.gz) |  21M |
-| OSF1.V5.1.cxx6 | [root_v4.00.02.OSF1.V5.1.cxx6.tar.gz](https://root.cern.ch/download/root_v4.00.02.OSF1.V5.1.cxx6.tar.gz) |  18M |
-| SunOS.5.7 | [root_v4.00.02.SunOS.5.7.tar.gz](https://root.cern.ch/download/root_v4.00.02.SunOS.5.7.tar.gz) |  20M |
-| SunOS.5.8 | [root_v4.00.02.SunOS.5.8.tar.gz](https://root.cern.ch/download/root_v4.00.02.SunOS.5.8.tar.gz) |  19M |
-| win32 | [root_v4.00.02.win32.tar.gz](https://root.cern.ch/download/root_v4.00.02.win32.tar.gz) |  16M |
-| win32gcc | [root_v4.00.02.win32gcc.tar.gz](https://root.cern.ch/download/root_v4.00.02.win32gcc.tar.gz) |  20M |
-| win32gdk | [root_v4.00.02.win32gdk.tar.gz](https://root.cern.ch/download/root_v4.00.02.win32gdk.tar.gz) |  16M |
-| root_v4.00.02a.win32gdk | [root_v4.00.02a.win32gdk.tar.gz](https://root.cern.ch/download/root_v4.00.02a.win32gdk.tar.gz) |  16M |
+| AIX.5 | [root_v4.00.02.AIX.5.tar.gz](https://root.cern/download/root_v4.00.02.AIX.5.tar.gz) |  19M |
+| HP UX.B.10.20.aCC | [root_v4.00.02.HP-UX.B.10.20.aCC.tar.gz](https://root.cern/download/root_v4.00.02.HP-UX.B.10.20.aCC.tar.gz) |  22M |
+| IRIX.6.5.cc | [root_v4.00.02.IRIX.6.5.cc.tar.gz](https://root.cern/download/root_v4.00.02.IRIX.6.5.cc.tar.gz) |  19M |
+| IRIX.6.5.gcc | [root_v4.00.02.IRIX.6.5.gcc.tar.gz](https://root.cern/download/root_v4.00.02.IRIX.6.5.gcc.tar.gz) |  20M |
+| IRIX.6.5.kcc | [root_v4.00.02.IRIX.6.5.kcc.tar.gz](https://root.cern/download/root_v4.00.02.IRIX.6.5.kcc.tar.gz) |  18M |
+| Linux.RH6.1.gcc2952 | [root_v4.00.02.Linux.RH6.1.gcc2952.tar.gz](https://root.cern/download/root_v4.00.02.Linux.RH6.1.gcc2952.tar.gz) |  17M |
+| Linux.RH7.3.gcc32 | [root_v4.00.02.Linux.RH7.3.gcc32.tar.gz](https://root.cern/download/root_v4.00.02.Linux.RH7.3.gcc32.tar.gz) |  16M |
+| Linux.RH7.3.gcc296 | [root_v4.00.02.Linux.RH7.3.gcc296.tar.gz](https://root.cern/download/root_v4.00.02.Linux.RH7.3.gcc296.tar.gz) |  18M |
+| Linux.RH7.3.gcc2952 | [root_v4.00.02.Linux.RH7.3.gcc2952.tar.gz](https://root.cern/download/root_v4.00.02.Linux.RH7.3.gcc2952.tar.gz) |  17M |
+| Linux.RH7.3.gcc2953 | [root_v4.00.02.Linux.RH7.3.gcc2953.tar.gz](https://root.cern/download/root_v4.00.02.Linux.RH7.3.gcc2953.tar.gz) |  17M |
+| Linux.RH9.0.gcc32 | [root_v4.00.02.Linux.RH9.0.gcc32.tar.gz](https://root.cern/download/root_v4.00.02.Linux.RH9.0.gcc32.tar.gz) |  14M |
+| Linux.RH10.0.gcc33 | [root_v4.00.02.Linux.RH10.0.gcc33.tar.gz](https://root.cern/download/root_v4.00.02.Linux.RH10.0.gcc33.tar.gz) |  13M |
+| OSF1.V4.0.cxx6 | [root_v4.00.02.OSF1.V4.0.cxx6.tar.gz](https://root.cern/download/root_v4.00.02.OSF1.V4.0.cxx6.tar.gz) |  18M |
+| OSF1.V4.0 | [root_v4.00.02.OSF1.V4.0.tar.gz](https://root.cern/download/root_v4.00.02.OSF1.V4.0.tar.gz) |  21M |
+| OSF1.V5.1.cxx6 | [root_v4.00.02.OSF1.V5.1.cxx6.tar.gz](https://root.cern/download/root_v4.00.02.OSF1.V5.1.cxx6.tar.gz) |  18M |
+| SunOS.5.7 | [root_v4.00.02.SunOS.5.7.tar.gz](https://root.cern/download/root_v4.00.02.SunOS.5.7.tar.gz) |  20M |
+| SunOS.5.8 | [root_v4.00.02.SunOS.5.8.tar.gz](https://root.cern/download/root_v4.00.02.SunOS.5.8.tar.gz) |  19M |
+| win32 | [root_v4.00.02.win32.tar.gz](https://root.cern/download/root_v4.00.02.win32.tar.gz) |  16M |
+| win32gcc | [root_v4.00.02.win32gcc.tar.gz](https://root.cern/download/root_v4.00.02.win32gcc.tar.gz) |  20M |
+| win32gdk | [root_v4.00.02.win32gdk.tar.gz](https://root.cern/download/root_v4.00.02.win32gdk.tar.gz) |  16M |
+| root_v4.00.02a.win32gdk | [root_v4.00.02a.win32gdk.tar.gz](https://root.cern/download/root_v4.00.02a.win32gdk.tar.gz) |  16M |
 
 
 ## Git

--- a/_releases/release-40003.md
+++ b/_releases/release-40003.md
@@ -15,38 +15,38 @@ sidebar:
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v4.00.03.source.tar.gz](https://root.cern.ch/download/root_v4.00.03.source.tar.gz) |  10M |
+| source | [root_v4.00.03.source.tar.gz](https://root.cern/download/root_v4.00.03.source.tar.gz) |  10M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| AIX.5 | [root_v4.00.03.AIX.5.tar.gz](https://root.cern.ch/download/root_v4.00.03.AIX.5.tar.gz) |  20M |
-| Darwin.7.3.0 | [root_v4.00.03.Darwin.7.3.0.tar.gz](https://root.cern.ch/download/root_v4.00.03.Darwin.7.3.0.tar.gz) |  31M |
-| HP UX.B.10.20.aCC | [root_v4.00.03.HP-UX.B.10.20.aCC.tar.gz](https://root.cern.ch/download/root_v4.00.03.HP-UX.B.10.20.aCC.tar.gz) |  22M |
-| IRIX.6.5.cc | [root_v4.00.03.IRIX.6.5.cc.tar.gz](https://root.cern.ch/download/root_v4.00.03.IRIX.6.5.cc.tar.gz) |  21M |
-| IRIX.6.5.gcc | [root_v4.00.03.IRIX.6.5.gcc.tar.gz](https://root.cern.ch/download/root_v4.00.03.IRIX.6.5.gcc.tar.gz) |  25M |
-| IRIX.6.5.kcc | [root_v4.00.03.IRIX.6.5.kcc.tar.gz](https://root.cern.ch/download/root_v4.00.03.IRIX.6.5.kcc.tar.gz) |  18M |
-| Linux RH7.2.linuxia64gcc | [root_v4.00.03.Linux-RH7.2.linuxia64gcc.tar.gz](https://root.cern.ch/download/root_v4.00.03.Linux-RH7.2.linuxia64gcc.tar.gz) |  18M |
-| Linux.linuxx8664gcc | [root_v4.00.03.Linux.linuxx8664gcc.tar.gz](https://root.cern.ch/download/root_v4.00.03.Linux.linuxx8664gcc.tar.gz) |  14M |
-| Linux.RH6.1.gcc2952 | [root_v4.00.03.Linux.RH6.1.gcc2952.tar.gz](https://root.cern.ch/download/root_v4.00.03.Linux.RH6.1.gcc2952.tar.gz) |  17M |
-| Linux.RH7.3.gcc32 | [root_v4.00.03.Linux.RH7.3.gcc32.tar.gz](https://root.cern.ch/download/root_v4.00.03.Linux.RH7.3.gcc32.tar.gz) |  16M |
-| Linux.RH7.3.gcc296 | [root_v4.00.03.Linux.RH7.3.gcc296.tar.gz](https://root.cern.ch/download/root_v4.00.03.Linux.RH7.3.gcc296.tar.gz) |  18M |
-| Linux.RH7.3.gcc2952 | [root_v4.00.03.Linux.RH7.3.gcc2952.tar.gz](https://root.cern.ch/download/root_v4.00.03.Linux.RH7.3.gcc2952.tar.gz) |  18M |
-| Linux.RH7.3.gcc2953 | [root_v4.00.03.Linux.RH7.3.gcc2953.tar.gz](https://root.cern.ch/download/root_v4.00.03.Linux.RH7.3.gcc2953.tar.gz) |  18M |
-| Linux.RH9.0.gcc32 | [root_v4.00.03.Linux.RH9.0.gcc32.tar.gz](https://root.cern.ch/download/root_v4.00.03.Linux.RH9.0.gcc32.tar.gz) |  16M |
-| Linux.RH9.icc8 | [root_v4.00.03.Linux.RH9.icc8.tar.gz](https://root.cern.ch/download/root_v4.00.03.Linux.RH9.icc8.tar.gz) |  20M |
-| Linux.RH10.0.gcc33 | [root_v4.00.03.Linux.RH10.0.gcc33.tar.gz](https://root.cern.ch/download/root_v4.00.03.Linux.RH10.0.gcc33.tar.gz) |  14M |
-| OSF1.V4.0.cxx6 | [root_v4.00.03.OSF1.V4.0.cxx6.tar.gz](https://root.cern.ch/download/root_v4.00.03.OSF1.V4.0.cxx6.tar.gz) |  18M |
-| OSF1.V4.0 | [root_v4.00.03.OSF1.V4.0.tar.gz](https://root.cern.ch/download/root_v4.00.03.OSF1.V4.0.tar.gz) |  21M |
-| OSF1.V5.1.cxx6 | [root_v4.00.03.OSF1.V5.1.cxx6.tar.gz](https://root.cern.ch/download/root_v4.00.03.OSF1.V5.1.cxx6.tar.gz) |  18M |
-| SunOS.5.7 | [root_v4.00.03.SunOS.5.7.tar.gz](https://root.cern.ch/download/root_v4.00.03.SunOS.5.7.tar.gz) |  21M |
-| SunOS.5.8 | [root_v4.00.03.SunOS.5.8.tar.gz](https://root.cern.ch/download/root_v4.00.03.SunOS.5.8.tar.gz) |  20M |
-| win32 | [root_v4.00.03.win32.tar.gz](https://root.cern.ch/download/root_v4.00.03.win32.tar.gz) |  17M |
-| win32gcc | [root_v4.00.03.win32gcc.tar.gz](https://root.cern.ch/download/root_v4.00.03.win32gcc.tar.gz) |  20M |
-| win32gdk (dbg) | [root_v4.00.03.win32gdk.debug.tar.gz](https://root.cern.ch/download/root_v4.00.03.win32gdk.debug.tar.gz) |  27M |
-| win32gdk | [root_v4.00.03.win32gdk.tar.gz](https://root.cern.ch/download/root_v4.00.03.win32gdk.tar.gz) |  16M |
+| AIX.5 | [root_v4.00.03.AIX.5.tar.gz](https://root.cern/download/root_v4.00.03.AIX.5.tar.gz) |  20M |
+| Darwin.7.3.0 | [root_v4.00.03.Darwin.7.3.0.tar.gz](https://root.cern/download/root_v4.00.03.Darwin.7.3.0.tar.gz) |  31M |
+| HP UX.B.10.20.aCC | [root_v4.00.03.HP-UX.B.10.20.aCC.tar.gz](https://root.cern/download/root_v4.00.03.HP-UX.B.10.20.aCC.tar.gz) |  22M |
+| IRIX.6.5.cc | [root_v4.00.03.IRIX.6.5.cc.tar.gz](https://root.cern/download/root_v4.00.03.IRIX.6.5.cc.tar.gz) |  21M |
+| IRIX.6.5.gcc | [root_v4.00.03.IRIX.6.5.gcc.tar.gz](https://root.cern/download/root_v4.00.03.IRIX.6.5.gcc.tar.gz) |  25M |
+| IRIX.6.5.kcc | [root_v4.00.03.IRIX.6.5.kcc.tar.gz](https://root.cern/download/root_v4.00.03.IRIX.6.5.kcc.tar.gz) |  18M |
+| Linux RH7.2.linuxia64gcc | [root_v4.00.03.Linux-RH7.2.linuxia64gcc.tar.gz](https://root.cern/download/root_v4.00.03.Linux-RH7.2.linuxia64gcc.tar.gz) |  18M |
+| Linux.linuxx8664gcc | [root_v4.00.03.Linux.linuxx8664gcc.tar.gz](https://root.cern/download/root_v4.00.03.Linux.linuxx8664gcc.tar.gz) |  14M |
+| Linux.RH6.1.gcc2952 | [root_v4.00.03.Linux.RH6.1.gcc2952.tar.gz](https://root.cern/download/root_v4.00.03.Linux.RH6.1.gcc2952.tar.gz) |  17M |
+| Linux.RH7.3.gcc32 | [root_v4.00.03.Linux.RH7.3.gcc32.tar.gz](https://root.cern/download/root_v4.00.03.Linux.RH7.3.gcc32.tar.gz) |  16M |
+| Linux.RH7.3.gcc296 | [root_v4.00.03.Linux.RH7.3.gcc296.tar.gz](https://root.cern/download/root_v4.00.03.Linux.RH7.3.gcc296.tar.gz) |  18M |
+| Linux.RH7.3.gcc2952 | [root_v4.00.03.Linux.RH7.3.gcc2952.tar.gz](https://root.cern/download/root_v4.00.03.Linux.RH7.3.gcc2952.tar.gz) |  18M |
+| Linux.RH7.3.gcc2953 | [root_v4.00.03.Linux.RH7.3.gcc2953.tar.gz](https://root.cern/download/root_v4.00.03.Linux.RH7.3.gcc2953.tar.gz) |  18M |
+| Linux.RH9.0.gcc32 | [root_v4.00.03.Linux.RH9.0.gcc32.tar.gz](https://root.cern/download/root_v4.00.03.Linux.RH9.0.gcc32.tar.gz) |  16M |
+| Linux.RH9.icc8 | [root_v4.00.03.Linux.RH9.icc8.tar.gz](https://root.cern/download/root_v4.00.03.Linux.RH9.icc8.tar.gz) |  20M |
+| Linux.RH10.0.gcc33 | [root_v4.00.03.Linux.RH10.0.gcc33.tar.gz](https://root.cern/download/root_v4.00.03.Linux.RH10.0.gcc33.tar.gz) |  14M |
+| OSF1.V4.0.cxx6 | [root_v4.00.03.OSF1.V4.0.cxx6.tar.gz](https://root.cern/download/root_v4.00.03.OSF1.V4.0.cxx6.tar.gz) |  18M |
+| OSF1.V4.0 | [root_v4.00.03.OSF1.V4.0.tar.gz](https://root.cern/download/root_v4.00.03.OSF1.V4.0.tar.gz) |  21M |
+| OSF1.V5.1.cxx6 | [root_v4.00.03.OSF1.V5.1.cxx6.tar.gz](https://root.cern/download/root_v4.00.03.OSF1.V5.1.cxx6.tar.gz) |  18M |
+| SunOS.5.7 | [root_v4.00.03.SunOS.5.7.tar.gz](https://root.cern/download/root_v4.00.03.SunOS.5.7.tar.gz) |  21M |
+| SunOS.5.8 | [root_v4.00.03.SunOS.5.8.tar.gz](https://root.cern/download/root_v4.00.03.SunOS.5.8.tar.gz) |  20M |
+| win32 | [root_v4.00.03.win32.tar.gz](https://root.cern/download/root_v4.00.03.win32.tar.gz) |  17M |
+| win32gcc | [root_v4.00.03.win32gcc.tar.gz](https://root.cern/download/root_v4.00.03.win32gcc.tar.gz) |  20M |
+| win32gdk (dbg) | [root_v4.00.03.win32gdk.debug.tar.gz](https://root.cern/download/root_v4.00.03.win32gdk.debug.tar.gz) |  27M |
+| win32gdk | [root_v4.00.03.win32gdk.tar.gz](https://root.cern/download/root_v4.00.03.win32gdk.tar.gz) |  16M |
 
 
 ## Git

--- a/_releases/release-40004.md
+++ b/_releases/release-40004.md
@@ -15,35 +15,35 @@ sidebar:
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v4.00.04.source.tar.gz](https://root.cern.ch/download/root_v4.00.04.source.tar.gz) |  10M |
+| source | [root_v4.00.04.source.tar.gz](https://root.cern/download/root_v4.00.04.source.tar.gz) |  10M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| AIX.5 | [root_v4.00.04.AIX.5.tar.gz](https://root.cern.ch/download/root_v4.00.04.AIX.5.tar.gz) |  21M |
-| HP UX.B.10.20.aCC | [root_v4.00.04.HP-UX.B.10.20.aCC.tar.gz](https://root.cern.ch/download/root_v4.00.04.HP-UX.B.10.20.aCC.tar.gz) |  22M |
-| IRIX.6.5.cc | [root_v4.00.04.IRIX.6.5.cc.tar.gz](https://root.cern.ch/download/root_v4.00.04.IRIX.6.5.cc.tar.gz) |  21M |
-| IRIX.6.5.gcc | [root_v4.00.04.IRIX.6.5.gcc.tar.gz](https://root.cern.ch/download/root_v4.00.04.IRIX.6.5.gcc.tar.gz) |  25M |
-| IRIX.6.5.kcc | [root_v4.00.04.IRIX.6.5.kcc.tar.gz](https://root.cern.ch/download/root_v4.00.04.IRIX.6.5.kcc.tar.gz) |  19M |
-| Linux.RH Fedora Core1.gcc3.3.2 | [root_v4.00.04.Linux.RH-Fedora-Core1.gcc3.3.2.tar.gz](https://root.cern.ch/download/root_v4.00.04.Linux.RH-Fedora-Core1.gcc3.3.2.tar.gz) |  13M |
-| Linux.RH6.1.gcc2952 | [root_v4.00.04.Linux.RH6.1.gcc2952.tar.gz](https://root.cern.ch/download/root_v4.00.04.Linux.RH6.1.gcc2952.tar.gz) |  17M |
-| Linux.RH7.3 cel3.gcc3.2.3 | [root_v4.00.04.Linux.RH7.3-cel3.gcc3.2.3.tar.gz](https://root.cern.ch/download/root_v4.00.04.Linux.RH7.3-cel3.gcc3.2.3.tar.gz) |  13M |
-| Linux.RH7.3.gcc32 | [root_v4.00.04.Linux.RH7.3.gcc32.tar.gz](https://root.cern.ch/download/root_v4.00.04.Linux.RH7.3.gcc32.tar.gz) |  17M |
-| Linux.RH7.3.gcc296 | [root_v4.00.04.Linux.RH7.3.gcc296.tar.gz](https://root.cern.ch/download/root_v4.00.04.Linux.RH7.3.gcc296.tar.gz) |  18M |
-| Linux.RH7.3.gcc2952 | [root_v4.00.04.Linux.RH7.3.gcc2952.tar.gz](https://root.cern.ch/download/root_v4.00.04.Linux.RH7.3.gcc2952.tar.gz) |  18M |
-| Linux.RH7.3.gcc2953 | [root_v4.00.04.Linux.RH7.3.gcc2953.tar.gz](https://root.cern.ch/download/root_v4.00.04.Linux.RH7.3.gcc2953.tar.gz) |  18M |
-| Linux.RH9.0.gcc32 | [root_v4.00.04.Linux.RH9.0.gcc32.tar.gz](https://root.cern.ch/download/root_v4.00.04.Linux.RH9.0.gcc32.tar.gz) |  16M |
-| OSF1.V4.0.cxx6 | [root_v4.00.04.OSF1.V4.0.cxx6.tar.gz](https://root.cern.ch/download/root_v4.00.04.OSF1.V4.0.cxx6.tar.gz) |  23M |
-| OSF1.V4.0 | [root_v4.00.04.OSF1.V4.0.tar.gz](https://root.cern.ch/download/root_v4.00.04.OSF1.V4.0.tar.gz) |  22M |
-| OSF1.V5.1.cxx6 | [root_v4.00.04.OSF1.V5.1.cxx6.tar.gz](https://root.cern.ch/download/root_v4.00.04.OSF1.V5.1.cxx6.tar.gz) |  19M |
-| SunOS.5.7 | [root_v4.00.04.SunOS.5.7.tar.gz](https://root.cern.ch/download/root_v4.00.04.SunOS.5.7.tar.gz) |  21M |
-| SunOS.5.8 | [root_v4.00.04.SunOS.5.8.tar.gz](https://root.cern.ch/download/root_v4.00.04.SunOS.5.8.tar.gz) |  19M |
-| win32 | [root_v4.00.04.win32.tar.gz](https://root.cern.ch/download/root_v4.00.04.win32.tar.gz) |  17M |
-| win32gcc | [root_v4.00.04.win32gcc.tar.gz](https://root.cern.ch/download/root_v4.00.04.win32gcc.tar.gz) |  21M |
-| win32gdk (dbg) | [root_v4.00.04.win32gdk.debug.tar.gz](https://root.cern.ch/download/root_v4.00.04.win32gdk.debug.tar.gz) |  28M |
-| win32gdk | [root_v4.00.04.win32gdk.tar.gz](https://root.cern.ch/download/root_v4.00.04.win32gdk.tar.gz) |  16M |
+| AIX.5 | [root_v4.00.04.AIX.5.tar.gz](https://root.cern/download/root_v4.00.04.AIX.5.tar.gz) |  21M |
+| HP UX.B.10.20.aCC | [root_v4.00.04.HP-UX.B.10.20.aCC.tar.gz](https://root.cern/download/root_v4.00.04.HP-UX.B.10.20.aCC.tar.gz) |  22M |
+| IRIX.6.5.cc | [root_v4.00.04.IRIX.6.5.cc.tar.gz](https://root.cern/download/root_v4.00.04.IRIX.6.5.cc.tar.gz) |  21M |
+| IRIX.6.5.gcc | [root_v4.00.04.IRIX.6.5.gcc.tar.gz](https://root.cern/download/root_v4.00.04.IRIX.6.5.gcc.tar.gz) |  25M |
+| IRIX.6.5.kcc | [root_v4.00.04.IRIX.6.5.kcc.tar.gz](https://root.cern/download/root_v4.00.04.IRIX.6.5.kcc.tar.gz) |  19M |
+| Linux.RH Fedora Core1.gcc3.3.2 | [root_v4.00.04.Linux.RH-Fedora-Core1.gcc3.3.2.tar.gz](https://root.cern/download/root_v4.00.04.Linux.RH-Fedora-Core1.gcc3.3.2.tar.gz) |  13M |
+| Linux.RH6.1.gcc2952 | [root_v4.00.04.Linux.RH6.1.gcc2952.tar.gz](https://root.cern/download/root_v4.00.04.Linux.RH6.1.gcc2952.tar.gz) |  17M |
+| Linux.RH7.3 cel3.gcc3.2.3 | [root_v4.00.04.Linux.RH7.3-cel3.gcc3.2.3.tar.gz](https://root.cern/download/root_v4.00.04.Linux.RH7.3-cel3.gcc3.2.3.tar.gz) |  13M |
+| Linux.RH7.3.gcc32 | [root_v4.00.04.Linux.RH7.3.gcc32.tar.gz](https://root.cern/download/root_v4.00.04.Linux.RH7.3.gcc32.tar.gz) |  17M |
+| Linux.RH7.3.gcc296 | [root_v4.00.04.Linux.RH7.3.gcc296.tar.gz](https://root.cern/download/root_v4.00.04.Linux.RH7.3.gcc296.tar.gz) |  18M |
+| Linux.RH7.3.gcc2952 | [root_v4.00.04.Linux.RH7.3.gcc2952.tar.gz](https://root.cern/download/root_v4.00.04.Linux.RH7.3.gcc2952.tar.gz) |  18M |
+| Linux.RH7.3.gcc2953 | [root_v4.00.04.Linux.RH7.3.gcc2953.tar.gz](https://root.cern/download/root_v4.00.04.Linux.RH7.3.gcc2953.tar.gz) |  18M |
+| Linux.RH9.0.gcc32 | [root_v4.00.04.Linux.RH9.0.gcc32.tar.gz](https://root.cern/download/root_v4.00.04.Linux.RH9.0.gcc32.tar.gz) |  16M |
+| OSF1.V4.0.cxx6 | [root_v4.00.04.OSF1.V4.0.cxx6.tar.gz](https://root.cern/download/root_v4.00.04.OSF1.V4.0.cxx6.tar.gz) |  23M |
+| OSF1.V4.0 | [root_v4.00.04.OSF1.V4.0.tar.gz](https://root.cern/download/root_v4.00.04.OSF1.V4.0.tar.gz) |  22M |
+| OSF1.V5.1.cxx6 | [root_v4.00.04.OSF1.V5.1.cxx6.tar.gz](https://root.cern/download/root_v4.00.04.OSF1.V5.1.cxx6.tar.gz) |  19M |
+| SunOS.5.7 | [root_v4.00.04.SunOS.5.7.tar.gz](https://root.cern/download/root_v4.00.04.SunOS.5.7.tar.gz) |  21M |
+| SunOS.5.8 | [root_v4.00.04.SunOS.5.8.tar.gz](https://root.cern/download/root_v4.00.04.SunOS.5.8.tar.gz) |  19M |
+| win32 | [root_v4.00.04.win32.tar.gz](https://root.cern/download/root_v4.00.04.win32.tar.gz) |  17M |
+| win32gcc | [root_v4.00.04.win32gcc.tar.gz](https://root.cern/download/root_v4.00.04.win32gcc.tar.gz) |  21M |
+| win32gdk (dbg) | [root_v4.00.04.win32gdk.debug.tar.gz](https://root.cern/download/root_v4.00.04.win32gdk.debug.tar.gz) |  28M |
+| win32gdk | [root_v4.00.04.win32gdk.tar.gz](https://root.cern/download/root_v4.00.04.win32gdk.tar.gz) |  16M |
 
 
 ## Git

--- a/_releases/release-40006.md
+++ b/_releases/release-40006.md
@@ -15,61 +15,61 @@ sidebar:
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v4.00.06.source.tar.gz](https://root.cern.ch/download/root_v4.00.06.source.tar.gz) |  10M |
-| sourcea | [root_v4.00.06.sourcea.tar.gz](https://root.cern.ch/download/root_v4.00.06.sourcea.tar.gz) |  10M |
+| source | [root_v4.00.06.source.tar.gz](https://root.cern/download/root_v4.00.06.source.tar.gz) |  10M |
+| sourcea | [root_v4.00.06.sourcea.tar.gz](https://root.cern/download/root_v4.00.06.sourcea.tar.gz) |  10M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| AIX.5 | [root_v4.00.06.AIX.5.tar.gz](https://root.cern.ch/download/root_v4.00.06.AIX.5.tar.gz) |  21M |
-| AIX.5a | [root_v4.00.06.AIX.5a.tar.gz](https://root.cern.ch/download/root_v4.00.06.AIX.5a.tar.gz) |  21M |
-| HP UX.B.10.20.aCC | [root_v4.00.06.HP-UX.B.10.20.aCC.tar.gz](https://root.cern.ch/download/root_v4.00.06.HP-UX.B.10.20.aCC.tar.gz) |  23M |
-| HP UX.B.10.20.aCCa | [root_v4.00.06.HP-UX.B.10.20.aCCa.tar.gz](https://root.cern.ch/download/root_v4.00.06.HP-UX.B.10.20.aCCa.tar.gz) |  23M |
-| IRIX.6.5.cc | [root_v4.00.06.IRIX.6.5.cc.tar.gz](https://root.cern.ch/download/root_v4.00.06.IRIX.6.5.cc.tar.gz) |  21M |
-| IRIX.6.5.cca | [root_v4.00.06.IRIX.6.5.cca.tar.gz](https://root.cern.ch/download/root_v4.00.06.IRIX.6.5.cca.tar.gz) |  21M |
-| IRIX.6.5.gcc | [root_v4.00.06.IRIX.6.5.gcc.tar.gz](https://root.cern.ch/download/root_v4.00.06.IRIX.6.5.gcc.tar.gz) |  26M |
-| IRIX.6.5.gcca | [root_v4.00.06.IRIX.6.5.gcca.tar.gz](https://root.cern.ch/download/root_v4.00.06.IRIX.6.5.gcca.tar.gz) |  26M |
-| IRIX.6.5.kcc | [root_v4.00.06.IRIX.6.5.kcc.tar.gz](https://root.cern.ch/download/root_v4.00.06.IRIX.6.5.kcc.tar.gz) |  19M |
-| IRIX.6.5.kcca | [root_v4.00.06.IRIX.6.5.kcca.tar.gz](https://root.cern.ch/download/root_v4.00.06.IRIX.6.5.kcca.tar.gz) |  19M |
-| Linux.RH6.1.gcc2952 | [root_v4.00.06.Linux.RH6.1.gcc2952.tar.gz](https://root.cern.ch/download/root_v4.00.06.Linux.RH6.1.gcc2952.tar.gz) |  18M |
-| Linux.RH7.3 cel3.gcc3.2.3 | [root_v4.00.06.Linux.RH7.3-cel3.gcc3.2.3.tar.gz](https://root.cern.ch/download/root_v4.00.06.Linux.RH7.3-cel3.gcc3.2.3.tar.gz) |  15M |
-| Linux.RH7.3 cel3.gcc3.2.3a | [root_v4.00.06.Linux.RH7.3-cel3.gcc3.2.3a.tar.gz](https://root.cern.ch/download/root_v4.00.06.Linux.RH7.3-cel3.gcc3.2.3a.tar.gz) |  15M |
-| Linux.RH7.3 slc3.gcc3.2.3a | [root_v4.00.06.Linux.RH7.3-slc3.gcc3.2.3a.tar.gz](https://root.cern.ch/download/root_v4.00.06.Linux.RH7.3-slc3.gcc3.2.3a.tar.gz) |  15M |
-| Linux.RH7.3.gcc32 | [root_v4.00.06.Linux.RH7.3.gcc32.tar.gz](https://root.cern.ch/download/root_v4.00.06.Linux.RH7.3.gcc32.tar.gz) |  19M |
-| Linux.RH7.3.gcc32a | [root_v4.00.06.Linux.RH7.3.gcc32a.tar.gz](https://root.cern.ch/download/root_v4.00.06.Linux.RH7.3.gcc32a.tar.gz) |  19M |
-| Linux.RH7.3.gcc296 | [root_v4.00.06.Linux.RH7.3.gcc296.tar.gz](https://root.cern.ch/download/root_v4.00.06.Linux.RH7.3.gcc296.tar.gz) |  21M |
-| Linux.RH7.3.gcc296a | [root_v4.00.06.Linux.RH7.3.gcc296a.tar.gz](https://root.cern.ch/download/root_v4.00.06.Linux.RH7.3.gcc296a.tar.gz) |  21M |
-| Linux.RH7.3.gcc2952 | [root_v4.00.06.Linux.RH7.3.gcc2952.tar.gz](https://root.cern.ch/download/root_v4.00.06.Linux.RH7.3.gcc2952.tar.gz) |  20M |
-| Linux.RH7.3.gcc2952a | [root_v4.00.06.Linux.RH7.3.gcc2952a.tar.gz](https://root.cern.ch/download/root_v4.00.06.Linux.RH7.3.gcc2952a.tar.gz) |  20M |
-| Linux.RH7.3.gcc2953 | [root_v4.00.06.Linux.RH7.3.gcc2953.tar.gz](https://root.cern.ch/download/root_v4.00.06.Linux.RH7.3.gcc2953.tar.gz) |  21M |
-| Linux.RH7.3.gcc2953a | [root_v4.00.06.Linux.RH7.3.gcc2953a.tar.gz](https://root.cern.ch/download/root_v4.00.06.Linux.RH7.3.gcc2953a.tar.gz) |  21M |
-| Linux.RH9.0.gcc32 | [root_v4.00.06.Linux.RH9.0.gcc32.tar.gz](https://root.cern.ch/download/root_v4.00.06.Linux.RH9.0.gcc32.tar.gz) |  16M |
-| Linux.RH9.0.gcc32a | [root_v4.00.06.Linux.RH9.0.gcc32a.tar.gz](https://root.cern.ch/download/root_v4.00.06.Linux.RH9.0.gcc32a.tar.gz) |  16M |
-| OSF1.V4.0.cxx6 | [root_v4.00.06.OSF1.V4.0.cxx6.tar.gz](https://root.cern.ch/download/root_v4.00.06.OSF1.V4.0.cxx6.tar.gz) |  21M |
-| OSF1.V4.0.cxx6a | [root_v4.00.06.OSF1.V4.0.cxx6a.tar.gz](https://root.cern.ch/download/root_v4.00.06.OSF1.V4.0.cxx6a.tar.gz) |  21M |
-| OSF1.V4.0 | [root_v4.00.06.OSF1.V4.0.tar.gz](https://root.cern.ch/download/root_v4.00.06.OSF1.V4.0.tar.gz) |  24M |
-| OSF1.V4.0a | [root_v4.00.06.OSF1.V4.0a.tar.gz](https://root.cern.ch/download/root_v4.00.06.OSF1.V4.0a.tar.gz) |  24M |
-| OSF1.V5.1.cxx6 | [root_v4.00.06.OSF1.V5.1.cxx6.tar.gz](https://root.cern.ch/download/root_v4.00.06.OSF1.V5.1.cxx6.tar.gz) |  19M |
-| OSF1.V5.1.cxx6a | [root_v4.00.06.OSF1.V5.1.cxx6a.tar.gz](https://root.cern.ch/download/root_v4.00.06.OSF1.V5.1.cxx6a.tar.gz) |  19M |
-| SunOS.5.7 | [root_v4.00.06.SunOS.5.7.tar.gz](https://root.cern.ch/download/root_v4.00.06.SunOS.5.7.tar.gz) |  24M |
-| SunOS.5.7a | [root_v4.00.06.SunOS.5.7a.tar.gz](https://root.cern.ch/download/root_v4.00.06.SunOS.5.7a.tar.gz) |  24M |
-| SunOS.5.8 | [root_v4.00.06.SunOS.5.8.tar.gz](https://root.cern.ch/download/root_v4.00.06.SunOS.5.8.tar.gz) |  21M |
-| SunOS.5.8a | [root_v4.00.06.SunOS.5.8a.tar.gz](https://root.cern.ch/download/root_v4.00.06.SunOS.5.8a.tar.gz) |  21M |
-| win32 | [root_v4.00.06.win32.tar.gz](https://root.cern.ch/download/root_v4.00.06.win32.tar.gz) |  18M |
-| win32a | [root_v4.00.06.win32a.tar.gz](https://root.cern.ch/download/root_v4.00.06.win32a.tar.gz) |  18M |
-| win32gcc | [root_v4.00.06.win32gcc.tar.gz](https://root.cern.ch/download/root_v4.00.06.win32gcc.tar.gz) |  21M |
-| win32gcca | [root_v4.00.06.win32gcca.tar.gz](https://root.cern.ch/download/root_v4.00.06.win32gcca.tar.gz) |  21M |
-| win32gdk (dbg) | [root_v4.00.06.win32gdk.debug.tar.gz](https://root.cern.ch/download/root_v4.00.06.win32gdk.debug.tar.gz) |  31M |
-| win32gdk (dbg)a | [root_v4.00.06.win32gdk.debuga.tar.gz](https://root.cern.ch/download/root_v4.00.06.win32gdk.debuga.tar.gz) |  31M |
-| win32gdk | [root_v4.00.06.win32gdk.tar.gz](https://root.cern.ch/download/root_v4.00.06.win32gdk.tar.gz) |  17M |
-| win32gdka | [root_v4.00.06.win32gdka.tar.gz](https://root.cern.ch/download/root_v4.00.06.win32gdka.tar.gz) |  17M |
-| root_v4.00.06a.Darwin.7.4.0 | [root_v4.00.06a.Darwin.7.4.0.tar.gz](https://root.cern.ch/download/root_v4.00.06a.Darwin.7.4.0.tar.gz) |  34M |
-| root_v4.00.06a.Linux RH7.2.linuxia64ecc | [root_v4.00.06a.Linux-RH7.2.linuxia64ecc.tar.gz](https://root.cern.ch/download/root_v4.00.06a.Linux-RH7.2.linuxia64ecc.tar.gz) |  32M |
-| root_v4.00.06a.Linux RH7.2.linuxia64gcc | [root_v4.00.06a.Linux-RH7.2.linuxia64gcc.tar.gz](https://root.cern.ch/download/root_v4.00.06a.Linux-RH7.2.linuxia64gcc.tar.gz) |  19M |
-| root_v4.00.06a.Linux.linuxx8664gcc | [root_v4.00.06a.Linux.linuxx8664gcc.tar.gz](https://root.cern.ch/download/root_v4.00.06a.Linux.linuxx8664gcc.tar.gz) |  15M |
-| root_v4.00.06a.Linux.RH9.icc8 | [root_v4.00.06a.Linux.RH9.icc8.tar.gz](https://root.cern.ch/download/root_v4.00.06a.Linux.RH9.icc8.tar.gz) |  22M |
+| AIX.5 | [root_v4.00.06.AIX.5.tar.gz](https://root.cern/download/root_v4.00.06.AIX.5.tar.gz) |  21M |
+| AIX.5a | [root_v4.00.06.AIX.5a.tar.gz](https://root.cern/download/root_v4.00.06.AIX.5a.tar.gz) |  21M |
+| HP UX.B.10.20.aCC | [root_v4.00.06.HP-UX.B.10.20.aCC.tar.gz](https://root.cern/download/root_v4.00.06.HP-UX.B.10.20.aCC.tar.gz) |  23M |
+| HP UX.B.10.20.aCCa | [root_v4.00.06.HP-UX.B.10.20.aCCa.tar.gz](https://root.cern/download/root_v4.00.06.HP-UX.B.10.20.aCCa.tar.gz) |  23M |
+| IRIX.6.5.cc | [root_v4.00.06.IRIX.6.5.cc.tar.gz](https://root.cern/download/root_v4.00.06.IRIX.6.5.cc.tar.gz) |  21M |
+| IRIX.6.5.cca | [root_v4.00.06.IRIX.6.5.cca.tar.gz](https://root.cern/download/root_v4.00.06.IRIX.6.5.cca.tar.gz) |  21M |
+| IRIX.6.5.gcc | [root_v4.00.06.IRIX.6.5.gcc.tar.gz](https://root.cern/download/root_v4.00.06.IRIX.6.5.gcc.tar.gz) |  26M |
+| IRIX.6.5.gcca | [root_v4.00.06.IRIX.6.5.gcca.tar.gz](https://root.cern/download/root_v4.00.06.IRIX.6.5.gcca.tar.gz) |  26M |
+| IRIX.6.5.kcc | [root_v4.00.06.IRIX.6.5.kcc.tar.gz](https://root.cern/download/root_v4.00.06.IRIX.6.5.kcc.tar.gz) |  19M |
+| IRIX.6.5.kcca | [root_v4.00.06.IRIX.6.5.kcca.tar.gz](https://root.cern/download/root_v4.00.06.IRIX.6.5.kcca.tar.gz) |  19M |
+| Linux.RH6.1.gcc2952 | [root_v4.00.06.Linux.RH6.1.gcc2952.tar.gz](https://root.cern/download/root_v4.00.06.Linux.RH6.1.gcc2952.tar.gz) |  18M |
+| Linux.RH7.3 cel3.gcc3.2.3 | [root_v4.00.06.Linux.RH7.3-cel3.gcc3.2.3.tar.gz](https://root.cern/download/root_v4.00.06.Linux.RH7.3-cel3.gcc3.2.3.tar.gz) |  15M |
+| Linux.RH7.3 cel3.gcc3.2.3a | [root_v4.00.06.Linux.RH7.3-cel3.gcc3.2.3a.tar.gz](https://root.cern/download/root_v4.00.06.Linux.RH7.3-cel3.gcc3.2.3a.tar.gz) |  15M |
+| Linux.RH7.3 slc3.gcc3.2.3a | [root_v4.00.06.Linux.RH7.3-slc3.gcc3.2.3a.tar.gz](https://root.cern/download/root_v4.00.06.Linux.RH7.3-slc3.gcc3.2.3a.tar.gz) |  15M |
+| Linux.RH7.3.gcc32 | [root_v4.00.06.Linux.RH7.3.gcc32.tar.gz](https://root.cern/download/root_v4.00.06.Linux.RH7.3.gcc32.tar.gz) |  19M |
+| Linux.RH7.3.gcc32a | [root_v4.00.06.Linux.RH7.3.gcc32a.tar.gz](https://root.cern/download/root_v4.00.06.Linux.RH7.3.gcc32a.tar.gz) |  19M |
+| Linux.RH7.3.gcc296 | [root_v4.00.06.Linux.RH7.3.gcc296.tar.gz](https://root.cern/download/root_v4.00.06.Linux.RH7.3.gcc296.tar.gz) |  21M |
+| Linux.RH7.3.gcc296a | [root_v4.00.06.Linux.RH7.3.gcc296a.tar.gz](https://root.cern/download/root_v4.00.06.Linux.RH7.3.gcc296a.tar.gz) |  21M |
+| Linux.RH7.3.gcc2952 | [root_v4.00.06.Linux.RH7.3.gcc2952.tar.gz](https://root.cern/download/root_v4.00.06.Linux.RH7.3.gcc2952.tar.gz) |  20M |
+| Linux.RH7.3.gcc2952a | [root_v4.00.06.Linux.RH7.3.gcc2952a.tar.gz](https://root.cern/download/root_v4.00.06.Linux.RH7.3.gcc2952a.tar.gz) |  20M |
+| Linux.RH7.3.gcc2953 | [root_v4.00.06.Linux.RH7.3.gcc2953.tar.gz](https://root.cern/download/root_v4.00.06.Linux.RH7.3.gcc2953.tar.gz) |  21M |
+| Linux.RH7.3.gcc2953a | [root_v4.00.06.Linux.RH7.3.gcc2953a.tar.gz](https://root.cern/download/root_v4.00.06.Linux.RH7.3.gcc2953a.tar.gz) |  21M |
+| Linux.RH9.0.gcc32 | [root_v4.00.06.Linux.RH9.0.gcc32.tar.gz](https://root.cern/download/root_v4.00.06.Linux.RH9.0.gcc32.tar.gz) |  16M |
+| Linux.RH9.0.gcc32a | [root_v4.00.06.Linux.RH9.0.gcc32a.tar.gz](https://root.cern/download/root_v4.00.06.Linux.RH9.0.gcc32a.tar.gz) |  16M |
+| OSF1.V4.0.cxx6 | [root_v4.00.06.OSF1.V4.0.cxx6.tar.gz](https://root.cern/download/root_v4.00.06.OSF1.V4.0.cxx6.tar.gz) |  21M |
+| OSF1.V4.0.cxx6a | [root_v4.00.06.OSF1.V4.0.cxx6a.tar.gz](https://root.cern/download/root_v4.00.06.OSF1.V4.0.cxx6a.tar.gz) |  21M |
+| OSF1.V4.0 | [root_v4.00.06.OSF1.V4.0.tar.gz](https://root.cern/download/root_v4.00.06.OSF1.V4.0.tar.gz) |  24M |
+| OSF1.V4.0a | [root_v4.00.06.OSF1.V4.0a.tar.gz](https://root.cern/download/root_v4.00.06.OSF1.V4.0a.tar.gz) |  24M |
+| OSF1.V5.1.cxx6 | [root_v4.00.06.OSF1.V5.1.cxx6.tar.gz](https://root.cern/download/root_v4.00.06.OSF1.V5.1.cxx6.tar.gz) |  19M |
+| OSF1.V5.1.cxx6a | [root_v4.00.06.OSF1.V5.1.cxx6a.tar.gz](https://root.cern/download/root_v4.00.06.OSF1.V5.1.cxx6a.tar.gz) |  19M |
+| SunOS.5.7 | [root_v4.00.06.SunOS.5.7.tar.gz](https://root.cern/download/root_v4.00.06.SunOS.5.7.tar.gz) |  24M |
+| SunOS.5.7a | [root_v4.00.06.SunOS.5.7a.tar.gz](https://root.cern/download/root_v4.00.06.SunOS.5.7a.tar.gz) |  24M |
+| SunOS.5.8 | [root_v4.00.06.SunOS.5.8.tar.gz](https://root.cern/download/root_v4.00.06.SunOS.5.8.tar.gz) |  21M |
+| SunOS.5.8a | [root_v4.00.06.SunOS.5.8a.tar.gz](https://root.cern/download/root_v4.00.06.SunOS.5.8a.tar.gz) |  21M |
+| win32 | [root_v4.00.06.win32.tar.gz](https://root.cern/download/root_v4.00.06.win32.tar.gz) |  18M |
+| win32a | [root_v4.00.06.win32a.tar.gz](https://root.cern/download/root_v4.00.06.win32a.tar.gz) |  18M |
+| win32gcc | [root_v4.00.06.win32gcc.tar.gz](https://root.cern/download/root_v4.00.06.win32gcc.tar.gz) |  21M |
+| win32gcca | [root_v4.00.06.win32gcca.tar.gz](https://root.cern/download/root_v4.00.06.win32gcca.tar.gz) |  21M |
+| win32gdk (dbg) | [root_v4.00.06.win32gdk.debug.tar.gz](https://root.cern/download/root_v4.00.06.win32gdk.debug.tar.gz) |  31M |
+| win32gdk (dbg)a | [root_v4.00.06.win32gdk.debuga.tar.gz](https://root.cern/download/root_v4.00.06.win32gdk.debuga.tar.gz) |  31M |
+| win32gdk | [root_v4.00.06.win32gdk.tar.gz](https://root.cern/download/root_v4.00.06.win32gdk.tar.gz) |  17M |
+| win32gdka | [root_v4.00.06.win32gdka.tar.gz](https://root.cern/download/root_v4.00.06.win32gdka.tar.gz) |  17M |
+| root_v4.00.06a.Darwin.7.4.0 | [root_v4.00.06a.Darwin.7.4.0.tar.gz](https://root.cern/download/root_v4.00.06a.Darwin.7.4.0.tar.gz) |  34M |
+| root_v4.00.06a.Linux RH7.2.linuxia64ecc | [root_v4.00.06a.Linux-RH7.2.linuxia64ecc.tar.gz](https://root.cern/download/root_v4.00.06a.Linux-RH7.2.linuxia64ecc.tar.gz) |  32M |
+| root_v4.00.06a.Linux RH7.2.linuxia64gcc | [root_v4.00.06a.Linux-RH7.2.linuxia64gcc.tar.gz](https://root.cern/download/root_v4.00.06a.Linux-RH7.2.linuxia64gcc.tar.gz) |  19M |
+| root_v4.00.06a.Linux.linuxx8664gcc | [root_v4.00.06a.Linux.linuxx8664gcc.tar.gz](https://root.cern/download/root_v4.00.06a.Linux.linuxx8664gcc.tar.gz) |  15M |
+| root_v4.00.06a.Linux.RH9.icc8 | [root_v4.00.06a.Linux.RH9.icc8.tar.gz](https://root.cern/download/root_v4.00.06a.Linux.RH9.icc8.tar.gz) |  22M |
 
 
 ## Git

--- a/_releases/release-40006a.md
+++ b/_releases/release-40006a.md
@@ -15,11 +15,11 @@ sidebar:
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| Darwin.7.4.0 | [root_v4.00.06a.Darwin.7.4.0.tar.gz](https://root.cern.ch/download/root_v4.00.06a.Darwin.7.4.0.tar.gz) |  34M |
-| Linux RH7.2.linuxia64ecc | [root_v4.00.06a.Linux-RH7.2.linuxia64ecc.tar.gz](https://root.cern.ch/download/root_v4.00.06a.Linux-RH7.2.linuxia64ecc.tar.gz) |  32M |
-| Linux RH7.2.linuxia64gcc | [root_v4.00.06a.Linux-RH7.2.linuxia64gcc.tar.gz](https://root.cern.ch/download/root_v4.00.06a.Linux-RH7.2.linuxia64gcc.tar.gz) |  19M |
-| Linux.linuxx8664gcc | [root_v4.00.06a.Linux.linuxx8664gcc.tar.gz](https://root.cern.ch/download/root_v4.00.06a.Linux.linuxx8664gcc.tar.gz) |  15M |
-| Linux.RH9.icc8 | [root_v4.00.06a.Linux.RH9.icc8.tar.gz](https://root.cern.ch/download/root_v4.00.06a.Linux.RH9.icc8.tar.gz) |  22M |
+| Darwin.7.4.0 | [root_v4.00.06a.Darwin.7.4.0.tar.gz](https://root.cern/download/root_v4.00.06a.Darwin.7.4.0.tar.gz) |  34M |
+| Linux RH7.2.linuxia64ecc | [root_v4.00.06a.Linux-RH7.2.linuxia64ecc.tar.gz](https://root.cern/download/root_v4.00.06a.Linux-RH7.2.linuxia64ecc.tar.gz) |  32M |
+| Linux RH7.2.linuxia64gcc | [root_v4.00.06a.Linux-RH7.2.linuxia64gcc.tar.gz](https://root.cern/download/root_v4.00.06a.Linux-RH7.2.linuxia64gcc.tar.gz) |  19M |
+| Linux.linuxx8664gcc | [root_v4.00.06a.Linux.linuxx8664gcc.tar.gz](https://root.cern/download/root_v4.00.06a.Linux.linuxx8664gcc.tar.gz) |  15M |
+| Linux.RH9.icc8 | [root_v4.00.06a.Linux.RH9.icc8.tar.gz](https://root.cern/download/root_v4.00.06a.Linux.RH9.icc8.tar.gz) |  22M |
 
 
 ## Git

--- a/_releases/release-40008.md
+++ b/_releases/release-40008.md
@@ -15,44 +15,44 @@ sidebar:
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v4.00.08.source.tar.gz](https://root.cern.ch/download/root_v4.00.08.source.tar.gz) |  11M |
-| root_v4.00.08a.source | [root_v4.00.08a.source.tar.gz](https://root.cern.ch/download/root_v4.00.08a.source.tar.gz) |  11M |
-| root_v4.00.08b.source | [root_v4.00.08b.source.tar.gz](https://root.cern.ch/download/root_v4.00.08b.source.tar.gz) |  11M |
-| root_v4.00.08c.source | [root_v4.00.08c.source.tar.gz](https://root.cern.ch/download/root_v4.00.08c.source.tar.gz) |  11M |
-| root_v4.00.08e.source | [root_v4.00.08e.source.tar.gz](https://root.cern.ch/download/root_v4.00.08e.source.tar.gz) |  11M |
-| root_v4.00.08f.source | [root_v4.00.08f.source.tar.gz](https://root.cern.ch/download/root_v4.00.08f.source.tar.gz) |  11M |
+| source | [root_v4.00.08.source.tar.gz](https://root.cern/download/root_v4.00.08.source.tar.gz) |  11M |
+| root_v4.00.08a.source | [root_v4.00.08a.source.tar.gz](https://root.cern/download/root_v4.00.08a.source.tar.gz) |  11M |
+| root_v4.00.08b.source | [root_v4.00.08b.source.tar.gz](https://root.cern/download/root_v4.00.08b.source.tar.gz) |  11M |
+| root_v4.00.08c.source | [root_v4.00.08c.source.tar.gz](https://root.cern/download/root_v4.00.08c.source.tar.gz) |  11M |
+| root_v4.00.08e.source | [root_v4.00.08e.source.tar.gz](https://root.cern/download/root_v4.00.08e.source.tar.gz) |  11M |
+| root_v4.00.08f.source | [root_v4.00.08f.source.tar.gz](https://root.cern/download/root_v4.00.08f.source.tar.gz) |  11M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| AIX.5 | [root_v4.00.08.AIX.5.tar.gz](https://root.cern.ch/download/root_v4.00.08.AIX.5.tar.gz) |  23M |
-| Darwin.7.4.0 | [root_v4.00.08.Darwin.7.4.0.tar.gz](https://root.cern.ch/download/root_v4.00.08.Darwin.7.4.0.tar.gz) |  35M |
-| HP UX.B.10.20.aCC | [root_v4.00.08.HP-UX.B.10.20.aCC.tar.gz](https://root.cern.ch/download/root_v4.00.08.HP-UX.B.10.20.aCC.tar.gz) |  24M |
-| IRIX.6.5.cc | [root_v4.00.08.IRIX.6.5.cc.tar.gz](https://root.cern.ch/download/root_v4.00.08.IRIX.6.5.cc.tar.gz) |  22M |
-| IRIX.6.5.gcc | [root_v4.00.08.IRIX.6.5.gcc.tar.gz](https://root.cern.ch/download/root_v4.00.08.IRIX.6.5.gcc.tar.gz) |  27M |
-| IRIX.6.5.kcc | [root_v4.00.08.IRIX.6.5.kcc.tar.gz](https://root.cern.ch/download/root_v4.00.08.IRIX.6.5.kcc.tar.gz) |  20M |
-| Linux RHEL3.linuxia64ecc | [root_v4.00.08.Linux-RHEL3.linuxia64ecc.tar.gz](https://root.cern.ch/download/root_v4.00.08.Linux-RHEL3.linuxia64ecc.tar.gz) |  32M |
-| Linux RHEL3.linuxia64gcc | [root_v4.00.08.Linux-RHEL3.linuxia64gcc.tar.gz](https://root.cern.ch/download/root_v4.00.08.Linux-RHEL3.linuxia64gcc.tar.gz) |  19M |
-| Linux.linuxx8664gcc | [root_v4.00.08.Linux.linuxx8664gcc.tar.gz](https://root.cern.ch/download/root_v4.00.08.Linux.linuxx8664gcc.tar.gz) |  16M |
-| Linux.RH6.1.gcc2952 | [root_v4.00.08.Linux.RH6.1.gcc2952.tar.gz](https://root.cern.ch/download/root_v4.00.08.Linux.RH6.1.gcc2952.tar.gz) |  19M |
-| Linux.RH7.3 scl3.gcc3.2.3 | [root_v4.00.08.Linux.RH7.3-scl3.gcc3.2.3.tar.gz](https://root.cern.ch/download/root_v4.00.08.Linux.RH7.3-scl3.gcc3.2.3.tar.gz) |  16M |
-| Linux.RH7.3 slc3.gcc3.2.3 | [root_v4.00.08.Linux.RH7.3-slc3.gcc3.2.3.tar.gz](https://root.cern.ch/download/root_v4.00.08.Linux.RH7.3-slc3.gcc3.2.3.tar.gz) |  16M |
-| Linux.RH7.3.gcc32 | [root_v4.00.08.Linux.RH7.3.gcc32.tar.gz](https://root.cern.ch/download/root_v4.00.08.Linux.RH7.3.gcc32.tar.gz) |  22M |
-| Linux.RH7.3.gcc296 | [root_v4.00.08.Linux.RH7.3.gcc296.tar.gz](https://root.cern.ch/download/root_v4.00.08.Linux.RH7.3.gcc296.tar.gz) |  32M |
-| Linux.RH7.3.gcc2952 | [root_v4.00.08.Linux.RH7.3.gcc2952.tar.gz](https://root.cern.ch/download/root_v4.00.08.Linux.RH7.3.gcc2952.tar.gz) |  21M |
-| Linux.RH7.3.gcc2953 | [root_v4.00.08.Linux.RH7.3.gcc2953.tar.gz](https://root.cern.ch/download/root_v4.00.08.Linux.RH7.3.gcc2953.tar.gz) |  23M |
-| Linux.RH9.0.gcc32 | [root_v4.00.08.Linux.RH9.0.gcc32.tar.gz](https://root.cern.ch/download/root_v4.00.08.Linux.RH9.0.gcc32.tar.gz) |  17M |
-| Linux.RH9.icc8 | [root_v4.00.08.Linux.RH9.icc8.tar.gz](https://root.cern.ch/download/root_v4.00.08.Linux.RH9.icc8.tar.gz) |  21M |
-| OSF1.V4.0.cxx6 | [root_v4.00.08.OSF1.V4.0.cxx6.tar.gz](https://root.cern.ch/download/root_v4.00.08.OSF1.V4.0.cxx6.tar.gz) |  22M |
-| OSF1.V4.0 | [root_v4.00.08.OSF1.V4.0.tar.gz](https://root.cern.ch/download/root_v4.00.08.OSF1.V4.0.tar.gz) |  25M |
-| OSF1.V5.1.cxx6 | [root_v4.00.08.OSF1.V5.1.cxx6.tar.gz](https://root.cern.ch/download/root_v4.00.08.OSF1.V5.1.cxx6.tar.gz) |  21M |
-| SunOS.5.7 | [root_v4.00.08.SunOS.5.7.tar.gz](https://root.cern.ch/download/root_v4.00.08.SunOS.5.7.tar.gz) |  25M |
-| SunOS.5.8 | [root_v4.00.08.SunOS.5.8.tar.gz](https://root.cern.ch/download/root_v4.00.08.SunOS.5.8.tar.gz) |  23M |
-| win32 | [root_v4.00.08.win32.tar.gz](https://root.cern.ch/download/root_v4.00.08.win32.tar.gz) |  20M |
-| win32gdk (dbg) | [root_v4.00.08.win32gdk.debug.tar.gz](https://root.cern.ch/download/root_v4.00.08.win32gdk.debug.tar.gz) |  32M |
-| win32gdk | [root_v4.00.08.win32gdk.tar.gz](https://root.cern.ch/download/root_v4.00.08.win32gdk.tar.gz) |  19M |
+| AIX.5 | [root_v4.00.08.AIX.5.tar.gz](https://root.cern/download/root_v4.00.08.AIX.5.tar.gz) |  23M |
+| Darwin.7.4.0 | [root_v4.00.08.Darwin.7.4.0.tar.gz](https://root.cern/download/root_v4.00.08.Darwin.7.4.0.tar.gz) |  35M |
+| HP UX.B.10.20.aCC | [root_v4.00.08.HP-UX.B.10.20.aCC.tar.gz](https://root.cern/download/root_v4.00.08.HP-UX.B.10.20.aCC.tar.gz) |  24M |
+| IRIX.6.5.cc | [root_v4.00.08.IRIX.6.5.cc.tar.gz](https://root.cern/download/root_v4.00.08.IRIX.6.5.cc.tar.gz) |  22M |
+| IRIX.6.5.gcc | [root_v4.00.08.IRIX.6.5.gcc.tar.gz](https://root.cern/download/root_v4.00.08.IRIX.6.5.gcc.tar.gz) |  27M |
+| IRIX.6.5.kcc | [root_v4.00.08.IRIX.6.5.kcc.tar.gz](https://root.cern/download/root_v4.00.08.IRIX.6.5.kcc.tar.gz) |  20M |
+| Linux RHEL3.linuxia64ecc | [root_v4.00.08.Linux-RHEL3.linuxia64ecc.tar.gz](https://root.cern/download/root_v4.00.08.Linux-RHEL3.linuxia64ecc.tar.gz) |  32M |
+| Linux RHEL3.linuxia64gcc | [root_v4.00.08.Linux-RHEL3.linuxia64gcc.tar.gz](https://root.cern/download/root_v4.00.08.Linux-RHEL3.linuxia64gcc.tar.gz) |  19M |
+| Linux.linuxx8664gcc | [root_v4.00.08.Linux.linuxx8664gcc.tar.gz](https://root.cern/download/root_v4.00.08.Linux.linuxx8664gcc.tar.gz) |  16M |
+| Linux.RH6.1.gcc2952 | [root_v4.00.08.Linux.RH6.1.gcc2952.tar.gz](https://root.cern/download/root_v4.00.08.Linux.RH6.1.gcc2952.tar.gz) |  19M |
+| Linux.RH7.3 scl3.gcc3.2.3 | [root_v4.00.08.Linux.RH7.3-scl3.gcc3.2.3.tar.gz](https://root.cern/download/root_v4.00.08.Linux.RH7.3-scl3.gcc3.2.3.tar.gz) |  16M |
+| Linux.RH7.3 slc3.gcc3.2.3 | [root_v4.00.08.Linux.RH7.3-slc3.gcc3.2.3.tar.gz](https://root.cern/download/root_v4.00.08.Linux.RH7.3-slc3.gcc3.2.3.tar.gz) |  16M |
+| Linux.RH7.3.gcc32 | [root_v4.00.08.Linux.RH7.3.gcc32.tar.gz](https://root.cern/download/root_v4.00.08.Linux.RH7.3.gcc32.tar.gz) |  22M |
+| Linux.RH7.3.gcc296 | [root_v4.00.08.Linux.RH7.3.gcc296.tar.gz](https://root.cern/download/root_v4.00.08.Linux.RH7.3.gcc296.tar.gz) |  32M |
+| Linux.RH7.3.gcc2952 | [root_v4.00.08.Linux.RH7.3.gcc2952.tar.gz](https://root.cern/download/root_v4.00.08.Linux.RH7.3.gcc2952.tar.gz) |  21M |
+| Linux.RH7.3.gcc2953 | [root_v4.00.08.Linux.RH7.3.gcc2953.tar.gz](https://root.cern/download/root_v4.00.08.Linux.RH7.3.gcc2953.tar.gz) |  23M |
+| Linux.RH9.0.gcc32 | [root_v4.00.08.Linux.RH9.0.gcc32.tar.gz](https://root.cern/download/root_v4.00.08.Linux.RH9.0.gcc32.tar.gz) |  17M |
+| Linux.RH9.icc8 | [root_v4.00.08.Linux.RH9.icc8.tar.gz](https://root.cern/download/root_v4.00.08.Linux.RH9.icc8.tar.gz) |  21M |
+| OSF1.V4.0.cxx6 | [root_v4.00.08.OSF1.V4.0.cxx6.tar.gz](https://root.cern/download/root_v4.00.08.OSF1.V4.0.cxx6.tar.gz) |  22M |
+| OSF1.V4.0 | [root_v4.00.08.OSF1.V4.0.tar.gz](https://root.cern/download/root_v4.00.08.OSF1.V4.0.tar.gz) |  25M |
+| OSF1.V5.1.cxx6 | [root_v4.00.08.OSF1.V5.1.cxx6.tar.gz](https://root.cern/download/root_v4.00.08.OSF1.V5.1.cxx6.tar.gz) |  21M |
+| SunOS.5.7 | [root_v4.00.08.SunOS.5.7.tar.gz](https://root.cern/download/root_v4.00.08.SunOS.5.7.tar.gz) |  25M |
+| SunOS.5.8 | [root_v4.00.08.SunOS.5.8.tar.gz](https://root.cern/download/root_v4.00.08.SunOS.5.8.tar.gz) |  23M |
+| win32 | [root_v4.00.08.win32.tar.gz](https://root.cern/download/root_v4.00.08.win32.tar.gz) |  20M |
+| win32gdk (dbg) | [root_v4.00.08.win32gdk.debug.tar.gz](https://root.cern/download/root_v4.00.08.win32gdk.debug.tar.gz) |  32M |
+| win32gdk | [root_v4.00.08.win32gdk.tar.gz](https://root.cern/download/root_v4.00.08.win32gdk.tar.gz) |  19M |
 
 
 ## Git

--- a/_releases/release-40102.md
+++ b/_releases/release-40102.md
@@ -15,37 +15,37 @@ sidebar:
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v4.01.02.source.tar.gz](https://root.cern.ch/download/root_v4.01.02.source.tar.gz) |  11M |
+| source | [root_v4.01.02.source.tar.gz](https://root.cern/download/root_v4.01.02.source.tar.gz) |  11M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| AIX.5 | [root_v4.01.02.AIX.5.tar.gz](https://root.cern.ch/download/root_v4.01.02.AIX.5.tar.gz) |  24M |
-| Darwin.7.5.0 | [root_v4.01.02.Darwin.7.5.0.tar.gz](https://root.cern.ch/download/root_v4.01.02.Darwin.7.5.0.tar.gz) |  37M |
-| HP UX.B.10.20.aCC | [root_v4.01.02.HP-UX.B.10.20.aCC.tar.gz](https://root.cern.ch/download/root_v4.01.02.HP-UX.B.10.20.aCC.tar.gz) |  25M |
-| IRIX.6.5.cc | [root_v4.01.02.IRIX.6.5.cc.tar.gz](https://root.cern.ch/download/root_v4.01.02.IRIX.6.5.cc.tar.gz) |  23M |
-| IRIX.6.5.gcc | [root_v4.01.02.IRIX.6.5.gcc.tar.gz](https://root.cern.ch/download/root_v4.01.02.IRIX.6.5.gcc.tar.gz) |  28M |
-| IRIX.6.5.kcc | [root_v4.01.02.IRIX.6.5.kcc.tar.gz](https://root.cern.ch/download/root_v4.01.02.IRIX.6.5.kcc.tar.gz) |  21M |
-| Linux RHEL3.linuxia64ecc | [root_v4.01.02.Linux-RHEL3.linuxia64ecc.tar.gz](https://root.cern.ch/download/root_v4.01.02.Linux-RHEL3.linuxia64ecc.tar.gz) |  35M |
-| Linux RHEL3.linuxia64gcc | [root_v4.01.02.Linux-RHEL3.linuxia64gcc.tar.gz](https://root.cern.ch/download/root_v4.01.02.Linux-RHEL3.linuxia64gcc.tar.gz) |  21M |
-| Linux.linuxx8664gcc | [root_v4.01.02.Linux.linuxx8664gcc.tar.gz](https://root.cern.ch/download/root_v4.01.02.Linux.linuxx8664gcc.tar.gz) |  17M |
-| Linux.RH6.1.gcc2952 | [root_v4.01.02.Linux.RH6.1.gcc2952.tar.gz](https://root.cern.ch/download/root_v4.01.02.Linux.RH6.1.gcc2952.tar.gz) |  20M |
-| Linux.RH7.3 slc3.gcc3.2.3 | [root_v4.01.02.Linux.RH7.3-slc3.gcc3.2.3.tar.gz](https://root.cern.ch/download/root_v4.01.02.Linux.RH7.3-slc3.gcc3.2.3.tar.gz) |  20M |
-| Linux.RH7.3.gcc32 | [root_v4.01.02.Linux.RH7.3.gcc32.tar.gz](https://root.cern.ch/download/root_v4.01.02.Linux.RH7.3.gcc32.tar.gz) |  22M |
-| Linux.RH7.3.gcc296 | [root_v4.01.02.Linux.RH7.3.gcc296.tar.gz](https://root.cern.ch/download/root_v4.01.02.Linux.RH7.3.gcc296.tar.gz) |  25M |
-| Linux.RH7.3.gcc2952 | [root_v4.01.02.Linux.RH7.3.gcc2952.tar.gz](https://root.cern.ch/download/root_v4.01.02.Linux.RH7.3.gcc2952.tar.gz) |  22M |
-| Linux.RH7.3.gcc2953 | [root_v4.01.02.Linux.RH7.3.gcc2953.tar.gz](https://root.cern.ch/download/root_v4.01.02.Linux.RH7.3.gcc2953.tar.gz) |  25M |
-| Linux.RH9.0.gcc32 | [root_v4.01.02.Linux.RH9.0.gcc32.tar.gz](https://root.cern.ch/download/root_v4.01.02.Linux.RH9.0.gcc32.tar.gz) |  19M |
-| Linux.RH9.icc8 | [root_v4.01.02.Linux.RH9.icc8.tar.gz](https://root.cern.ch/download/root_v4.01.02.Linux.RH9.icc8.tar.gz) |  21M |
-| OSF1.V4.0.cxx6 | [root_v4.01.02.OSF1.V4.0.cxx6.tar.gz](https://root.cern.ch/download/root_v4.01.02.OSF1.V4.0.cxx6.tar.gz) |  24M |
-| OSF1.V5.1.cxx6 | [root_v4.01.02.OSF1.V5.1.cxx6.tar.gz](https://root.cern.ch/download/root_v4.01.02.OSF1.V5.1.cxx6.tar.gz) |  22M |
-| SunOS.5.7 | [root_v4.01.02.SunOS.5.7.tar.gz](https://root.cern.ch/download/root_v4.01.02.SunOS.5.7.tar.gz) |  27M |
-| SunOS.5.8 | [root_v4.01.02.SunOS.5.8.tar.gz](https://root.cern.ch/download/root_v4.01.02.SunOS.5.8.tar.gz) |  24M |
-| win32gcc | [root_v4.01.02.win32gcc.tar.gz](https://root.cern.ch/download/root_v4.01.02.win32gcc.tar.gz) |  20M |
-| win32gdk (dbg) | [root_v4.01.02.win32gdk.debug.tar.gz](https://root.cern.ch/download/root_v4.01.02.win32gdk.debug.tar.gz) |  33M |
-| win32gdk | [root_v4.01.02.win32gdk.tar.gz](https://root.cern.ch/download/root_v4.01.02.win32gdk.tar.gz) |  22M |
+| AIX.5 | [root_v4.01.02.AIX.5.tar.gz](https://root.cern/download/root_v4.01.02.AIX.5.tar.gz) |  24M |
+| Darwin.7.5.0 | [root_v4.01.02.Darwin.7.5.0.tar.gz](https://root.cern/download/root_v4.01.02.Darwin.7.5.0.tar.gz) |  37M |
+| HP UX.B.10.20.aCC | [root_v4.01.02.HP-UX.B.10.20.aCC.tar.gz](https://root.cern/download/root_v4.01.02.HP-UX.B.10.20.aCC.tar.gz) |  25M |
+| IRIX.6.5.cc | [root_v4.01.02.IRIX.6.5.cc.tar.gz](https://root.cern/download/root_v4.01.02.IRIX.6.5.cc.tar.gz) |  23M |
+| IRIX.6.5.gcc | [root_v4.01.02.IRIX.6.5.gcc.tar.gz](https://root.cern/download/root_v4.01.02.IRIX.6.5.gcc.tar.gz) |  28M |
+| IRIX.6.5.kcc | [root_v4.01.02.IRIX.6.5.kcc.tar.gz](https://root.cern/download/root_v4.01.02.IRIX.6.5.kcc.tar.gz) |  21M |
+| Linux RHEL3.linuxia64ecc | [root_v4.01.02.Linux-RHEL3.linuxia64ecc.tar.gz](https://root.cern/download/root_v4.01.02.Linux-RHEL3.linuxia64ecc.tar.gz) |  35M |
+| Linux RHEL3.linuxia64gcc | [root_v4.01.02.Linux-RHEL3.linuxia64gcc.tar.gz](https://root.cern/download/root_v4.01.02.Linux-RHEL3.linuxia64gcc.tar.gz) |  21M |
+| Linux.linuxx8664gcc | [root_v4.01.02.Linux.linuxx8664gcc.tar.gz](https://root.cern/download/root_v4.01.02.Linux.linuxx8664gcc.tar.gz) |  17M |
+| Linux.RH6.1.gcc2952 | [root_v4.01.02.Linux.RH6.1.gcc2952.tar.gz](https://root.cern/download/root_v4.01.02.Linux.RH6.1.gcc2952.tar.gz) |  20M |
+| Linux.RH7.3 slc3.gcc3.2.3 | [root_v4.01.02.Linux.RH7.3-slc3.gcc3.2.3.tar.gz](https://root.cern/download/root_v4.01.02.Linux.RH7.3-slc3.gcc3.2.3.tar.gz) |  20M |
+| Linux.RH7.3.gcc32 | [root_v4.01.02.Linux.RH7.3.gcc32.tar.gz](https://root.cern/download/root_v4.01.02.Linux.RH7.3.gcc32.tar.gz) |  22M |
+| Linux.RH7.3.gcc296 | [root_v4.01.02.Linux.RH7.3.gcc296.tar.gz](https://root.cern/download/root_v4.01.02.Linux.RH7.3.gcc296.tar.gz) |  25M |
+| Linux.RH7.3.gcc2952 | [root_v4.01.02.Linux.RH7.3.gcc2952.tar.gz](https://root.cern/download/root_v4.01.02.Linux.RH7.3.gcc2952.tar.gz) |  22M |
+| Linux.RH7.3.gcc2953 | [root_v4.01.02.Linux.RH7.3.gcc2953.tar.gz](https://root.cern/download/root_v4.01.02.Linux.RH7.3.gcc2953.tar.gz) |  25M |
+| Linux.RH9.0.gcc32 | [root_v4.01.02.Linux.RH9.0.gcc32.tar.gz](https://root.cern/download/root_v4.01.02.Linux.RH9.0.gcc32.tar.gz) |  19M |
+| Linux.RH9.icc8 | [root_v4.01.02.Linux.RH9.icc8.tar.gz](https://root.cern/download/root_v4.01.02.Linux.RH9.icc8.tar.gz) |  21M |
+| OSF1.V4.0.cxx6 | [root_v4.01.02.OSF1.V4.0.cxx6.tar.gz](https://root.cern/download/root_v4.01.02.OSF1.V4.0.cxx6.tar.gz) |  24M |
+| OSF1.V5.1.cxx6 | [root_v4.01.02.OSF1.V5.1.cxx6.tar.gz](https://root.cern/download/root_v4.01.02.OSF1.V5.1.cxx6.tar.gz) |  22M |
+| SunOS.5.7 | [root_v4.01.02.SunOS.5.7.tar.gz](https://root.cern/download/root_v4.01.02.SunOS.5.7.tar.gz) |  27M |
+| SunOS.5.8 | [root_v4.01.02.SunOS.5.8.tar.gz](https://root.cern/download/root_v4.01.02.SunOS.5.8.tar.gz) |  24M |
+| win32gcc | [root_v4.01.02.win32gcc.tar.gz](https://root.cern/download/root_v4.01.02.win32gcc.tar.gz) |  20M |
+| win32gdk (dbg) | [root_v4.01.02.win32gdk.debug.tar.gz](https://root.cern/download/root_v4.01.02.win32gdk.debug.tar.gz) |  33M |
+| win32gdk | [root_v4.01.02.win32gdk.tar.gz](https://root.cern/download/root_v4.01.02.win32gdk.tar.gz) |  22M |
 
 
 ## Git

--- a/_releases/release-40104.md
+++ b/_releases/release-40104.md
@@ -15,35 +15,35 @@ sidebar:
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v4.01.04.source.tar.gz](https://root.cern.ch/download/root_v4.01.04.source.tar.gz) |  12M |
-| root_v4.01.04a.source | [root_v4.01.04a.source.tar.gz](https://root.cern.ch/download/root_v4.01.04a.source.tar.gz) |  12M |
+| source | [root_v4.01.04.source.tar.gz](https://root.cern/download/root_v4.01.04.source.tar.gz) |  12M |
+| root_v4.01.04a.source | [root_v4.01.04a.source.tar.gz](https://root.cern/download/root_v4.01.04a.source.tar.gz) |  12M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| AIX.5 | [root_v4.01.04.AIX.5.tar.gz](https://root.cern.ch/download/root_v4.01.04.AIX.5.tar.gz) |  24M |
-| Darwin.7.6.0 | [root_v4.01.04.Darwin.7.6.0.tar.gz](https://root.cern.ch/download/root_v4.01.04.Darwin.7.6.0.tar.gz) |  40M |
-| Linux RHEL3.linuxia64ecc | [root_v4.01.04.Linux-RHEL3.linuxia64ecc.tar.gz](https://root.cern.ch/download/root_v4.01.04.Linux-RHEL3.linuxia64ecc.tar.gz) |  41M |
-| Linux RHEL3.linuxia64gcc | [root_v4.01.04.Linux-RHEL3.linuxia64gcc.tar.gz](https://root.cern.ch/download/root_v4.01.04.Linux-RHEL3.linuxia64gcc.tar.gz) |  25M |
-| Linux.FedoraCore2.gcc3.3.3 | [root_v4.01.04.Linux.FedoraCore2.gcc3.3.3.tar.gz](https://root.cern.ch/download/root_v4.01.04.Linux.FedoraCore2.gcc3.3.3.tar.gz) |  21M |
-| Linux.linuxx8664gcc | [root_v4.01.04.Linux.linuxx8664gcc.tar.gz](https://root.cern.ch/download/root_v4.01.04.Linux.linuxx8664gcc.tar.gz) |  19M |
-| Linux.RH6.1.gcc2952 | [root_v4.01.04.Linux.RH6.1.gcc2952.tar.gz](https://root.cern.ch/download/root_v4.01.04.Linux.RH6.1.gcc2952.tar.gz) |  20M |
-| Linux.RH7.3 slc3.gcc3.2.3 | [root_v4.01.04.Linux.RH7.3-slc3.gcc3.2.3.tar.gz](https://root.cern.ch/download/root_v4.01.04.Linux.RH7.3-slc3.gcc3.2.3.tar.gz) |  20M |
-| Linux.RH7.3.gcc32 | [root_v4.01.04.Linux.RH7.3.gcc32.tar.gz](https://root.cern.ch/download/root_v4.01.04.Linux.RH7.3.gcc32.tar.gz) |  24M |
-| Linux.RH7.3.gcc296 | [root_v4.01.04.Linux.RH7.3.gcc296.tar.gz](https://root.cern.ch/download/root_v4.01.04.Linux.RH7.3.gcc296.tar.gz) |  26M |
-| Linux.RH7.3.gcc2952 | [root_v4.01.04.Linux.RH7.3.gcc2952.tar.gz](https://root.cern.ch/download/root_v4.01.04.Linux.RH7.3.gcc2952.tar.gz) |  25M |
-| Linux.RH7.3.gcc2953 | [root_v4.01.04.Linux.RH7.3.gcc2953.tar.gz](https://root.cern.ch/download/root_v4.01.04.Linux.RH7.3.gcc2953.tar.gz) |  26M |
-| Linux.RH9.0.gcc32 | [root_v4.01.04.Linux.RH9.0.gcc32.tar.gz](https://root.cern.ch/download/root_v4.01.04.Linux.RH9.0.gcc32.tar.gz) |  19M |
-| Linux.RH9.icc8 | [root_v4.01.04.Linux.RH9.icc8.tar.gz](https://root.cern.ch/download/root_v4.01.04.Linux.RH9.icc8.tar.gz) |  27M |
-| OSF1.V4.0.cxx6 | [root_v4.01.04.OSF1.V4.0.cxx6.tar.gz](https://root.cern.ch/download/root_v4.01.04.OSF1.V4.0.cxx6.tar.gz) |  23M |
-| OSF1.V5.1.cxx6 | [root_v4.01.04.OSF1.V5.1.cxx6.tar.gz](https://root.cern.ch/download/root_v4.01.04.OSF1.V5.1.cxx6.tar.gz) |  23M |
-| SunOS.5.7 | [root_v4.01.04.SunOS.5.7.tar.gz](https://root.cern.ch/download/root_v4.01.04.SunOS.5.7.tar.gz) |  26M |
-| SunOS.5.8 | [root_v4.01.04.SunOS.5.8.tar.gz](https://root.cern.ch/download/root_v4.01.04.SunOS.5.8.tar.gz) |  25M |
-| win32gcc | [root_v4.01.04.win32gcc.tar.gz](https://root.cern.ch/download/root_v4.01.04.win32gcc.tar.gz) |  25M |
-| win32gdk (dbg) | [root_v4.01.04.win32gdk.debug.tar.gz](https://root.cern.ch/download/root_v4.01.04.win32gdk.debug.tar.gz) |  42M |
-| win32gdk | [root_v4.01.04.win32gdk.tar.gz](https://root.cern.ch/download/root_v4.01.04.win32gdk.tar.gz) |  23M |
+| AIX.5 | [root_v4.01.04.AIX.5.tar.gz](https://root.cern/download/root_v4.01.04.AIX.5.tar.gz) |  24M |
+| Darwin.7.6.0 | [root_v4.01.04.Darwin.7.6.0.tar.gz](https://root.cern/download/root_v4.01.04.Darwin.7.6.0.tar.gz) |  40M |
+| Linux RHEL3.linuxia64ecc | [root_v4.01.04.Linux-RHEL3.linuxia64ecc.tar.gz](https://root.cern/download/root_v4.01.04.Linux-RHEL3.linuxia64ecc.tar.gz) |  41M |
+| Linux RHEL3.linuxia64gcc | [root_v4.01.04.Linux-RHEL3.linuxia64gcc.tar.gz](https://root.cern/download/root_v4.01.04.Linux-RHEL3.linuxia64gcc.tar.gz) |  25M |
+| Linux.FedoraCore2.gcc3.3.3 | [root_v4.01.04.Linux.FedoraCore2.gcc3.3.3.tar.gz](https://root.cern/download/root_v4.01.04.Linux.FedoraCore2.gcc3.3.3.tar.gz) |  21M |
+| Linux.linuxx8664gcc | [root_v4.01.04.Linux.linuxx8664gcc.tar.gz](https://root.cern/download/root_v4.01.04.Linux.linuxx8664gcc.tar.gz) |  19M |
+| Linux.RH6.1.gcc2952 | [root_v4.01.04.Linux.RH6.1.gcc2952.tar.gz](https://root.cern/download/root_v4.01.04.Linux.RH6.1.gcc2952.tar.gz) |  20M |
+| Linux.RH7.3 slc3.gcc3.2.3 | [root_v4.01.04.Linux.RH7.3-slc3.gcc3.2.3.tar.gz](https://root.cern/download/root_v4.01.04.Linux.RH7.3-slc3.gcc3.2.3.tar.gz) |  20M |
+| Linux.RH7.3.gcc32 | [root_v4.01.04.Linux.RH7.3.gcc32.tar.gz](https://root.cern/download/root_v4.01.04.Linux.RH7.3.gcc32.tar.gz) |  24M |
+| Linux.RH7.3.gcc296 | [root_v4.01.04.Linux.RH7.3.gcc296.tar.gz](https://root.cern/download/root_v4.01.04.Linux.RH7.3.gcc296.tar.gz) |  26M |
+| Linux.RH7.3.gcc2952 | [root_v4.01.04.Linux.RH7.3.gcc2952.tar.gz](https://root.cern/download/root_v4.01.04.Linux.RH7.3.gcc2952.tar.gz) |  25M |
+| Linux.RH7.3.gcc2953 | [root_v4.01.04.Linux.RH7.3.gcc2953.tar.gz](https://root.cern/download/root_v4.01.04.Linux.RH7.3.gcc2953.tar.gz) |  26M |
+| Linux.RH9.0.gcc32 | [root_v4.01.04.Linux.RH9.0.gcc32.tar.gz](https://root.cern/download/root_v4.01.04.Linux.RH9.0.gcc32.tar.gz) |  19M |
+| Linux.RH9.icc8 | [root_v4.01.04.Linux.RH9.icc8.tar.gz](https://root.cern/download/root_v4.01.04.Linux.RH9.icc8.tar.gz) |  27M |
+| OSF1.V4.0.cxx6 | [root_v4.01.04.OSF1.V4.0.cxx6.tar.gz](https://root.cern/download/root_v4.01.04.OSF1.V4.0.cxx6.tar.gz) |  23M |
+| OSF1.V5.1.cxx6 | [root_v4.01.04.OSF1.V5.1.cxx6.tar.gz](https://root.cern/download/root_v4.01.04.OSF1.V5.1.cxx6.tar.gz) |  23M |
+| SunOS.5.7 | [root_v4.01.04.SunOS.5.7.tar.gz](https://root.cern/download/root_v4.01.04.SunOS.5.7.tar.gz) |  26M |
+| SunOS.5.8 | [root_v4.01.04.SunOS.5.8.tar.gz](https://root.cern/download/root_v4.01.04.SunOS.5.8.tar.gz) |  25M |
+| win32gcc | [root_v4.01.04.win32gcc.tar.gz](https://root.cern/download/root_v4.01.04.win32gcc.tar.gz) |  25M |
+| win32gdk (dbg) | [root_v4.01.04.win32gdk.debug.tar.gz](https://root.cern/download/root_v4.01.04.win32gdk.debug.tar.gz) |  42M |
+| win32gdk | [root_v4.01.04.win32gdk.tar.gz](https://root.cern/download/root_v4.01.04.win32gdk.tar.gz) |  23M |
 
 
 ## Git

--- a/_releases/release-40200.md
+++ b/_releases/release-40200.md
@@ -15,34 +15,34 @@ sidebar:
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v4.02.00.source.tar.gz](https://root.cern.ch/download/root_v4.02.00.source.tar.gz) |  12M |
+| source | [root_v4.02.00.source.tar.gz](https://root.cern/download/root_v4.02.00.source.tar.gz) |  12M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| AIX.5 | [root_v4.02.00.AIX.5.tar.gz](https://root.cern.ch/download/root_v4.02.00.AIX.5.tar.gz) |  25M |
-| Darwin.7.6.0 | [root_v4.02.00.Darwin.7.6.0.tar.gz](https://root.cern.ch/download/root_v4.02.00.Darwin.7.6.0.tar.gz) |  41M |
-| Linux RHEL3.linuxia64gcc | [root_v4.02.00.Linux-RHEL3.linuxia64gcc.tar.gz](https://root.cern.ch/download/root_v4.02.00.Linux-RHEL3.linuxia64gcc.tar.gz) |  23M |
-| Linux.FedoraCore2.gcc3.3.3 | [root_v4.02.00.Linux.FedoraCore2.gcc3.3.3.tar.gz](https://root.cern.ch/download/root_v4.02.00.Linux.FedoraCore2.gcc3.3.3.tar.gz) |  22M |
-| Linux.linuxx8664gcc | [root_v4.02.00.Linux.linuxx8664gcc.tar.gz](https://root.cern.ch/download/root_v4.02.00.Linux.linuxx8664gcc.tar.gz) |  19M |
-| Linux.RH6.1.gcc2952 | [root_v4.02.00.Linux.RH6.1.gcc2952.tar.gz](https://root.cern.ch/download/root_v4.02.00.Linux.RH6.1.gcc2952.tar.gz) |  21M |
-| Linux.RH7.3 slc3.gcc3.2.3 | [root_v4.02.00.Linux.RH7.3-slc3.gcc3.2.3.tar.gz](https://root.cern.ch/download/root_v4.02.00.Linux.RH7.3-slc3.gcc3.2.3.tar.gz) |  20M |
-| Linux.RH7.3.gcc32 | [root_v4.02.00.Linux.RH7.3.gcc32.tar.gz](https://root.cern.ch/download/root_v4.02.00.Linux.RH7.3.gcc32.tar.gz) |  24M |
-| Linux.RH7.3.gcc296 | [root_v4.02.00.Linux.RH7.3.gcc296.tar.gz](https://root.cern.ch/download/root_v4.02.00.Linux.RH7.3.gcc296.tar.gz) |  26M |
-| Linux.RH7.3.gcc2952 | [root_v4.02.00.Linux.RH7.3.gcc2952.tar.gz](https://root.cern.ch/download/root_v4.02.00.Linux.RH7.3.gcc2952.tar.gz) |  25M |
-| Linux.RH7.3.gcc2953 | [root_v4.02.00.Linux.RH7.3.gcc2953.tar.gz](https://root.cern.ch/download/root_v4.02.00.Linux.RH7.3.gcc2953.tar.gz) |  26M |
-| Linux.RH9.0.gcc32 | [root_v4.02.00.Linux.RH9.0.gcc32.tar.gz](https://root.cern.ch/download/root_v4.02.00.Linux.RH9.0.gcc32.tar.gz) |  20M |
-| Linux.RH9.icc8 | [root_v4.02.00.Linux.RH9.icc8.tar.gz](https://root.cern.ch/download/root_v4.02.00.Linux.RH9.icc8.tar.gz) |  26M |
-| OSF1.V4.0.cxx6 | [root_v4.02.00.OSF1.V4.0.cxx6.tar.gz](https://root.cern.ch/download/root_v4.02.00.OSF1.V4.0.cxx6.tar.gz) |  24M |
-| OSF1.V5.1.cxx6 | [root_v4.02.00.OSF1.V5.1.cxx6.tar.gz](https://root.cern.ch/download/root_v4.02.00.OSF1.V5.1.cxx6.tar.gz) |  24M |
-| SunOS.5.7 | [root_v4.02.00.SunOS.5.7.tar.gz](https://root.cern.ch/download/root_v4.02.00.SunOS.5.7.tar.gz) |  28M |
-| SunOS.5.8 | [root_v4.02.00.SunOS.5.8.tar.gz](https://root.cern.ch/download/root_v4.02.00.SunOS.5.8.tar.gz) |  26M |
-| win32gcc | [root_v4.02.00.win32gcc.tar.gz](https://root.cern.ch/download/root_v4.02.00.win32gcc.tar.gz) |  27M |
-| win32gdk (dbg) | [root_v4.02.00.win32gdk.debug.tar.gz](https://root.cern.ch/download/root_v4.02.00.win32gdk.debug.tar.gz) |  43M |
-| win32gdk | [root_v4.02.00.win32gdk.tar.gz](https://root.cern.ch/download/root_v4.02.00.win32gdk.tar.gz) |  23M |
-| root_v4.02.00a.Linux.RH7.3 slc3.gcc3.2.3 | [root_v4.02.00a.Linux.RH7.3-slc3.gcc3.2.3.tar.gz](https://root.cern.ch/download/root_v4.02.00a.Linux.RH7.3-slc3.gcc3.2.3.tar.gz) |  18M |
+| AIX.5 | [root_v4.02.00.AIX.5.tar.gz](https://root.cern/download/root_v4.02.00.AIX.5.tar.gz) |  25M |
+| Darwin.7.6.0 | [root_v4.02.00.Darwin.7.6.0.tar.gz](https://root.cern/download/root_v4.02.00.Darwin.7.6.0.tar.gz) |  41M |
+| Linux RHEL3.linuxia64gcc | [root_v4.02.00.Linux-RHEL3.linuxia64gcc.tar.gz](https://root.cern/download/root_v4.02.00.Linux-RHEL3.linuxia64gcc.tar.gz) |  23M |
+| Linux.FedoraCore2.gcc3.3.3 | [root_v4.02.00.Linux.FedoraCore2.gcc3.3.3.tar.gz](https://root.cern/download/root_v4.02.00.Linux.FedoraCore2.gcc3.3.3.tar.gz) |  22M |
+| Linux.linuxx8664gcc | [root_v4.02.00.Linux.linuxx8664gcc.tar.gz](https://root.cern/download/root_v4.02.00.Linux.linuxx8664gcc.tar.gz) |  19M |
+| Linux.RH6.1.gcc2952 | [root_v4.02.00.Linux.RH6.1.gcc2952.tar.gz](https://root.cern/download/root_v4.02.00.Linux.RH6.1.gcc2952.tar.gz) |  21M |
+| Linux.RH7.3 slc3.gcc3.2.3 | [root_v4.02.00.Linux.RH7.3-slc3.gcc3.2.3.tar.gz](https://root.cern/download/root_v4.02.00.Linux.RH7.3-slc3.gcc3.2.3.tar.gz) |  20M |
+| Linux.RH7.3.gcc32 | [root_v4.02.00.Linux.RH7.3.gcc32.tar.gz](https://root.cern/download/root_v4.02.00.Linux.RH7.3.gcc32.tar.gz) |  24M |
+| Linux.RH7.3.gcc296 | [root_v4.02.00.Linux.RH7.3.gcc296.tar.gz](https://root.cern/download/root_v4.02.00.Linux.RH7.3.gcc296.tar.gz) |  26M |
+| Linux.RH7.3.gcc2952 | [root_v4.02.00.Linux.RH7.3.gcc2952.tar.gz](https://root.cern/download/root_v4.02.00.Linux.RH7.3.gcc2952.tar.gz) |  25M |
+| Linux.RH7.3.gcc2953 | [root_v4.02.00.Linux.RH7.3.gcc2953.tar.gz](https://root.cern/download/root_v4.02.00.Linux.RH7.3.gcc2953.tar.gz) |  26M |
+| Linux.RH9.0.gcc32 | [root_v4.02.00.Linux.RH9.0.gcc32.tar.gz](https://root.cern/download/root_v4.02.00.Linux.RH9.0.gcc32.tar.gz) |  20M |
+| Linux.RH9.icc8 | [root_v4.02.00.Linux.RH9.icc8.tar.gz](https://root.cern/download/root_v4.02.00.Linux.RH9.icc8.tar.gz) |  26M |
+| OSF1.V4.0.cxx6 | [root_v4.02.00.OSF1.V4.0.cxx6.tar.gz](https://root.cern/download/root_v4.02.00.OSF1.V4.0.cxx6.tar.gz) |  24M |
+| OSF1.V5.1.cxx6 | [root_v4.02.00.OSF1.V5.1.cxx6.tar.gz](https://root.cern/download/root_v4.02.00.OSF1.V5.1.cxx6.tar.gz) |  24M |
+| SunOS.5.7 | [root_v4.02.00.SunOS.5.7.tar.gz](https://root.cern/download/root_v4.02.00.SunOS.5.7.tar.gz) |  28M |
+| SunOS.5.8 | [root_v4.02.00.SunOS.5.8.tar.gz](https://root.cern/download/root_v4.02.00.SunOS.5.8.tar.gz) |  26M |
+| win32gcc | [root_v4.02.00.win32gcc.tar.gz](https://root.cern/download/root_v4.02.00.win32gcc.tar.gz) |  27M |
+| win32gdk (dbg) | [root_v4.02.00.win32gdk.debug.tar.gz](https://root.cern/download/root_v4.02.00.win32gdk.debug.tar.gz) |  43M |
+| win32gdk | [root_v4.02.00.win32gdk.tar.gz](https://root.cern/download/root_v4.02.00.win32gdk.tar.gz) |  23M |
+| root_v4.02.00a.Linux.RH7.3 slc3.gcc3.2.3 | [root_v4.02.00a.Linux.RH7.3-slc3.gcc3.2.3.tar.gz](https://root.cern/download/root_v4.02.00a.Linux.RH7.3-slc3.gcc3.2.3.tar.gz) |  18M |
 
 
 ## Git

--- a/_releases/release-40302.md
+++ b/_releases/release-40302.md
@@ -15,26 +15,26 @@ sidebar:
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v4.03.02.source.tar.gz](https://root.cern.ch/download/root_v4.03.02.source.tar.gz) |  13M |
+| source | [root_v4.03.02.source.tar.gz](https://root.cern/download/root_v4.03.02.source.tar.gz) |  13M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| AIX.5 | [root_v4.03.02.AIX.5.tar.gz](https://root.cern.ch/download/root_v4.03.02.AIX.5.tar.gz) |  25M |
-| Linux.FedoraCore2.gcc3.3.3 | [root_v4.03.02.Linux.FedoraCore2.gcc3.3.3.tar.gz](https://root.cern.ch/download/root_v4.03.02.Linux.FedoraCore2.gcc3.3.3.tar.gz) |  21M |
-| Linux.RH6.1.gcc2952 | [root_v4.03.02.Linux.RH6.1.gcc2952.tar.gz](https://root.cern.ch/download/root_v4.03.02.Linux.RH6.1.gcc2952.tar.gz) |  20M |
-| Linux.RH7.3.gcc32 | [root_v4.03.02.Linux.RH7.3.gcc32.tar.gz](https://root.cern.ch/download/root_v4.03.02.Linux.RH7.3.gcc32.tar.gz) |  23M |
-| Linux.RH9.0.gcc32 | [root_v4.03.02.Linux.RH9.0.gcc32.tar.gz](https://root.cern.ch/download/root_v4.03.02.Linux.RH9.0.gcc32.tar.gz) |  20M |
-| Linux.slc3.gcc3.2.3 | [root_v4.03.02.Linux.slc3.gcc3.2.3.tar.gz](https://root.cern.ch/download/root_v4.03.02.Linux.slc3.gcc3.2.3.tar.gz) |  18M |
-| OSF1.V4.0.cxx6 | [root_v4.03.02.OSF1.V4.0.cxx6.tar.gz](https://root.cern.ch/download/root_v4.03.02.OSF1.V4.0.cxx6.tar.gz) |  22M |
-| OSF1.V5.1.cxx6 | [root_v4.03.02.OSF1.V5.1.cxx6.tar.gz](https://root.cern.ch/download/root_v4.03.02.OSF1.V5.1.cxx6.tar.gz) |  24M |
-| SunOS.5.7 | [root_v4.03.02.SunOS.5.7.tar.gz](https://root.cern.ch/download/root_v4.03.02.SunOS.5.7.tar.gz) |  26M |
-| SunOS.5.8 | [root_v4.03.02.SunOS.5.8.tar.gz](https://root.cern.ch/download/root_v4.03.02.SunOS.5.8.tar.gz) |  24M |
-| win32gcc | [root_v4.03.02.win32gcc.tar.gz](https://root.cern.ch/download/root_v4.03.02.win32gcc.tar.gz) |  25M |
-| win32gdk (dbg) | [root_v4.03.02.win32gdk.debug.tar.gz](https://root.cern.ch/download/root_v4.03.02.win32gdk.debug.tar.gz) |  36M |
-| win32gdk | [root_v4.03.02.win32gdk.tar.gz](https://root.cern.ch/download/root_v4.03.02.win32gdk.tar.gz) |  23M |
+| AIX.5 | [root_v4.03.02.AIX.5.tar.gz](https://root.cern/download/root_v4.03.02.AIX.5.tar.gz) |  25M |
+| Linux.FedoraCore2.gcc3.3.3 | [root_v4.03.02.Linux.FedoraCore2.gcc3.3.3.tar.gz](https://root.cern/download/root_v4.03.02.Linux.FedoraCore2.gcc3.3.3.tar.gz) |  21M |
+| Linux.RH6.1.gcc2952 | [root_v4.03.02.Linux.RH6.1.gcc2952.tar.gz](https://root.cern/download/root_v4.03.02.Linux.RH6.1.gcc2952.tar.gz) |  20M |
+| Linux.RH7.3.gcc32 | [root_v4.03.02.Linux.RH7.3.gcc32.tar.gz](https://root.cern/download/root_v4.03.02.Linux.RH7.3.gcc32.tar.gz) |  23M |
+| Linux.RH9.0.gcc32 | [root_v4.03.02.Linux.RH9.0.gcc32.tar.gz](https://root.cern/download/root_v4.03.02.Linux.RH9.0.gcc32.tar.gz) |  20M |
+| Linux.slc3.gcc3.2.3 | [root_v4.03.02.Linux.slc3.gcc3.2.3.tar.gz](https://root.cern/download/root_v4.03.02.Linux.slc3.gcc3.2.3.tar.gz) |  18M |
+| OSF1.V4.0.cxx6 | [root_v4.03.02.OSF1.V4.0.cxx6.tar.gz](https://root.cern/download/root_v4.03.02.OSF1.V4.0.cxx6.tar.gz) |  22M |
+| OSF1.V5.1.cxx6 | [root_v4.03.02.OSF1.V5.1.cxx6.tar.gz](https://root.cern/download/root_v4.03.02.OSF1.V5.1.cxx6.tar.gz) |  24M |
+| SunOS.5.7 | [root_v4.03.02.SunOS.5.7.tar.gz](https://root.cern/download/root_v4.03.02.SunOS.5.7.tar.gz) |  26M |
+| SunOS.5.8 | [root_v4.03.02.SunOS.5.8.tar.gz](https://root.cern/download/root_v4.03.02.SunOS.5.8.tar.gz) |  24M |
+| win32gcc | [root_v4.03.02.win32gcc.tar.gz](https://root.cern/download/root_v4.03.02.win32gcc.tar.gz) |  25M |
+| win32gdk (dbg) | [root_v4.03.02.win32gdk.debug.tar.gz](https://root.cern/download/root_v4.03.02.win32gdk.debug.tar.gz) |  36M |
+| win32gdk | [root_v4.03.02.win32gdk.tar.gz](https://root.cern/download/root_v4.03.02.win32gdk.tar.gz) |  23M |
 
 
 ## Git

--- a/_releases/release-40304.md
+++ b/_releases/release-40304.md
@@ -15,31 +15,31 @@ sidebar:
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v4.03.04.source.tar.gz](https://root.cern.ch/download/root_v4.03.04.source.tar.gz) |  13M |
+| source | [root_v4.03.04.source.tar.gz](https://root.cern/download/root_v4.03.04.source.tar.gz) |  13M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| AIX.5 | [root_v4.03.04.AIX.5.tar.gz](https://root.cern.ch/download/root_v4.03.04.AIX.5.tar.gz) |  25M |
-| Darwin.7.8.0 | [root_v4.03.04.Darwin.7.8.0.tar.gz](https://root.cern.ch/download/root_v4.03.04.Darwin.7.8.0.tar.gz) |  42M |
-| Linux.FedoraCore2.gcc3.3.3 | [root_v4.03.04.Linux.FedoraCore2.gcc3.3.3.tar.gz](https://root.cern.ch/download/root_v4.03.04.Linux.FedoraCore2.gcc3.3.3.tar.gz) |  21M |
-| Linux.linuxx8664gcc | [root_v4.03.04.Linux.linuxx8664gcc.tar.gz](https://root.cern.ch/download/root_v4.03.04.Linux.linuxx8664gcc.tar.gz) |  20M |
-| Linux.RH6.1.gcc2952 | [root_v4.03.04.Linux.RH6.1.gcc2952.tar.gz](https://root.cern.ch/download/root_v4.03.04.Linux.RH6.1.gcc2952.tar.gz) |  21M |
-| Linux.RH7.3.gcc32 | [root_v4.03.04.Linux.RH7.3.gcc32.tar.gz](https://root.cern.ch/download/root_v4.03.04.Linux.RH7.3.gcc32.tar.gz) |  24M |
-| Linux.RH7.3.gcc2952 | [root_v4.03.04.Linux.RH7.3.gcc2952.tar.gz](https://root.cern.ch/download/root_v4.03.04.Linux.RH7.3.gcc2952.tar.gz) |  24M |
-| Linux.RH9.0.gcc32 | [root_v4.03.04.Linux.RH9.0.gcc32.tar.gz](https://root.cern.ch/download/root_v4.03.04.Linux.RH9.0.gcc32.tar.gz) |  21M |
-| Linux.RH9.icc81 | [root_v4.03.04.Linux.RH9.icc81.tar.gz](https://root.cern.ch/download/root_v4.03.04.Linux.RH9.icc81.tar.gz) |  31M |
-| Linux.slc3.gcc3.2.3 | [root_v4.03.04.Linux.slc3.gcc3.2.3.tar.gz](https://root.cern.ch/download/root_v4.03.04.Linux.slc3.gcc3.2.3.tar.gz) |  21M |
-| Linux.slc3.gcc3.4.3 | [root_v4.03.04.Linux.slc3.gcc3.4.3.tar.gz](https://root.cern.ch/download/root_v4.03.04.Linux.slc3.gcc3.4.3.tar.gz) |  22M |
-| OSF1.V4.0.cxx6 | [root_v4.03.04.OSF1.V4.0.cxx6.tar.gz](https://root.cern.ch/download/root_v4.03.04.OSF1.V4.0.cxx6.tar.gz) |  25M |
-| OSF1.V5.1.cxx6 | [root_v4.03.04.OSF1.V5.1.cxx6.tar.gz](https://root.cern.ch/download/root_v4.03.04.OSF1.V5.1.cxx6.tar.gz) |  25M |
-| SunOS.5.7 | [root_v4.03.04.SunOS.5.7.tar.gz](https://root.cern.ch/download/root_v4.03.04.SunOS.5.7.tar.gz) |  28M |
-| SunOS.5.8 | [root_v4.03.04.SunOS.5.8.tar.gz](https://root.cern.ch/download/root_v4.03.04.SunOS.5.8.tar.gz) |  25M |
-| win32gcc | [root_v4.03.04.win32gcc.tar.gz](https://root.cern.ch/download/root_v4.03.04.win32gcc.tar.gz) |  25M |
-| win32gdk (dbg) | [root_v4.03.04.win32gdk.debug.tar.gz](https://root.cern.ch/download/root_v4.03.04.win32gdk.debug.tar.gz) |  48M |
-| win32gdk | [root_v4.03.04.win32gdk.tar.gz](https://root.cern.ch/download/root_v4.03.04.win32gdk.tar.gz) |  26M |
+| AIX.5 | [root_v4.03.04.AIX.5.tar.gz](https://root.cern/download/root_v4.03.04.AIX.5.tar.gz) |  25M |
+| Darwin.7.8.0 | [root_v4.03.04.Darwin.7.8.0.tar.gz](https://root.cern/download/root_v4.03.04.Darwin.7.8.0.tar.gz) |  42M |
+| Linux.FedoraCore2.gcc3.3.3 | [root_v4.03.04.Linux.FedoraCore2.gcc3.3.3.tar.gz](https://root.cern/download/root_v4.03.04.Linux.FedoraCore2.gcc3.3.3.tar.gz) |  21M |
+| Linux.linuxx8664gcc | [root_v4.03.04.Linux.linuxx8664gcc.tar.gz](https://root.cern/download/root_v4.03.04.Linux.linuxx8664gcc.tar.gz) |  20M |
+| Linux.RH6.1.gcc2952 | [root_v4.03.04.Linux.RH6.1.gcc2952.tar.gz](https://root.cern/download/root_v4.03.04.Linux.RH6.1.gcc2952.tar.gz) |  21M |
+| Linux.RH7.3.gcc32 | [root_v4.03.04.Linux.RH7.3.gcc32.tar.gz](https://root.cern/download/root_v4.03.04.Linux.RH7.3.gcc32.tar.gz) |  24M |
+| Linux.RH7.3.gcc2952 | [root_v4.03.04.Linux.RH7.3.gcc2952.tar.gz](https://root.cern/download/root_v4.03.04.Linux.RH7.3.gcc2952.tar.gz) |  24M |
+| Linux.RH9.0.gcc32 | [root_v4.03.04.Linux.RH9.0.gcc32.tar.gz](https://root.cern/download/root_v4.03.04.Linux.RH9.0.gcc32.tar.gz) |  21M |
+| Linux.RH9.icc81 | [root_v4.03.04.Linux.RH9.icc81.tar.gz](https://root.cern/download/root_v4.03.04.Linux.RH9.icc81.tar.gz) |  31M |
+| Linux.slc3.gcc3.2.3 | [root_v4.03.04.Linux.slc3.gcc3.2.3.tar.gz](https://root.cern/download/root_v4.03.04.Linux.slc3.gcc3.2.3.tar.gz) |  21M |
+| Linux.slc3.gcc3.4.3 | [root_v4.03.04.Linux.slc3.gcc3.4.3.tar.gz](https://root.cern/download/root_v4.03.04.Linux.slc3.gcc3.4.3.tar.gz) |  22M |
+| OSF1.V4.0.cxx6 | [root_v4.03.04.OSF1.V4.0.cxx6.tar.gz](https://root.cern/download/root_v4.03.04.OSF1.V4.0.cxx6.tar.gz) |  25M |
+| OSF1.V5.1.cxx6 | [root_v4.03.04.OSF1.V5.1.cxx6.tar.gz](https://root.cern/download/root_v4.03.04.OSF1.V5.1.cxx6.tar.gz) |  25M |
+| SunOS.5.7 | [root_v4.03.04.SunOS.5.7.tar.gz](https://root.cern/download/root_v4.03.04.SunOS.5.7.tar.gz) |  28M |
+| SunOS.5.8 | [root_v4.03.04.SunOS.5.8.tar.gz](https://root.cern/download/root_v4.03.04.SunOS.5.8.tar.gz) |  25M |
+| win32gcc | [root_v4.03.04.win32gcc.tar.gz](https://root.cern/download/root_v4.03.04.win32gcc.tar.gz) |  25M |
+| win32gdk (dbg) | [root_v4.03.04.win32gdk.debug.tar.gz](https://root.cern/download/root_v4.03.04.win32gdk.debug.tar.gz) |  48M |
+| win32gdk | [root_v4.03.04.win32gdk.tar.gz](https://root.cern/download/root_v4.03.04.win32gdk.tar.gz) |  26M |
 
 
 ## Git

--- a/_releases/release-40402.md
+++ b/_releases/release-40402.md
@@ -15,41 +15,41 @@ sidebar:
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v4.04.02.source.tar.gz](https://root.cern.ch/download/root_v4.04.02.source.tar.gz) |  13M |
-| root_v4.04.02b.source | [root_v4.04.02b.source.tar.gz](https://root.cern.ch/download/root_v4.04.02b.source.tar.gz) |  13M |
-| root_v4.04.02c.source | [root_v4.04.02c.source.tar.gz](https://root.cern.ch/download/root_v4.04.02c.source.tar.gz) |  13M |
-| root_v4.04.02d.source | [root_v4.04.02d.source.tar.gz](https://root.cern.ch/download/root_v4.04.02d.source.tar.gz) |  13M |
-| root_v4.04.02e.source | [root_v4.04.02e.source.tar.gz](https://root.cern.ch/download/root_v4.04.02e.source.tar.gz) |  13M |
-| root_v4.04.02f.source | [root_v4.04.02f.source.tar.gz](https://root.cern.ch/download/root_v4.04.02f.source.tar.gz) |  13M |
-| root_v4.04.02g.source | [root_v4.04.02g.source.tar.gz](https://root.cern.ch/download/root_v4.04.02g.source.tar.gz) |  13M |
+| source | [root_v4.04.02.source.tar.gz](https://root.cern/download/root_v4.04.02.source.tar.gz) |  13M |
+| root_v4.04.02b.source | [root_v4.04.02b.source.tar.gz](https://root.cern/download/root_v4.04.02b.source.tar.gz) |  13M |
+| root_v4.04.02c.source | [root_v4.04.02c.source.tar.gz](https://root.cern/download/root_v4.04.02c.source.tar.gz) |  13M |
+| root_v4.04.02d.source | [root_v4.04.02d.source.tar.gz](https://root.cern/download/root_v4.04.02d.source.tar.gz) |  13M |
+| root_v4.04.02e.source | [root_v4.04.02e.source.tar.gz](https://root.cern/download/root_v4.04.02e.source.tar.gz) |  13M |
+| root_v4.04.02f.source | [root_v4.04.02f.source.tar.gz](https://root.cern/download/root_v4.04.02f.source.tar.gz) |  13M |
+| root_v4.04.02g.source | [root_v4.04.02g.source.tar.gz](https://root.cern/download/root_v4.04.02g.source.tar.gz) |  13M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| AIX.5 | [root_v4.04.02.AIX.5.tar.gz](https://root.cern.ch/download/root_v4.04.02.AIX.5.tar.gz) |  27M |
-| Darwin.7.9.0 | [root_v4.04.02.Darwin.7.9.0.tar.gz](https://root.cern.ch/download/root_v4.04.02.Darwin.7.9.0.tar.gz) |  43M |
-| Darwin.8.0.0 | [root_v4.04.02.Darwin.8.0.0.tar.gz](https://root.cern.ch/download/root_v4.04.02.Darwin.8.0.0.tar.gz) |  18M |
-| hpuxia64acc | [root_v4.04.02.hpuxia64acc.tar.gz](https://root.cern.ch/download/root_v4.04.02.hpuxia64acc.tar.gz) |  49M |
-| Linux RHEL3.linuxia64ecc | [root_v4.04.02.Linux-RHEL3.linuxia64ecc.tar.gz](https://root.cern.ch/download/root_v4.04.02.Linux-RHEL3.linuxia64ecc.tar.gz) |  41M |
-| Linux RHEL3.linuxia64gcc | [root_v4.04.02.Linux-RHEL3.linuxia64gcc.tar.gz](https://root.cern.ch/download/root_v4.04.02.Linux-RHEL3.linuxia64gcc.tar.gz) |  25M |
-| Linux.FedoraCore2.gcc3.3.3 | [root_v4.04.02.Linux.FedoraCore2.gcc3.3.3.tar.gz](https://root.cern.ch/download/root_v4.04.02.Linux.FedoraCore2.gcc3.3.3.tar.gz) |  22M |
-| Linux.linuxppc64 | [root_v4.04.02.Linux.linuxppc64.tar.gz](https://root.cern.ch/download/root_v4.04.02.Linux.linuxppc64.tar.gz) |  22M |
-| Linux.linuxx8664gcc | [root_v4.04.02.Linux.linuxx8664gcc.tar.gz](https://root.cern.ch/download/root_v4.04.02.Linux.linuxx8664gcc.tar.gz) |  22M |
-| Linux.RH6.1.gcc2952 | [root_v4.04.02.Linux.RH6.1.gcc2952.tar.gz](https://root.cern.ch/download/root_v4.04.02.Linux.RH6.1.gcc2952.tar.gz) |  22M |
-| Linux.RH7.3.gcc32 | [root_v4.04.02.Linux.RH7.3.gcc32.tar.gz](https://root.cern.ch/download/root_v4.04.02.Linux.RH7.3.gcc32.tar.gz) |  25M |
-| Linux.RH7.3.gcc2952 | [root_v4.04.02.Linux.RH7.3.gcc2952.tar.gz](https://root.cern.ch/download/root_v4.04.02.Linux.RH7.3.gcc2952.tar.gz) |  25M |
-| Linux.RH9.0.gcc32 | [root_v4.04.02.Linux.RH9.0.gcc32.tar.gz](https://root.cern.ch/download/root_v4.04.02.Linux.RH9.0.gcc32.tar.gz) |  23M |
-| Linux.RH9.icc81 | [root_v4.04.02.Linux.RH9.icc81.tar.gz](https://root.cern.ch/download/root_v4.04.02.Linux.RH9.icc81.tar.gz) |  31M |
-| Linux.slc3.gcc3.2.3 | [root_v4.04.02.Linux.slc3.gcc3.2.3.tar.gz](https://root.cern.ch/download/root_v4.04.02.Linux.slc3.gcc3.2.3.tar.gz) |  21M |
-| Linux.slc3.gcc3.4.3 | [root_v4.04.02.Linux.slc3.gcc3.4.3.tar.gz](https://root.cern.ch/download/root_v4.04.02.Linux.slc3.gcc3.4.3.tar.gz) |  22M |
-| OSF1.V5.1.cxx6 | [root_v4.04.02.OSF1.V5.1.cxx6.tar.gz](https://root.cern.ch/download/root_v4.04.02.OSF1.V5.1.cxx6.tar.gz) |  26M |
-| SunOS.5.7 | [root_v4.04.02.SunOS.5.7.tar.gz](https://root.cern.ch/download/root_v4.04.02.SunOS.5.7.tar.gz) |  28M |
-| SunOS.5.8 | [root_v4.04.02.SunOS.5.8.tar.gz](https://root.cern.ch/download/root_v4.04.02.SunOS.5.8.tar.gz) |  26M |
-| win32gcc | [root_v4.04.02.win32gcc.tar.gz](https://root.cern.ch/download/root_v4.04.02.win32gcc.tar.gz) |  25M |
-| win32gdk (dbg) | [root_v4.04.02.win32gdk.debug.tar.gz](https://root.cern.ch/download/root_v4.04.02.win32gdk.debug.tar.gz) |  49M |
-| win32gdk | [root_v4.04.02.win32gdk.tar.gz](https://root.cern.ch/download/root_v4.04.02.win32gdk.tar.gz) |  26M |
+| AIX.5 | [root_v4.04.02.AIX.5.tar.gz](https://root.cern/download/root_v4.04.02.AIX.5.tar.gz) |  27M |
+| Darwin.7.9.0 | [root_v4.04.02.Darwin.7.9.0.tar.gz](https://root.cern/download/root_v4.04.02.Darwin.7.9.0.tar.gz) |  43M |
+| Darwin.8.0.0 | [root_v4.04.02.Darwin.8.0.0.tar.gz](https://root.cern/download/root_v4.04.02.Darwin.8.0.0.tar.gz) |  18M |
+| hpuxia64acc | [root_v4.04.02.hpuxia64acc.tar.gz](https://root.cern/download/root_v4.04.02.hpuxia64acc.tar.gz) |  49M |
+| Linux RHEL3.linuxia64ecc | [root_v4.04.02.Linux-RHEL3.linuxia64ecc.tar.gz](https://root.cern/download/root_v4.04.02.Linux-RHEL3.linuxia64ecc.tar.gz) |  41M |
+| Linux RHEL3.linuxia64gcc | [root_v4.04.02.Linux-RHEL3.linuxia64gcc.tar.gz](https://root.cern/download/root_v4.04.02.Linux-RHEL3.linuxia64gcc.tar.gz) |  25M |
+| Linux.FedoraCore2.gcc3.3.3 | [root_v4.04.02.Linux.FedoraCore2.gcc3.3.3.tar.gz](https://root.cern/download/root_v4.04.02.Linux.FedoraCore2.gcc3.3.3.tar.gz) |  22M |
+| Linux.linuxppc64 | [root_v4.04.02.Linux.linuxppc64.tar.gz](https://root.cern/download/root_v4.04.02.Linux.linuxppc64.tar.gz) |  22M |
+| Linux.linuxx8664gcc | [root_v4.04.02.Linux.linuxx8664gcc.tar.gz](https://root.cern/download/root_v4.04.02.Linux.linuxx8664gcc.tar.gz) |  22M |
+| Linux.RH6.1.gcc2952 | [root_v4.04.02.Linux.RH6.1.gcc2952.tar.gz](https://root.cern/download/root_v4.04.02.Linux.RH6.1.gcc2952.tar.gz) |  22M |
+| Linux.RH7.3.gcc32 | [root_v4.04.02.Linux.RH7.3.gcc32.tar.gz](https://root.cern/download/root_v4.04.02.Linux.RH7.3.gcc32.tar.gz) |  25M |
+| Linux.RH7.3.gcc2952 | [root_v4.04.02.Linux.RH7.3.gcc2952.tar.gz](https://root.cern/download/root_v4.04.02.Linux.RH7.3.gcc2952.tar.gz) |  25M |
+| Linux.RH9.0.gcc32 | [root_v4.04.02.Linux.RH9.0.gcc32.tar.gz](https://root.cern/download/root_v4.04.02.Linux.RH9.0.gcc32.tar.gz) |  23M |
+| Linux.RH9.icc81 | [root_v4.04.02.Linux.RH9.icc81.tar.gz](https://root.cern/download/root_v4.04.02.Linux.RH9.icc81.tar.gz) |  31M |
+| Linux.slc3.gcc3.2.3 | [root_v4.04.02.Linux.slc3.gcc3.2.3.tar.gz](https://root.cern/download/root_v4.04.02.Linux.slc3.gcc3.2.3.tar.gz) |  21M |
+| Linux.slc3.gcc3.4.3 | [root_v4.04.02.Linux.slc3.gcc3.4.3.tar.gz](https://root.cern/download/root_v4.04.02.Linux.slc3.gcc3.4.3.tar.gz) |  22M |
+| OSF1.V5.1.cxx6 | [root_v4.04.02.OSF1.V5.1.cxx6.tar.gz](https://root.cern/download/root_v4.04.02.OSF1.V5.1.cxx6.tar.gz) |  26M |
+| SunOS.5.7 | [root_v4.04.02.SunOS.5.7.tar.gz](https://root.cern/download/root_v4.04.02.SunOS.5.7.tar.gz) |  28M |
+| SunOS.5.8 | [root_v4.04.02.SunOS.5.8.tar.gz](https://root.cern/download/root_v4.04.02.SunOS.5.8.tar.gz) |  26M |
+| win32gcc | [root_v4.04.02.win32gcc.tar.gz](https://root.cern/download/root_v4.04.02.win32gcc.tar.gz) |  25M |
+| win32gdk (dbg) | [root_v4.04.02.win32gdk.debug.tar.gz](https://root.cern/download/root_v4.04.02.win32gdk.debug.tar.gz) |  49M |
+| win32gdk | [root_v4.04.02.win32gdk.tar.gz](https://root.cern/download/root_v4.04.02.win32gdk.tar.gz) |  26M |
 
 
 ## Git

--- a/_releases/release-50200.md
+++ b/_releases/release-50200.md
@@ -15,26 +15,26 @@ sidebar:
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v5.02.00.source.tar.gz](https://root.cern.ch/download/root_v5.02.00.source.tar.gz) |  14M |
+| source | [root_v5.02.00.source.tar.gz](https://root.cern/download/root_v5.02.00.source.tar.gz) |  14M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| AIX.5 | [root_v5.02.00.AIX.5.tar.gz](https://root.cern.ch/download/root_v5.02.00.AIX.5.tar.gz) |  34M |
-| Linux.FedoraCore2.gcc3.3.3 | [root_v5.02.00.Linux.FedoraCore2.gcc3.3.3.tar.gz](https://root.cern.ch/download/root_v5.02.00.Linux.FedoraCore2.gcc3.3.3.tar.gz) |  26M |
-| Linux.RH6.1.gcc2952 | [root_v5.02.00.Linux.RH6.1.gcc2952.tar.gz](https://root.cern.ch/download/root_v5.02.00.Linux.RH6.1.gcc2952.tar.gz) |  23M |
-| Linux.RH7.3.gcc32 | [root_v5.02.00.Linux.RH7.3.gcc32.tar.gz](https://root.cern.ch/download/root_v5.02.00.Linux.RH7.3.gcc32.tar.gz) |  28M |
-| Linux.RH9.0.gcc32 | [root_v5.02.00.Linux.RH9.0.gcc32.tar.gz](https://root.cern.ch/download/root_v5.02.00.Linux.RH9.0.gcc32.tar.gz) |  25M |
-| Linux.slc3.gcc3.2.3 | [root_v5.02.00.Linux.slc3.gcc3.2.3.tar.gz](https://root.cern.ch/download/root_v5.02.00.Linux.slc3.gcc3.2.3.tar.gz) |  24M |
-| Linux.slc3.gcc3.4.3 | [root_v5.02.00.Linux.slc3.gcc3.4.3.tar.gz](https://root.cern.ch/download/root_v5.02.00.Linux.slc3.gcc3.4.3.tar.gz) |  27M |
-| OSF1.V5.1.cxx6 | [root_v5.02.00.OSF1.V5.1.cxx6.tar.gz](https://root.cern.ch/download/root_v5.02.00.OSF1.V5.1.cxx6.tar.gz) |  31M |
-| SunOS.5.7 | [root_v5.02.00.SunOS.5.7.tar.gz](https://root.cern.ch/download/root_v5.02.00.SunOS.5.7.tar.gz) |  33M |
-| SunOS.5.8 | [root_v5.02.00.SunOS.5.8.tar.gz](https://root.cern.ch/download/root_v5.02.00.SunOS.5.8.tar.gz) |  30M |
-| win32gcc | [root_v5.02.00.win32gcc.tar.gz](https://root.cern.ch/download/root_v5.02.00.win32gcc.tar.gz) |  28M |
-| win32gdk (dbg) | [root_v5.02.00.win32gdk.debug.tar.gz](https://root.cern.ch/download/root_v5.02.00.win32gdk.debug.tar.gz) |  56M |
-| win32gdk | [root_v5.02.00.win32gdk.tar.gz](https://root.cern.ch/download/root_v5.02.00.win32gdk.tar.gz) |  30M |
+| AIX.5 | [root_v5.02.00.AIX.5.tar.gz](https://root.cern/download/root_v5.02.00.AIX.5.tar.gz) |  34M |
+| Linux.FedoraCore2.gcc3.3.3 | [root_v5.02.00.Linux.FedoraCore2.gcc3.3.3.tar.gz](https://root.cern/download/root_v5.02.00.Linux.FedoraCore2.gcc3.3.3.tar.gz) |  26M |
+| Linux.RH6.1.gcc2952 | [root_v5.02.00.Linux.RH6.1.gcc2952.tar.gz](https://root.cern/download/root_v5.02.00.Linux.RH6.1.gcc2952.tar.gz) |  23M |
+| Linux.RH7.3.gcc32 | [root_v5.02.00.Linux.RH7.3.gcc32.tar.gz](https://root.cern/download/root_v5.02.00.Linux.RH7.3.gcc32.tar.gz) |  28M |
+| Linux.RH9.0.gcc32 | [root_v5.02.00.Linux.RH9.0.gcc32.tar.gz](https://root.cern/download/root_v5.02.00.Linux.RH9.0.gcc32.tar.gz) |  25M |
+| Linux.slc3.gcc3.2.3 | [root_v5.02.00.Linux.slc3.gcc3.2.3.tar.gz](https://root.cern/download/root_v5.02.00.Linux.slc3.gcc3.2.3.tar.gz) |  24M |
+| Linux.slc3.gcc3.4.3 | [root_v5.02.00.Linux.slc3.gcc3.4.3.tar.gz](https://root.cern/download/root_v5.02.00.Linux.slc3.gcc3.4.3.tar.gz) |  27M |
+| OSF1.V5.1.cxx6 | [root_v5.02.00.OSF1.V5.1.cxx6.tar.gz](https://root.cern/download/root_v5.02.00.OSF1.V5.1.cxx6.tar.gz) |  31M |
+| SunOS.5.7 | [root_v5.02.00.SunOS.5.7.tar.gz](https://root.cern/download/root_v5.02.00.SunOS.5.7.tar.gz) |  33M |
+| SunOS.5.8 | [root_v5.02.00.SunOS.5.8.tar.gz](https://root.cern/download/root_v5.02.00.SunOS.5.8.tar.gz) |  30M |
+| win32gcc | [root_v5.02.00.win32gcc.tar.gz](https://root.cern/download/root_v5.02.00.win32gcc.tar.gz) |  28M |
+| win32gdk (dbg) | [root_v5.02.00.win32gdk.debug.tar.gz](https://root.cern/download/root_v5.02.00.win32gdk.debug.tar.gz) |  56M |
+| win32gdk | [root_v5.02.00.win32gdk.tar.gz](https://root.cern/download/root_v5.02.00.win32gdk.tar.gz) |  30M |
 
 
 ## Git

--- a/_releases/release-50400.md
+++ b/_releases/release-50400.md
@@ -15,25 +15,25 @@ sidebar:
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v5.04.00.source.tar.gz](https://root.cern.ch/download/root_v5.04.00.source.tar.gz) |  15M |
+| source | [root_v5.04.00.source.tar.gz](https://root.cern/download/root_v5.04.00.source.tar.gz) |  15M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| AIX.5 | [root_v5.04.00.AIX.5.tar.gz](https://root.cern.ch/download/root_v5.04.00.AIX.5.tar.gz) |  37M |
-| Linux.FedoraCore2.gcc3.3.3 | [root_v5.04.00.Linux.FedoraCore2.gcc3.3.3.tar.gz](https://root.cern.ch/download/root_v5.04.00.Linux.FedoraCore2.gcc3.3.3.tar.gz) |  36M |
-| Linux.RH9.0.gcc32 | [root_v5.04.00.Linux.RH9.0.gcc32.tar.gz](https://root.cern.ch/download/root_v5.04.00.Linux.RH9.0.gcc32.tar.gz) |  28M |
-| Linux.slc3.gcc3.2.3 | [root_v5.04.00.Linux.slc3.gcc3.2.3.tar.gz](https://root.cern.ch/download/root_v5.04.00.Linux.slc3.gcc3.2.3.tar.gz) |  27M |
-| Linux.slc3.gcc3.4.3 | [root_v5.04.00.Linux.slc3.gcc3.4.3.tar.gz](https://root.cern.ch/download/root_v5.04.00.Linux.slc3.gcc3.4.3.tar.gz) |  30M |
-| macosx gcc 4.0 | [root_v5.04.00.macosx-gcc-4.0.tar.gz](https://root.cern.ch/download/root_v5.04.00.macosx-gcc-4.0.tar.gz) |  21M |
-| OSF1.V5.1.cxx6 | [root_v5.04.00.OSF1.V5.1.cxx6.tar.gz](https://root.cern.ch/download/root_v5.04.00.OSF1.V5.1.cxx6.tar.gz) |  33M |
-| SunOS.5.8 | [root_v5.04.00.SunOS.5.8.tar.gz](https://root.cern.ch/download/root_v5.04.00.SunOS.5.8.tar.gz) |  33M |
-| SunOS.5.9 | [root_v5.04.00.SunOS.5.9.tar.gz](https://root.cern.ch/download/root_v5.04.00.SunOS.5.9.tar.gz) |  29M |
-| win32gcc | [root_v5.04.00.win32gcc.tar.gz](https://root.cern.ch/download/root_v5.04.00.win32gcc.tar.gz) |  31M |
-| win32gdk (dbg) | [root_v5.04.00.win32gdk.debug.tar.gz](https://root.cern.ch/download/root_v5.04.00.win32gdk.debug.tar.gz) |  60M |
-| win32gdk | [root_v5.04.00.win32gdk.tar.gz](https://root.cern.ch/download/root_v5.04.00.win32gdk.tar.gz) |  32M |
+| AIX.5 | [root_v5.04.00.AIX.5.tar.gz](https://root.cern/download/root_v5.04.00.AIX.5.tar.gz) |  37M |
+| Linux.FedoraCore2.gcc3.3.3 | [root_v5.04.00.Linux.FedoraCore2.gcc3.3.3.tar.gz](https://root.cern/download/root_v5.04.00.Linux.FedoraCore2.gcc3.3.3.tar.gz) |  36M |
+| Linux.RH9.0.gcc32 | [root_v5.04.00.Linux.RH9.0.gcc32.tar.gz](https://root.cern/download/root_v5.04.00.Linux.RH9.0.gcc32.tar.gz) |  28M |
+| Linux.slc3.gcc3.2.3 | [root_v5.04.00.Linux.slc3.gcc3.2.3.tar.gz](https://root.cern/download/root_v5.04.00.Linux.slc3.gcc3.2.3.tar.gz) |  27M |
+| Linux.slc3.gcc3.4.3 | [root_v5.04.00.Linux.slc3.gcc3.4.3.tar.gz](https://root.cern/download/root_v5.04.00.Linux.slc3.gcc3.4.3.tar.gz) |  30M |
+| macosx gcc 4.0 | [root_v5.04.00.macosx-gcc-4.0.tar.gz](https://root.cern/download/root_v5.04.00.macosx-gcc-4.0.tar.gz) |  21M |
+| OSF1.V5.1.cxx6 | [root_v5.04.00.OSF1.V5.1.cxx6.tar.gz](https://root.cern/download/root_v5.04.00.OSF1.V5.1.cxx6.tar.gz) |  33M |
+| SunOS.5.8 | [root_v5.04.00.SunOS.5.8.tar.gz](https://root.cern/download/root_v5.04.00.SunOS.5.8.tar.gz) |  33M |
+| SunOS.5.9 | [root_v5.04.00.SunOS.5.9.tar.gz](https://root.cern/download/root_v5.04.00.SunOS.5.9.tar.gz) |  29M |
+| win32gcc | [root_v5.04.00.win32gcc.tar.gz](https://root.cern/download/root_v5.04.00.win32gcc.tar.gz) |  31M |
+| win32gdk (dbg) | [root_v5.04.00.win32gdk.debug.tar.gz](https://root.cern/download/root_v5.04.00.win32gdk.debug.tar.gz) |  60M |
+| win32gdk | [root_v5.04.00.win32gdk.tar.gz](https://root.cern/download/root_v5.04.00.win32gdk.tar.gz) |  32M |
 
 
 ## Git

--- a/_releases/release-50600.md
+++ b/_releases/release-50600.md
@@ -15,28 +15,28 @@ sidebar:
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v5.06.00.source.tar.gz](https://root.cern.ch/download/root_v5.06.00.source.tar.gz) |  16M |
+| source | [root_v5.06.00.source.tar.gz](https://root.cern/download/root_v5.06.00.source.tar.gz) |  16M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| AIX.5 | [root_v5.06.00.AIX.5.tar.gz](https://root.cern.ch/download/root_v5.06.00.AIX.5.tar.gz) |  38M |
-| hpuxia64acc | [root_v5.06.00.hpuxia64acc.tar.gz](https://root.cern.ch/download/root_v5.06.00.hpuxia64acc.tar.gz) |  56M |
-| Linux.FedoraCore2.gcc3.3.3 | [root_v5.06.00.Linux.FedoraCore2.gcc3.3.3.tar.gz](https://root.cern.ch/download/root_v5.06.00.Linux.FedoraCore2.gcc3.3.3.tar.gz) |  38M |
-| Linux.RH9.0.gcc32 | [root_v5.06.00.Linux.RH9.0.gcc32.tar.gz](https://root.cern.ch/download/root_v5.06.00.Linux.RH9.0.gcc32.tar.gz) |  30M |
-| Linux.slc3.gcc3.2.3 | [root_v5.06.00.Linux.slc3.gcc3.2.3.tar.gz](https://root.cern.ch/download/root_v5.06.00.Linux.slc3.gcc3.2.3.tar.gz) |  28M |
-| Linux.slc3.gcc3.4.3 | [root_v5.06.00.Linux.slc3.gcc3.4.3.tar.gz](https://root.cern.ch/download/root_v5.06.00.Linux.slc3.gcc3.4.3.tar.gz) |  30M |
-| linuxia64gcc gcc 3.2 | [root_v5.06.00.linuxia64gcc-gcc-3.2.tar.gz](https://root.cern.ch/download/root_v5.06.00.linuxia64gcc-gcc-3.2.tar.gz) |  28M |
-| linuxx8664gcc gcc 4.0 | [root_v5.06.00.linuxx8664gcc-gcc-4.0.tar.gz](https://root.cern.ch/download/root_v5.06.00.linuxx8664gcc-gcc-4.0.tar.gz) |  27M |
-| macosx gcc 4.0 | [root_v5.06.00.macosx-gcc-4.0.tar.gz](https://root.cern.ch/download/root_v5.06.00.macosx-gcc-4.0.tar.gz) |  22M |
-| OSF1.V5.1.cxx6 | [root_v5.06.00.OSF1.V5.1.cxx6.tar.gz](https://root.cern.ch/download/root_v5.06.00.OSF1.V5.1.cxx6.tar.gz) |  34M |
-| SunOS.5.8 | [root_v5.06.00.SunOS.5.8.tar.gz](https://root.cern.ch/download/root_v5.06.00.SunOS.5.8.tar.gz) |  33M |
-| SunOS.5.9 | [root_v5.06.00.SunOS.5.9.tar.gz](https://root.cern.ch/download/root_v5.06.00.SunOS.5.9.tar.gz) |  30M |
-| win32gcc | [root_v5.06.00.win32gcc.tar.gz](https://root.cern.ch/download/root_v5.06.00.win32gcc.tar.gz) |  33M |
-| win32gdk (dbg) | [root_v5.06.00.win32gdk.debug.tar.gz](https://root.cern.ch/download/root_v5.06.00.win32gdk.debug.tar.gz) |  61M |
-| win32gdk | [root_v5.06.00.win32gdk.tar.gz](https://root.cern.ch/download/root_v5.06.00.win32gdk.tar.gz) |  33M |
+| AIX.5 | [root_v5.06.00.AIX.5.tar.gz](https://root.cern/download/root_v5.06.00.AIX.5.tar.gz) |  38M |
+| hpuxia64acc | [root_v5.06.00.hpuxia64acc.tar.gz](https://root.cern/download/root_v5.06.00.hpuxia64acc.tar.gz) |  56M |
+| Linux.FedoraCore2.gcc3.3.3 | [root_v5.06.00.Linux.FedoraCore2.gcc3.3.3.tar.gz](https://root.cern/download/root_v5.06.00.Linux.FedoraCore2.gcc3.3.3.tar.gz) |  38M |
+| Linux.RH9.0.gcc32 | [root_v5.06.00.Linux.RH9.0.gcc32.tar.gz](https://root.cern/download/root_v5.06.00.Linux.RH9.0.gcc32.tar.gz) |  30M |
+| Linux.slc3.gcc3.2.3 | [root_v5.06.00.Linux.slc3.gcc3.2.3.tar.gz](https://root.cern/download/root_v5.06.00.Linux.slc3.gcc3.2.3.tar.gz) |  28M |
+| Linux.slc3.gcc3.4.3 | [root_v5.06.00.Linux.slc3.gcc3.4.3.tar.gz](https://root.cern/download/root_v5.06.00.Linux.slc3.gcc3.4.3.tar.gz) |  30M |
+| linuxia64gcc gcc 3.2 | [root_v5.06.00.linuxia64gcc-gcc-3.2.tar.gz](https://root.cern/download/root_v5.06.00.linuxia64gcc-gcc-3.2.tar.gz) |  28M |
+| linuxx8664gcc gcc 4.0 | [root_v5.06.00.linuxx8664gcc-gcc-4.0.tar.gz](https://root.cern/download/root_v5.06.00.linuxx8664gcc-gcc-4.0.tar.gz) |  27M |
+| macosx gcc 4.0 | [root_v5.06.00.macosx-gcc-4.0.tar.gz](https://root.cern/download/root_v5.06.00.macosx-gcc-4.0.tar.gz) |  22M |
+| OSF1.V5.1.cxx6 | [root_v5.06.00.OSF1.V5.1.cxx6.tar.gz](https://root.cern/download/root_v5.06.00.OSF1.V5.1.cxx6.tar.gz) |  34M |
+| SunOS.5.8 | [root_v5.06.00.SunOS.5.8.tar.gz](https://root.cern/download/root_v5.06.00.SunOS.5.8.tar.gz) |  33M |
+| SunOS.5.9 | [root_v5.06.00.SunOS.5.9.tar.gz](https://root.cern/download/root_v5.06.00.SunOS.5.9.tar.gz) |  30M |
+| win32gcc | [root_v5.06.00.win32gcc.tar.gz](https://root.cern/download/root_v5.06.00.win32gcc.tar.gz) |  33M |
+| win32gdk (dbg) | [root_v5.06.00.win32gdk.debug.tar.gz](https://root.cern/download/root_v5.06.00.win32gdk.debug.tar.gz) |  61M |
+| win32gdk | [root_v5.06.00.win32gdk.tar.gz](https://root.cern/download/root_v5.06.00.win32gdk.tar.gz) |  33M |
 
 
 ## Git

--- a/_releases/release-50800.md
+++ b/_releases/release-50800.md
@@ -15,28 +15,28 @@ sidebar:
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v5.08.00.source.tar.gz](https://root.cern.ch/download/root_v5.08.00.source.tar.gz) |  17M |
-| root_v5.08.00b.source | [root_v5.08.00b.source.tar.gz](https://root.cern.ch/download/root_v5.08.00b.source.tar.gz) |  17M |
+| source | [root_v5.08.00.source.tar.gz](https://root.cern/download/root_v5.08.00.source.tar.gz) |  17M |
+| root_v5.08.00b.source | [root_v5.08.00b.source.tar.gz](https://root.cern/download/root_v5.08.00b.source.tar.gz) |  17M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| AIX.5 | [root_v5.08.00.AIX.5.tar.gz](https://root.cern.ch/download/root_v5.08.00.AIX.5.tar.gz) |  36M |
-| Linux.FedoraCore2.gcc3.3.3 | [root_v5.08.00.Linux.FedoraCore2.gcc3.3.3.tar.gz](https://root.cern.ch/download/root_v5.08.00.Linux.FedoraCore2.gcc3.3.3.tar.gz) |  40M |
-| Linux.RH9.0.gcc32 | [root_v5.08.00.Linux.RH9.0.gcc32.tar.gz](https://root.cern.ch/download/root_v5.08.00.Linux.RH9.0.gcc32.tar.gz) |  37M |
-| Linux.slc3.gcc3.2.3 | [root_v5.08.00.Linux.slc3.gcc3.2.3.tar.gz](https://root.cern.ch/download/root_v5.08.00.Linux.slc3.gcc3.2.3.tar.gz) |  32M |
-| Linux.slc3.gcc3.4.3 | [root_v5.08.00.Linux.slc3.gcc3.4.3.tar.gz](https://root.cern.ch/download/root_v5.08.00.Linux.slc3.gcc3.4.3.tar.gz) |  36M |
-| linuxicc | [root_v5.08.00.linuxicc.tar.gz](https://root.cern.ch/download/root_v5.08.00.linuxicc.tar.gz) |  45M |
-| linuxx8664gcc gcc 4.0 | [root_v5.08.00.linuxx8664gcc-gcc-4.0.tar.gz](https://root.cern.ch/download/root_v5.08.00.linuxx8664gcc-gcc-4.0.tar.gz) |  29M |
-| macosx gcc 4.0 | [root_v5.08.00.macosx-gcc-4.0.tar.gz](https://root.cern.ch/download/root_v5.08.00.macosx-gcc-4.0.tar.gz) |  25M |
-| OSF1.V5.1.cxx6 | [root_v5.08.00.OSF1.V5.1.cxx6.tar.gz](https://root.cern.ch/download/root_v5.08.00.OSF1.V5.1.cxx6.tar.gz) |  36M |
-| SunOS.5.8 | [root_v5.08.00.SunOS.5.8.tar.gz](https://root.cern.ch/download/root_v5.08.00.SunOS.5.8.tar.gz) |  34M |
-| SunOS.5.9 | [root_v5.08.00.SunOS.5.9.tar.gz](https://root.cern.ch/download/root_v5.08.00.SunOS.5.9.tar.gz) |  31M |
-| win32gcc | [root_v5.08.00.win32gcc.tar.gz](https://root.cern.ch/download/root_v5.08.00.win32gcc.tar.gz) |  33M |
-| win32gdk (dbg) | [root_v5.08.00.win32gdk.debug.tar.gz](https://root.cern.ch/download/root_v5.08.00.win32gdk.debug.tar.gz) |  64M |
-| win32gdk | [root_v5.08.00.win32gdk.tar.gz](https://root.cern.ch/download/root_v5.08.00.win32gdk.tar.gz) |  35M |
+| AIX.5 | [root_v5.08.00.AIX.5.tar.gz](https://root.cern/download/root_v5.08.00.AIX.5.tar.gz) |  36M |
+| Linux.FedoraCore2.gcc3.3.3 | [root_v5.08.00.Linux.FedoraCore2.gcc3.3.3.tar.gz](https://root.cern/download/root_v5.08.00.Linux.FedoraCore2.gcc3.3.3.tar.gz) |  40M |
+| Linux.RH9.0.gcc32 | [root_v5.08.00.Linux.RH9.0.gcc32.tar.gz](https://root.cern/download/root_v5.08.00.Linux.RH9.0.gcc32.tar.gz) |  37M |
+| Linux.slc3.gcc3.2.3 | [root_v5.08.00.Linux.slc3.gcc3.2.3.tar.gz](https://root.cern/download/root_v5.08.00.Linux.slc3.gcc3.2.3.tar.gz) |  32M |
+| Linux.slc3.gcc3.4.3 | [root_v5.08.00.Linux.slc3.gcc3.4.3.tar.gz](https://root.cern/download/root_v5.08.00.Linux.slc3.gcc3.4.3.tar.gz) |  36M |
+| linuxicc | [root_v5.08.00.linuxicc.tar.gz](https://root.cern/download/root_v5.08.00.linuxicc.tar.gz) |  45M |
+| linuxx8664gcc gcc 4.0 | [root_v5.08.00.linuxx8664gcc-gcc-4.0.tar.gz](https://root.cern/download/root_v5.08.00.linuxx8664gcc-gcc-4.0.tar.gz) |  29M |
+| macosx gcc 4.0 | [root_v5.08.00.macosx-gcc-4.0.tar.gz](https://root.cern/download/root_v5.08.00.macosx-gcc-4.0.tar.gz) |  25M |
+| OSF1.V5.1.cxx6 | [root_v5.08.00.OSF1.V5.1.cxx6.tar.gz](https://root.cern/download/root_v5.08.00.OSF1.V5.1.cxx6.tar.gz) |  36M |
+| SunOS.5.8 | [root_v5.08.00.SunOS.5.8.tar.gz](https://root.cern/download/root_v5.08.00.SunOS.5.8.tar.gz) |  34M |
+| SunOS.5.9 | [root_v5.08.00.SunOS.5.9.tar.gz](https://root.cern/download/root_v5.08.00.SunOS.5.9.tar.gz) |  31M |
+| win32gcc | [root_v5.08.00.win32gcc.tar.gz](https://root.cern/download/root_v5.08.00.win32gcc.tar.gz) |  33M |
+| win32gdk (dbg) | [root_v5.08.00.win32gdk.debug.tar.gz](https://root.cern/download/root_v5.08.00.win32gdk.debug.tar.gz) |  64M |
+| win32gdk | [root_v5.08.00.win32gdk.tar.gz](https://root.cern/download/root_v5.08.00.win32gdk.tar.gz) |  35M |
 
 
 ## Git

--- a/_releases/release-51000.md
+++ b/_releases/release-51000.md
@@ -15,33 +15,33 @@ sidebar:
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v5.10.00.source.tar.gz](https://root.cern.ch/download/root_v5.10.00.source.tar.gz) |  17M |
-| root_v5.10.00a.source | [root_v5.10.00a.source.tar.gz](https://root.cern.ch/download/root_v5.10.00a.source.tar.gz) |  17M |
-| root_v5.10.00b.source | [root_v5.10.00b.source.tar.gz](https://root.cern.ch/download/root_v5.10.00b.source.tar.gz) |  17M |
-| root_v5.10.00c.source | [root_v5.10.00c.source.tar.gz](https://root.cern.ch/download/root_v5.10.00c.source.tar.gz) |  17M |
-| root_v5.10.00d.source | [root_v5.10.00d.source.tar.gz](https://root.cern.ch/download/root_v5.10.00d.source.tar.gz) |  17M |
-| root_v5.10.00e.source | [root_v5.10.00e.source.tar.gz](https://root.cern.ch/download/root_v5.10.00e.source.tar.gz) |  17M |
-| root_v5.10.00f.source | [root_v5.10.00f.source.tar.gz](https://root.cern.ch/download/root_v5.10.00f.source.tar.gz) |  17M |
+| source | [root_v5.10.00.source.tar.gz](https://root.cern/download/root_v5.10.00.source.tar.gz) |  17M |
+| root_v5.10.00a.source | [root_v5.10.00a.source.tar.gz](https://root.cern/download/root_v5.10.00a.source.tar.gz) |  17M |
+| root_v5.10.00b.source | [root_v5.10.00b.source.tar.gz](https://root.cern/download/root_v5.10.00b.source.tar.gz) |  17M |
+| root_v5.10.00c.source | [root_v5.10.00c.source.tar.gz](https://root.cern/download/root_v5.10.00c.source.tar.gz) |  17M |
+| root_v5.10.00d.source | [root_v5.10.00d.source.tar.gz](https://root.cern/download/root_v5.10.00d.source.tar.gz) |  17M |
+| root_v5.10.00e.source | [root_v5.10.00e.source.tar.gz](https://root.cern/download/root_v5.10.00e.source.tar.gz) |  17M |
+| root_v5.10.00f.source | [root_v5.10.00f.source.tar.gz](https://root.cern/download/root_v5.10.00f.source.tar.gz) |  17M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| Linux.FedoraCore3.gcc3.4.3 | [root_v5.10.00.Linux.FedoraCore3.gcc3.4.3.tar.gz](https://root.cern.ch/download/root_v5.10.00.Linux.FedoraCore3.gcc3.4.3.tar.gz) |  34M |
-| Linux.RH9.0.gcc32 | [root_v5.10.00.Linux.RH9.0.gcc32.tar.gz](https://root.cern.ch/download/root_v5.10.00.Linux.RH9.0.gcc32.tar.gz) |  38M |
-| Linux.slc3.gcc3.2.3 | [root_v5.10.00.Linux.slc3.gcc3.2.3.tar.gz](https://root.cern.ch/download/root_v5.10.00.Linux.slc3.gcc3.2.3.tar.gz) |  33M |
-| Linux.slc3.gcc3.4.3 | [root_v5.10.00.Linux.slc3.gcc3.4.3.tar.gz](https://root.cern.ch/download/root_v5.10.00.Linux.slc3.gcc3.4.3.tar.gz) |  37M |
-| Linux.slc3_amd64.gcc3.4.3 | [root_v5.10.00.Linux.slc3_amd64.gcc3.4.3.tar.gz](https://root.cern.ch/download/root_v5.10.00.Linux.slc3_amd64.gcc3.4.3.tar.gz) |  37M |
-| linuxia64gcc gcc 3.2 | [root_v5.10.00.linuxia64gcc-gcc-3.2.tar.gz](https://root.cern.ch/download/root_v5.10.00.linuxia64gcc-gcc-3.2.tar.gz) |  31M |
-| linuxicc | [root_v5.10.00.linuxicc.tar.gz](https://root.cern.ch/download/root_v5.10.00.linuxicc.tar.gz) |  45M |
-| linuxx8664gcc gcc 4.0 | [root_v5.10.00.linuxx8664gcc-gcc-4.0.tar.gz](https://root.cern.ch/download/root_v5.10.00.linuxx8664gcc-gcc-4.0.tar.gz) |  35M |
-| macosx i386 gcc 4.0 | [root_v5.10.00.macosx-i386-gcc-4.0.tar.gz](https://root.cern.ch/download/root_v5.10.00.macosx-i386-gcc-4.0.tar.gz) |  25M |
-| macosx powerpc gcc 4.0 | [root_v5.10.00.macosx-powerpc-gcc-4.0.tar.gz](https://root.cern.ch/download/root_v5.10.00.macosx-powerpc-gcc-4.0.tar.gz) |  26M |
-| SunOS.5.9 | [root_v5.10.00.SunOS.5.9.tar.gz](https://root.cern.ch/download/root_v5.10.00.SunOS.5.9.tar.gz) |  32M |
-| win32gcc | [root_v5.10.00.win32gcc.tar.gz](https://root.cern.ch/download/root_v5.10.00.win32gcc.tar.gz) |  33M |
-| win32gdk (dbg) | [root_v5.10.00.win32gdk.debug.tar.gz](https://root.cern.ch/download/root_v5.10.00.win32gdk.debug.tar.gz) |  66M |
-| win32gdk | [root_v5.10.00.win32gdk.tar.gz](https://root.cern.ch/download/root_v5.10.00.win32gdk.tar.gz) |  36M |
+| Linux.FedoraCore3.gcc3.4.3 | [root_v5.10.00.Linux.FedoraCore3.gcc3.4.3.tar.gz](https://root.cern/download/root_v5.10.00.Linux.FedoraCore3.gcc3.4.3.tar.gz) |  34M |
+| Linux.RH9.0.gcc32 | [root_v5.10.00.Linux.RH9.0.gcc32.tar.gz](https://root.cern/download/root_v5.10.00.Linux.RH9.0.gcc32.tar.gz) |  38M |
+| Linux.slc3.gcc3.2.3 | [root_v5.10.00.Linux.slc3.gcc3.2.3.tar.gz](https://root.cern/download/root_v5.10.00.Linux.slc3.gcc3.2.3.tar.gz) |  33M |
+| Linux.slc3.gcc3.4.3 | [root_v5.10.00.Linux.slc3.gcc3.4.3.tar.gz](https://root.cern/download/root_v5.10.00.Linux.slc3.gcc3.4.3.tar.gz) |  37M |
+| Linux.slc3_amd64.gcc3.4.3 | [root_v5.10.00.Linux.slc3_amd64.gcc3.4.3.tar.gz](https://root.cern/download/root_v5.10.00.Linux.slc3_amd64.gcc3.4.3.tar.gz) |  37M |
+| linuxia64gcc gcc 3.2 | [root_v5.10.00.linuxia64gcc-gcc-3.2.tar.gz](https://root.cern/download/root_v5.10.00.linuxia64gcc-gcc-3.2.tar.gz) |  31M |
+| linuxicc | [root_v5.10.00.linuxicc.tar.gz](https://root.cern/download/root_v5.10.00.linuxicc.tar.gz) |  45M |
+| linuxx8664gcc gcc 4.0 | [root_v5.10.00.linuxx8664gcc-gcc-4.0.tar.gz](https://root.cern/download/root_v5.10.00.linuxx8664gcc-gcc-4.0.tar.gz) |  35M |
+| macosx i386 gcc 4.0 | [root_v5.10.00.macosx-i386-gcc-4.0.tar.gz](https://root.cern/download/root_v5.10.00.macosx-i386-gcc-4.0.tar.gz) |  25M |
+| macosx powerpc gcc 4.0 | [root_v5.10.00.macosx-powerpc-gcc-4.0.tar.gz](https://root.cern/download/root_v5.10.00.macosx-powerpc-gcc-4.0.tar.gz) |  26M |
+| SunOS.5.9 | [root_v5.10.00.SunOS.5.9.tar.gz](https://root.cern/download/root_v5.10.00.SunOS.5.9.tar.gz) |  32M |
+| win32gcc | [root_v5.10.00.win32gcc.tar.gz](https://root.cern/download/root_v5.10.00.win32gcc.tar.gz) |  33M |
+| win32gdk (dbg) | [root_v5.10.00.win32gdk.debug.tar.gz](https://root.cern/download/root_v5.10.00.win32gdk.debug.tar.gz) |  66M |
+| win32gdk | [root_v5.10.00.win32gdk.tar.gz](https://root.cern/download/root_v5.10.00.win32gdk.tar.gz) |  36M |
 
 
 ## Git

--- a/_releases/release-51102.md
+++ b/_releases/release-51102.md
@@ -15,27 +15,27 @@ sidebar:
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v5.11.02.source.tar.gz](https://root.cern.ch/download/root_v5.11.02.source.tar.gz) |  18M |
+| source | [root_v5.11.02.source.tar.gz](https://root.cern/download/root_v5.11.02.source.tar.gz) |  18M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| Linux.FedoraCore3.gcc3.4.3 | [root_v5.11.02.Linux.FedoraCore3.gcc3.4.3.tar.gz](https://root.cern.ch/download/root_v5.11.02.Linux.FedoraCore3.gcc3.4.3.tar.gz) |  34M |
-| Linux.RH9.0.gcc32 | [root_v5.11.02.Linux.RH9.0.gcc32.tar.gz](https://root.cern.ch/download/root_v5.11.02.Linux.RH9.0.gcc32.tar.gz) |  37M |
-| Linux.slc3.gcc3.2.3 | [root_v5.11.02.Linux.slc3.gcc3.2.3.tar.gz](https://root.cern.ch/download/root_v5.11.02.Linux.slc3.gcc3.2.3.tar.gz) |  33M |
-| Linux.slc3_amd64.gcc3.4.3 | [root_v5.11.02.Linux.slc3_amd64.gcc3.4.3.tar.gz](https://root.cern.ch/download/root_v5.11.02.Linux.slc3_amd64.gcc3.4.3.tar.gz) |  38M |
-| Linux.slc4.gcc3.4 | [root_v5.11.02.Linux.slc4.gcc3.4.tar.gz](https://root.cern.ch/download/root_v5.11.02.Linux.slc4.gcc3.4.tar.gz) |  32M |
-| Linux.slc4_amd64.gcc3.4 | [root_v5.11.02.Linux.slc4_amd64.gcc3.4.tar.gz](https://root.cern.ch/download/root_v5.11.02.Linux.slc4_amd64.gcc3.4.tar.gz) |  32M |
-| linuxx8664gcc gcc 4.0 | [root_v5.11.02.linuxx8664gcc-gcc-4.0.tar.gz](https://root.cern.ch/download/root_v5.11.02.linuxx8664gcc-gcc-4.0.tar.gz) |  37M |
-| macosx i386 gcc 4.0 | [root_v5.11.02.macosx-i386-gcc-4.0.tar.gz](https://root.cern.ch/download/root_v5.11.02.macosx-i386-gcc-4.0.tar.gz) |  42M |
-| macosx i386 icc 9.1 | [root_v5.11.02.macosx-i386-icc-9.1.tar.gz](https://root.cern.ch/download/root_v5.11.02.macosx-i386-icc-9.1.tar.gz) |  58M |
-| macosx powerpc gcc 4.0 | [root_v5.11.02.macosx-powerpc-gcc-4.0.tar.gz](https://root.cern.ch/download/root_v5.11.02.macosx-powerpc-gcc-4.0.tar.gz) |  29M |
-| SunOS.5.9 | [root_v5.11.02.SunOS.5.9.tar.gz](https://root.cern.ch/download/root_v5.11.02.SunOS.5.9.tar.gz) |  33M |
-| win32gcc | [root_v5.11.02.win32gcc.tar.gz](https://root.cern.ch/download/root_v5.11.02.win32gcc.tar.gz) |  34M |
-| win32gdk (dbg) | [root_v5.11.02.win32gdk.debug.tar.gz](https://root.cern.ch/download/root_v5.11.02.win32gdk.debug.tar.gz) |  69M |
-| win32gdk | [root_v5.11.02.win32gdk.tar.gz](https://root.cern.ch/download/root_v5.11.02.win32gdk.tar.gz) |  37M |
+| Linux.FedoraCore3.gcc3.4.3 | [root_v5.11.02.Linux.FedoraCore3.gcc3.4.3.tar.gz](https://root.cern/download/root_v5.11.02.Linux.FedoraCore3.gcc3.4.3.tar.gz) |  34M |
+| Linux.RH9.0.gcc32 | [root_v5.11.02.Linux.RH9.0.gcc32.tar.gz](https://root.cern/download/root_v5.11.02.Linux.RH9.0.gcc32.tar.gz) |  37M |
+| Linux.slc3.gcc3.2.3 | [root_v5.11.02.Linux.slc3.gcc3.2.3.tar.gz](https://root.cern/download/root_v5.11.02.Linux.slc3.gcc3.2.3.tar.gz) |  33M |
+| Linux.slc3_amd64.gcc3.4.3 | [root_v5.11.02.Linux.slc3_amd64.gcc3.4.3.tar.gz](https://root.cern/download/root_v5.11.02.Linux.slc3_amd64.gcc3.4.3.tar.gz) |  38M |
+| Linux.slc4.gcc3.4 | [root_v5.11.02.Linux.slc4.gcc3.4.tar.gz](https://root.cern/download/root_v5.11.02.Linux.slc4.gcc3.4.tar.gz) |  32M |
+| Linux.slc4_amd64.gcc3.4 | [root_v5.11.02.Linux.slc4_amd64.gcc3.4.tar.gz](https://root.cern/download/root_v5.11.02.Linux.slc4_amd64.gcc3.4.tar.gz) |  32M |
+| linuxx8664gcc gcc 4.0 | [root_v5.11.02.linuxx8664gcc-gcc-4.0.tar.gz](https://root.cern/download/root_v5.11.02.linuxx8664gcc-gcc-4.0.tar.gz) |  37M |
+| macosx i386 gcc 4.0 | [root_v5.11.02.macosx-i386-gcc-4.0.tar.gz](https://root.cern/download/root_v5.11.02.macosx-i386-gcc-4.0.tar.gz) |  42M |
+| macosx i386 icc 9.1 | [root_v5.11.02.macosx-i386-icc-9.1.tar.gz](https://root.cern/download/root_v5.11.02.macosx-i386-icc-9.1.tar.gz) |  58M |
+| macosx powerpc gcc 4.0 | [root_v5.11.02.macosx-powerpc-gcc-4.0.tar.gz](https://root.cern/download/root_v5.11.02.macosx-powerpc-gcc-4.0.tar.gz) |  29M |
+| SunOS.5.9 | [root_v5.11.02.SunOS.5.9.tar.gz](https://root.cern/download/root_v5.11.02.SunOS.5.9.tar.gz) |  33M |
+| win32gcc | [root_v5.11.02.win32gcc.tar.gz](https://root.cern/download/root_v5.11.02.win32gcc.tar.gz) |  34M |
+| win32gdk (dbg) | [root_v5.11.02.win32gdk.debug.tar.gz](https://root.cern/download/root_v5.11.02.win32gdk.debug.tar.gz) |  69M |
+| win32gdk | [root_v5.11.02.win32gdk.tar.gz](https://root.cern/download/root_v5.11.02.win32gdk.tar.gz) |  37M |
 
 
 ## Git

--- a/_releases/release-51104.md
+++ b/_releases/release-51104.md
@@ -15,26 +15,26 @@ sidebar:
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v5.11.04.source.tar.gz](https://root.cern.ch/download/root_v5.11.04.source.tar.gz) |  18M |
+| source | [root_v5.11.04.source.tar.gz](https://root.cern/download/root_v5.11.04.source.tar.gz) |  18M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| Linux.FedoraCore3.gcc3.4.3 | [root_v5.11.04.Linux.FedoraCore3.gcc3.4.3.tar.gz](https://root.cern.ch/download/root_v5.11.04.Linux.FedoraCore3.gcc3.4.3.tar.gz) |  34M |
-| Linux.RH9.0.gcc32 | [root_v5.11.04.Linux.RH9.0.gcc32.tar.gz](https://root.cern.ch/download/root_v5.11.04.Linux.RH9.0.gcc32.tar.gz) |  38M |
-| Linux.slc3.gcc3.2.3 | [root_v5.11.04.Linux.slc3.gcc3.2.3.tar.gz](https://root.cern.ch/download/root_v5.11.04.Linux.slc3.gcc3.2.3.tar.gz) |  34M |
-| Linux.slc3.gcc3.4.4 | [root_v5.11.04.Linux.slc3.gcc3.4.4.tar.gz](https://root.cern.ch/download/root_v5.11.04.Linux.slc3.gcc3.4.4.tar.gz) |  32M |
-| Linux.slc3_amd64.gcc3.4.3 | [root_v5.11.04.Linux.slc3_amd64.gcc3.4.3.tar.gz](https://root.cern.ch/download/root_v5.11.04.Linux.slc3_amd64.gcc3.4.3.tar.gz) |  39M |
-| Linux.slc4.gcc3.4.5 | [root_v5.11.04.Linux.slc4.gcc3.4.5.tar.gz](https://root.cern.ch/download/root_v5.11.04.Linux.slc4.gcc3.4.5.tar.gz) |  32M |
-| Linux.slc4_amd64.gcc3.4.5 | [root_v5.11.04.Linux.slc4_amd64.gcc3.4.5.tar.gz](https://root.cern.ch/download/root_v5.11.04.Linux.slc4_amd64.gcc3.4.5.tar.gz) |  32M |
-| macosx i386 gcc 4.0 | [root_v5.11.04.macosx-i386-gcc-4.0.tar.gz](https://root.cern.ch/download/root_v5.11.04.macosx-i386-gcc-4.0.tar.gz) |  29M |
-| macosx i386 icc 9.1 | [root_v5.11.04.macosx-i386-icc-9.1.tar.gz](https://root.cern.ch/download/root_v5.11.04.macosx-i386-icc-9.1.tar.gz) |  60M |
-| SunOS.5.9 | [root_v5.11.04.SunOS.5.9.tar.gz](https://root.cern.ch/download/root_v5.11.04.SunOS.5.9.tar.gz) |  34M |
-| win32gcc | [root_v5.11.04.win32gcc.tar.gz](https://root.cern.ch/download/root_v5.11.04.win32gcc.tar.gz) |  32M |
-| win32gdk (dbg) | [root_v5.11.04.win32gdk.debug.tar.gz](https://root.cern.ch/download/root_v5.11.04.win32gdk.debug.tar.gz) |  59M |
-| win32gdk | [root_v5.11.04.win32gdk.tar.gz](https://root.cern.ch/download/root_v5.11.04.win32gdk.tar.gz) |  38M |
+| Linux.FedoraCore3.gcc3.4.3 | [root_v5.11.04.Linux.FedoraCore3.gcc3.4.3.tar.gz](https://root.cern/download/root_v5.11.04.Linux.FedoraCore3.gcc3.4.3.tar.gz) |  34M |
+| Linux.RH9.0.gcc32 | [root_v5.11.04.Linux.RH9.0.gcc32.tar.gz](https://root.cern/download/root_v5.11.04.Linux.RH9.0.gcc32.tar.gz) |  38M |
+| Linux.slc3.gcc3.2.3 | [root_v5.11.04.Linux.slc3.gcc3.2.3.tar.gz](https://root.cern/download/root_v5.11.04.Linux.slc3.gcc3.2.3.tar.gz) |  34M |
+| Linux.slc3.gcc3.4.4 | [root_v5.11.04.Linux.slc3.gcc3.4.4.tar.gz](https://root.cern/download/root_v5.11.04.Linux.slc3.gcc3.4.4.tar.gz) |  32M |
+| Linux.slc3_amd64.gcc3.4.3 | [root_v5.11.04.Linux.slc3_amd64.gcc3.4.3.tar.gz](https://root.cern/download/root_v5.11.04.Linux.slc3_amd64.gcc3.4.3.tar.gz) |  39M |
+| Linux.slc4.gcc3.4.5 | [root_v5.11.04.Linux.slc4.gcc3.4.5.tar.gz](https://root.cern/download/root_v5.11.04.Linux.slc4.gcc3.4.5.tar.gz) |  32M |
+| Linux.slc4_amd64.gcc3.4.5 | [root_v5.11.04.Linux.slc4_amd64.gcc3.4.5.tar.gz](https://root.cern/download/root_v5.11.04.Linux.slc4_amd64.gcc3.4.5.tar.gz) |  32M |
+| macosx i386 gcc 4.0 | [root_v5.11.04.macosx-i386-gcc-4.0.tar.gz](https://root.cern/download/root_v5.11.04.macosx-i386-gcc-4.0.tar.gz) |  29M |
+| macosx i386 icc 9.1 | [root_v5.11.04.macosx-i386-icc-9.1.tar.gz](https://root.cern/download/root_v5.11.04.macosx-i386-icc-9.1.tar.gz) |  60M |
+| SunOS.5.9 | [root_v5.11.04.SunOS.5.9.tar.gz](https://root.cern/download/root_v5.11.04.SunOS.5.9.tar.gz) |  34M |
+| win32gcc | [root_v5.11.04.win32gcc.tar.gz](https://root.cern/download/root_v5.11.04.win32gcc.tar.gz) |  32M |
+| win32gdk (dbg) | [root_v5.11.04.win32gdk.debug.tar.gz](https://root.cern/download/root_v5.11.04.win32gdk.debug.tar.gz) |  59M |
+| win32gdk | [root_v5.11.04.win32gdk.tar.gz](https://root.cern/download/root_v5.11.04.win32gdk.tar.gz) |  38M |
 
 
 ## Git

--- a/_releases/release-51106.md
+++ b/_releases/release-51106.md
@@ -15,26 +15,26 @@ sidebar:
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v5.11.06.source.tar.gz](https://root.cern.ch/download/root_v5.11.06.source.tar.gz) |  18M |
+| source | [root_v5.11.06.source.tar.gz](https://root.cern/download/root_v5.11.06.source.tar.gz) |  18M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| Linux.FedoraCore3.gcc3.4.3 | [root_v5.11.06.Linux.FedoraCore3.gcc3.4.3.tar.gz](https://root.cern.ch/download/root_v5.11.06.Linux.FedoraCore3.gcc3.4.3.tar.gz) |  34M |
-| Linux.RH9.0.gcc32 | [root_v5.11.06.Linux.RH9.0.gcc32.tar.gz](https://root.cern.ch/download/root_v5.11.06.Linux.RH9.0.gcc32.tar.gz) |  38M |
-| Linux.slc3.gcc3.2.3 | [root_v5.11.06.Linux.slc3.gcc3.2.3.tar.gz](https://root.cern.ch/download/root_v5.11.06.Linux.slc3.gcc3.2.3.tar.gz) |  34M |
-| Linux.slc3.gcc3.4.4 | [root_v5.11.06.Linux.slc3.gcc3.4.4.tar.gz](https://root.cern.ch/download/root_v5.11.06.Linux.slc3.gcc3.4.4.tar.gz) |  32M |
-| Linux.slc3_amd64.gcc3.4.3 | [root_v5.11.06.Linux.slc3_amd64.gcc3.4.3.tar.gz](https://root.cern.ch/download/root_v5.11.06.Linux.slc3_amd64.gcc3.4.3.tar.gz) |  39M |
-| Linux.slc4.gcc3.4.5 | [root_v5.11.06.Linux.slc4.gcc3.4.5.tar.gz](https://root.cern.ch/download/root_v5.11.06.Linux.slc4.gcc3.4.5.tar.gz) |  32M |
-| Linux.slc4_amd64.gcc3.4.5 | [root_v5.11.06.Linux.slc4_amd64.gcc3.4.5.tar.gz](https://root.cern.ch/download/root_v5.11.06.Linux.slc4_amd64.gcc3.4.5.tar.gz) |  32M |
-| macosx i386 gcc 4.0 | [root_v5.11.06.macosx-i386-gcc-4.0.tar.gz](https://root.cern.ch/download/root_v5.11.06.macosx-i386-gcc-4.0.tar.gz) |  29M |
-| macosx i386 icc 9.1 | [root_v5.11.06.macosx-i386-icc-9.1.tar.gz](https://root.cern.ch/download/root_v5.11.06.macosx-i386-icc-9.1.tar.gz) |  60M |
-| SunOS.5.9 | [root_v5.11.06.SunOS.5.9.tar.gz](https://root.cern.ch/download/root_v5.11.06.SunOS.5.9.tar.gz) |  34M |
-| win32gcc | [root_v5.11.06.win32gcc.tar.gz](https://root.cern.ch/download/root_v5.11.06.win32gcc.tar.gz) |  32M |
-| win32gdk (dbg) | [root_v5.11.06.win32gdk.debug.tar.gz](https://root.cern.ch/download/root_v5.11.06.win32gdk.debug.tar.gz) |  59M |
-| win32gdk | [root_v5.11.06.win32gdk.tar.gz](https://root.cern.ch/download/root_v5.11.06.win32gdk.tar.gz) |  38M |
+| Linux.FedoraCore3.gcc3.4.3 | [root_v5.11.06.Linux.FedoraCore3.gcc3.4.3.tar.gz](https://root.cern/download/root_v5.11.06.Linux.FedoraCore3.gcc3.4.3.tar.gz) |  34M |
+| Linux.RH9.0.gcc32 | [root_v5.11.06.Linux.RH9.0.gcc32.tar.gz](https://root.cern/download/root_v5.11.06.Linux.RH9.0.gcc32.tar.gz) |  38M |
+| Linux.slc3.gcc3.2.3 | [root_v5.11.06.Linux.slc3.gcc3.2.3.tar.gz](https://root.cern/download/root_v5.11.06.Linux.slc3.gcc3.2.3.tar.gz) |  34M |
+| Linux.slc3.gcc3.4.4 | [root_v5.11.06.Linux.slc3.gcc3.4.4.tar.gz](https://root.cern/download/root_v5.11.06.Linux.slc3.gcc3.4.4.tar.gz) |  32M |
+| Linux.slc3_amd64.gcc3.4.3 | [root_v5.11.06.Linux.slc3_amd64.gcc3.4.3.tar.gz](https://root.cern/download/root_v5.11.06.Linux.slc3_amd64.gcc3.4.3.tar.gz) |  39M |
+| Linux.slc4.gcc3.4.5 | [root_v5.11.06.Linux.slc4.gcc3.4.5.tar.gz](https://root.cern/download/root_v5.11.06.Linux.slc4.gcc3.4.5.tar.gz) |  32M |
+| Linux.slc4_amd64.gcc3.4.5 | [root_v5.11.06.Linux.slc4_amd64.gcc3.4.5.tar.gz](https://root.cern/download/root_v5.11.06.Linux.slc4_amd64.gcc3.4.5.tar.gz) |  32M |
+| macosx i386 gcc 4.0 | [root_v5.11.06.macosx-i386-gcc-4.0.tar.gz](https://root.cern/download/root_v5.11.06.macosx-i386-gcc-4.0.tar.gz) |  29M |
+| macosx i386 icc 9.1 | [root_v5.11.06.macosx-i386-icc-9.1.tar.gz](https://root.cern/download/root_v5.11.06.macosx-i386-icc-9.1.tar.gz) |  60M |
+| SunOS.5.9 | [root_v5.11.06.SunOS.5.9.tar.gz](https://root.cern/download/root_v5.11.06.SunOS.5.9.tar.gz) |  34M |
+| win32gcc | [root_v5.11.06.win32gcc.tar.gz](https://root.cern/download/root_v5.11.06.win32gcc.tar.gz) |  32M |
+| win32gdk (dbg) | [root_v5.11.06.win32gdk.debug.tar.gz](https://root.cern/download/root_v5.11.06.win32gdk.debug.tar.gz) |  59M |
+| win32gdk | [root_v5.11.06.win32gdk.tar.gz](https://root.cern/download/root_v5.11.06.win32gdk.tar.gz) |  38M |
 
 
 ## Git

--- a/_releases/release-51200.md
+++ b/_releases/release-51200.md
@@ -15,40 +15,40 @@ sidebar:
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v5.12.00.source.tar.gz](https://root.cern.ch/download/root_v5.12.00.source.tar.gz) |  17M |
-| root_v5.12.00a.source | [root_v5.12.00a.source.tar.gz](https://root.cern.ch/download/root_v5.12.00a.source.tar.gz) |  17M |
-| root_v5.12.00c.source | [root_v5.12.00c.source.tar.gz](https://root.cern.ch/download/root_v5.12.00c.source.tar.gz) |  17M |
-| root_v5.12.00d.source | [root_v5.12.00d.source.tar.gz](https://root.cern.ch/download/root_v5.12.00d.source.tar.gz) |  17M |
-| root_v5.12.00e.source | [root_v5.12.00e.source.tar.gz](https://root.cern.ch/download/root_v5.12.00e.source.tar.gz) |  17M |
-| root_v5.12.00f.source | [root_v5.12.00f.source.tar.gz](https://root.cern.ch/download/root_v5.12.00f.source.tar.gz) |  17M |
-| root_v5.12.00g.source | [root_v5.12.00g.source.tar.gz](https://root.cern.ch/download/root_v5.12.00g.source.tar.gz) |  17M |
+| source | [root_v5.12.00.source.tar.gz](https://root.cern/download/root_v5.12.00.source.tar.gz) |  17M |
+| root_v5.12.00a.source | [root_v5.12.00a.source.tar.gz](https://root.cern/download/root_v5.12.00a.source.tar.gz) |  17M |
+| root_v5.12.00c.source | [root_v5.12.00c.source.tar.gz](https://root.cern/download/root_v5.12.00c.source.tar.gz) |  17M |
+| root_v5.12.00d.source | [root_v5.12.00d.source.tar.gz](https://root.cern/download/root_v5.12.00d.source.tar.gz) |  17M |
+| root_v5.12.00e.source | [root_v5.12.00e.source.tar.gz](https://root.cern/download/root_v5.12.00e.source.tar.gz) |  17M |
+| root_v5.12.00f.source | [root_v5.12.00f.source.tar.gz](https://root.cern/download/root_v5.12.00f.source.tar.gz) |  17M |
+| root_v5.12.00g.source | [root_v5.12.00g.source.tar.gz](https://root.cern/download/root_v5.12.00g.source.tar.gz) |  17M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| linux gcc 4.1 | [root_v5.12.00.linux-gcc-4.1.tar.gz](https://root.cern.ch/download/root_v5.12.00.linux-gcc-4.1.tar.gz) |  28M |
-| Linux.FedoraCore3.gcc3.4.3 | [root_v5.12.00.Linux.FedoraCore3.gcc3.4.3.tar.gz](https://root.cern.ch/download/root_v5.12.00.Linux.FedoraCore3.gcc3.4.3.tar.gz) |  34M |
-| Linux.RH9.0.gcc32 | [root_v5.12.00.Linux.RH9.0.gcc32.tar.gz](https://root.cern.ch/download/root_v5.12.00.Linux.RH9.0.gcc32.tar.gz) |  41M |
-| Linux.slc3.gcc3.2.3 | [root_v5.12.00.Linux.slc3.gcc3.2.3.tar.gz](https://root.cern.ch/download/root_v5.12.00.Linux.slc3.gcc3.2.3.tar.gz) |  37M |
-| Linux.slc3.gcc3.4.4 | [root_v5.12.00.Linux.slc3.gcc3.4.4.tar.gz](https://root.cern.ch/download/root_v5.12.00.Linux.slc3.gcc3.4.4.tar.gz) |  34M |
-| Linux.slc3_amd64.gcc3.4.3 | [root_v5.12.00.Linux.slc3_amd64.gcc3.4.3.tar.gz](https://root.cern.ch/download/root_v5.12.00.Linux.slc3_amd64.gcc3.4.3.tar.gz) |  42M |
-| Linux.slc4.gcc3.4.5 | [root_v5.12.00.Linux.slc4.gcc3.4.5.tar.gz](https://root.cern.ch/download/root_v5.12.00.Linux.slc4.gcc3.4.5.tar.gz) |  34M |
-| Linux.slc4_amd64.gcc3.4.5 | [root_v5.12.00.Linux.slc4_amd64.gcc3.4.5.tar.gz](https://root.cern.ch/download/root_v5.12.00.Linux.slc4_amd64.gcc3.4.5.tar.gz) |  35M |
-| macosx i386 gcc 4.0 | [root_v5.12.00.macosx-i386-gcc-4.0.tar.gz](https://root.cern.ch/download/root_v5.12.00.macosx-i386-gcc-4.0.tar.gz) |  33M |
-| macosx i386 icc 9.1 | [root_v5.12.00.macosx-i386-icc-9.1.tar.gz](https://root.cern.ch/download/root_v5.12.00.macosx-i386-icc-9.1.tar.gz) |  59M |
-| macosx powerpc gcc 4.0 | [root_v5.12.00.macosx-powerpc-gcc-4.0.tar.gz](https://root.cern.ch/download/root_v5.12.00.macosx-powerpc-gcc-4.0.tar.gz) |  27M |
-| SunOS.5.9 | [root_v5.12.00.SunOS.5.9.tar.gz](https://root.cern.ch/download/root_v5.12.00.SunOS.5.9.tar.gz) |  36M |
-| win32gcc | [root_v5.12.00.win32gcc.tar.gz](https://root.cern.ch/download/root_v5.12.00.win32gcc.tar.gz) |  39M |
-| win32gdk (dbg) | [root_v5.12.00.win32gdk.debug.tar.gz](https://root.cern.ch/download/root_v5.12.00.win32gdk.debug.tar.gz) |  63M |
-| win32gdk | [root_v5.12.00.win32gdk.tar.gz](https://root.cern.ch/download/root_v5.12.00.win32gdk.tar.gz) |  38M |
-| root_v5.12.00d.Linux.slc3.gcc3.4.4 | [root_v5.12.00d.Linux.slc3.gcc3.4.4.tar.gz](https://root.cern.ch/download/root_v5.12.00d.Linux.slc3.gcc3.4.4.tar.gz) |  34M |
-| root_v5.12.00d.Linux.slc4.gcc3.4.5 | [root_v5.12.00d.Linux.slc4.gcc3.4.5.tar.gz](https://root.cern.ch/download/root_v5.12.00d.Linux.slc4.gcc3.4.5.tar.gz) |  34M |
-| root_v5.12.00d.Linux.slc4_amd64.gcc3.4.5 | [root_v5.12.00d.Linux.slc4_amd64.gcc3.4.5.tar.gz](https://root.cern.ch/download/root_v5.12.00d.Linux.slc4_amd64.gcc3.4.5.tar.gz) |  35M |
-| root_v5.12.00e.Linux.slc3.gcc3.4.4 | [root_v5.12.00e.Linux.slc3.gcc3.4.4.tar.gz](https://root.cern.ch/download/root_v5.12.00e.Linux.slc3.gcc3.4.4.tar.gz) |  34M |
-| root_v5.12.00e.Linux.slc4.gcc3.4.5 | [root_v5.12.00e.Linux.slc4.gcc3.4.5.tar.gz](https://root.cern.ch/download/root_v5.12.00e.Linux.slc4.gcc3.4.5.tar.gz) |  34M |
-| root_v5.12.00e.Linux.slc4_amd64.gcc3.4.5 | [root_v5.12.00e.Linux.slc4_amd64.gcc3.4.5.tar.gz](https://root.cern.ch/download/root_v5.12.00e.Linux.slc4_amd64.gcc3.4.5.tar.gz) |  35M |
+| linux gcc 4.1 | [root_v5.12.00.linux-gcc-4.1.tar.gz](https://root.cern/download/root_v5.12.00.linux-gcc-4.1.tar.gz) |  28M |
+| Linux.FedoraCore3.gcc3.4.3 | [root_v5.12.00.Linux.FedoraCore3.gcc3.4.3.tar.gz](https://root.cern/download/root_v5.12.00.Linux.FedoraCore3.gcc3.4.3.tar.gz) |  34M |
+| Linux.RH9.0.gcc32 | [root_v5.12.00.Linux.RH9.0.gcc32.tar.gz](https://root.cern/download/root_v5.12.00.Linux.RH9.0.gcc32.tar.gz) |  41M |
+| Linux.slc3.gcc3.2.3 | [root_v5.12.00.Linux.slc3.gcc3.2.3.tar.gz](https://root.cern/download/root_v5.12.00.Linux.slc3.gcc3.2.3.tar.gz) |  37M |
+| Linux.slc3.gcc3.4.4 | [root_v5.12.00.Linux.slc3.gcc3.4.4.tar.gz](https://root.cern/download/root_v5.12.00.Linux.slc3.gcc3.4.4.tar.gz) |  34M |
+| Linux.slc3_amd64.gcc3.4.3 | [root_v5.12.00.Linux.slc3_amd64.gcc3.4.3.tar.gz](https://root.cern/download/root_v5.12.00.Linux.slc3_amd64.gcc3.4.3.tar.gz) |  42M |
+| Linux.slc4.gcc3.4.5 | [root_v5.12.00.Linux.slc4.gcc3.4.5.tar.gz](https://root.cern/download/root_v5.12.00.Linux.slc4.gcc3.4.5.tar.gz) |  34M |
+| Linux.slc4_amd64.gcc3.4.5 | [root_v5.12.00.Linux.slc4_amd64.gcc3.4.5.tar.gz](https://root.cern/download/root_v5.12.00.Linux.slc4_amd64.gcc3.4.5.tar.gz) |  35M |
+| macosx i386 gcc 4.0 | [root_v5.12.00.macosx-i386-gcc-4.0.tar.gz](https://root.cern/download/root_v5.12.00.macosx-i386-gcc-4.0.tar.gz) |  33M |
+| macosx i386 icc 9.1 | [root_v5.12.00.macosx-i386-icc-9.1.tar.gz](https://root.cern/download/root_v5.12.00.macosx-i386-icc-9.1.tar.gz) |  59M |
+| macosx powerpc gcc 4.0 | [root_v5.12.00.macosx-powerpc-gcc-4.0.tar.gz](https://root.cern/download/root_v5.12.00.macosx-powerpc-gcc-4.0.tar.gz) |  27M |
+| SunOS.5.9 | [root_v5.12.00.SunOS.5.9.tar.gz](https://root.cern/download/root_v5.12.00.SunOS.5.9.tar.gz) |  36M |
+| win32gcc | [root_v5.12.00.win32gcc.tar.gz](https://root.cern/download/root_v5.12.00.win32gcc.tar.gz) |  39M |
+| win32gdk (dbg) | [root_v5.12.00.win32gdk.debug.tar.gz](https://root.cern/download/root_v5.12.00.win32gdk.debug.tar.gz) |  63M |
+| win32gdk | [root_v5.12.00.win32gdk.tar.gz](https://root.cern/download/root_v5.12.00.win32gdk.tar.gz) |  38M |
+| root_v5.12.00d.Linux.slc3.gcc3.4.4 | [root_v5.12.00d.Linux.slc3.gcc3.4.4.tar.gz](https://root.cern/download/root_v5.12.00d.Linux.slc3.gcc3.4.4.tar.gz) |  34M |
+| root_v5.12.00d.Linux.slc4.gcc3.4.5 | [root_v5.12.00d.Linux.slc4.gcc3.4.5.tar.gz](https://root.cern/download/root_v5.12.00d.Linux.slc4.gcc3.4.5.tar.gz) |  34M |
+| root_v5.12.00d.Linux.slc4_amd64.gcc3.4.5 | [root_v5.12.00d.Linux.slc4_amd64.gcc3.4.5.tar.gz](https://root.cern/download/root_v5.12.00d.Linux.slc4_amd64.gcc3.4.5.tar.gz) |  35M |
+| root_v5.12.00e.Linux.slc3.gcc3.4.4 | [root_v5.12.00e.Linux.slc3.gcc3.4.4.tar.gz](https://root.cern/download/root_v5.12.00e.Linux.slc3.gcc3.4.4.tar.gz) |  34M |
+| root_v5.12.00e.Linux.slc4.gcc3.4.5 | [root_v5.12.00e.Linux.slc4.gcc3.4.5.tar.gz](https://root.cern/download/root_v5.12.00e.Linux.slc4.gcc3.4.5.tar.gz) |  34M |
+| root_v5.12.00e.Linux.slc4_amd64.gcc3.4.5 | [root_v5.12.00e.Linux.slc4_amd64.gcc3.4.5.tar.gz](https://root.cern/download/root_v5.12.00e.Linux.slc4_amd64.gcc3.4.5.tar.gz) |  35M |
 
 
 ## Git

--- a/_releases/release-51200d.md
+++ b/_releases/release-51200d.md
@@ -15,16 +15,16 @@ sidebar:
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v5.12.00d.source.tar.gz](https://root.cern.ch/download/root_v5.12.00d.source.tar.gz) |  17M |
+| source | [root_v5.12.00d.source.tar.gz](https://root.cern/download/root_v5.12.00d.source.tar.gz) |  17M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| Linux.slc3.gcc3.4.4 | [root_v5.12.00d.Linux.slc3.gcc3.4.4.tar.gz](https://root.cern.ch/download/root_v5.12.00d.Linux.slc3.gcc3.4.4.tar.gz) |  34M |
-| Linux.slc4.gcc3.4.5 | [root_v5.12.00d.Linux.slc4.gcc3.4.5.tar.gz](https://root.cern.ch/download/root_v5.12.00d.Linux.slc4.gcc3.4.5.tar.gz) |  34M |
-| Linux.slc4_amd64.gcc3.4.5 | [root_v5.12.00d.Linux.slc4_amd64.gcc3.4.5.tar.gz](https://root.cern.ch/download/root_v5.12.00d.Linux.slc4_amd64.gcc3.4.5.tar.gz) |  35M |
+| Linux.slc3.gcc3.4.4 | [root_v5.12.00d.Linux.slc3.gcc3.4.4.tar.gz](https://root.cern/download/root_v5.12.00d.Linux.slc3.gcc3.4.4.tar.gz) |  34M |
+| Linux.slc4.gcc3.4.5 | [root_v5.12.00d.Linux.slc4.gcc3.4.5.tar.gz](https://root.cern/download/root_v5.12.00d.Linux.slc4.gcc3.4.5.tar.gz) |  34M |
+| Linux.slc4_amd64.gcc3.4.5 | [root_v5.12.00d.Linux.slc4_amd64.gcc3.4.5.tar.gz](https://root.cern/download/root_v5.12.00d.Linux.slc4_amd64.gcc3.4.5.tar.gz) |  35M |
 
 
 ## Git

--- a/_releases/release-51200e.md
+++ b/_releases/release-51200e.md
@@ -15,16 +15,16 @@ sidebar:
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v5.12.00e.source.tar.gz](https://root.cern.ch/download/root_v5.12.00e.source.tar.gz) |  17M |
+| source | [root_v5.12.00e.source.tar.gz](https://root.cern/download/root_v5.12.00e.source.tar.gz) |  17M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| Linux.slc3.gcc3.4.4 | [root_v5.12.00e.Linux.slc3.gcc3.4.4.tar.gz](https://root.cern.ch/download/root_v5.12.00e.Linux.slc3.gcc3.4.4.tar.gz) |  34M |
-| Linux.slc4.gcc3.4.5 | [root_v5.12.00e.Linux.slc4.gcc3.4.5.tar.gz](https://root.cern.ch/download/root_v5.12.00e.Linux.slc4.gcc3.4.5.tar.gz) |  34M |
-| Linux.slc4_amd64.gcc3.4.5 | [root_v5.12.00e.Linux.slc4_amd64.gcc3.4.5.tar.gz](https://root.cern.ch/download/root_v5.12.00e.Linux.slc4_amd64.gcc3.4.5.tar.gz) |  35M |
+| Linux.slc3.gcc3.4.4 | [root_v5.12.00e.Linux.slc3.gcc3.4.4.tar.gz](https://root.cern/download/root_v5.12.00e.Linux.slc3.gcc3.4.4.tar.gz) |  34M |
+| Linux.slc4.gcc3.4.5 | [root_v5.12.00e.Linux.slc4.gcc3.4.5.tar.gz](https://root.cern/download/root_v5.12.00e.Linux.slc4.gcc3.4.5.tar.gz) |  34M |
+| Linux.slc4_amd64.gcc3.4.5 | [root_v5.12.00e.Linux.slc4_amd64.gcc3.4.5.tar.gz](https://root.cern/download/root_v5.12.00e.Linux.slc4_amd64.gcc3.4.5.tar.gz) |  35M |
 
 
 

--- a/_releases/release-51302.md
+++ b/_releases/release-51302.md
@@ -15,25 +15,25 @@ sidebar:
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v5.13.02.source.tar.gz](https://root.cern.ch/download/root_v5.13.02.source.tar.gz) |  18M |
+| source | [root_v5.13.02.source.tar.gz](https://root.cern/download/root_v5.13.02.source.tar.gz) |  18M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| Linux.RH9.0.gcc32 | [root_v5.13.02.Linux.RH9.0.gcc32.tar.gz](https://root.cern.ch/download/root_v5.13.02.Linux.RH9.0.gcc32.tar.gz) |  41M |
-| Linux.slc3.gcc3.2.3 | [root_v5.13.02.Linux.slc3.gcc3.2.3.tar.gz](https://root.cern.ch/download/root_v5.13.02.Linux.slc3.gcc3.2.3.tar.gz) |  37M |
-| Linux.slc3.gcc3.4.4 | [root_v5.13.02.Linux.slc3.gcc3.4.4.tar.gz](https://root.cern.ch/download/root_v5.13.02.Linux.slc3.gcc3.4.4.tar.gz) |  33M |
-| Linux.slc3_amd64.gcc3.4.3 | [root_v5.13.02.Linux.slc3_amd64.gcc3.4.3.tar.gz](https://root.cern.ch/download/root_v5.13.02.Linux.slc3_amd64.gcc3.4.3.tar.gz) |  42M |
-| Linux.slc4.gcc3.4.5 | [root_v5.13.02.Linux.slc4.gcc3.4.5.tar.gz](https://root.cern.ch/download/root_v5.13.02.Linux.slc4.gcc3.4.5.tar.gz) |  33M |
-| Linux.slc4_amd64.gcc3.4.5 | [root_v5.13.02.Linux.slc4_amd64.gcc3.4.5.tar.gz](https://root.cern.ch/download/root_v5.13.02.Linux.slc4_amd64.gcc3.4.5.tar.gz) |  34M |
-| macosx i386 gcc 4.0 | [root_v5.13.02.macosx-i386-gcc-4.0.tar.gz](https://root.cern.ch/download/root_v5.13.02.macosx-i386-gcc-4.0.tar.gz) |  34M |
-| macosx i386 icc 9.1 | [root_v5.13.02.macosx-i386-icc-9.1.tar.gz](https://root.cern.ch/download/root_v5.13.02.macosx-i386-icc-9.1.tar.gz) |  67M |
-| SunOS.5.9 | [root_v5.13.02.SunOS.5.9.tar.gz](https://root.cern.ch/download/root_v5.13.02.SunOS.5.9.tar.gz) |  36M |
-| win32gcc | [root_v5.13.02.win32gcc.tar.gz](https://root.cern.ch/download/root_v5.13.02.win32gcc.tar.gz) |  36M |
-| win32gdk (dbg) | [root_v5.13.02.win32gdk.debug.tar.gz](https://root.cern.ch/download/root_v5.13.02.win32gdk.debug.tar.gz) |  69M |
-| win32gdk | [root_v5.13.02.win32gdk.tar.gz](https://root.cern.ch/download/root_v5.13.02.win32gdk.tar.gz) |  39M |
+| Linux.RH9.0.gcc32 | [root_v5.13.02.Linux.RH9.0.gcc32.tar.gz](https://root.cern/download/root_v5.13.02.Linux.RH9.0.gcc32.tar.gz) |  41M |
+| Linux.slc3.gcc3.2.3 | [root_v5.13.02.Linux.slc3.gcc3.2.3.tar.gz](https://root.cern/download/root_v5.13.02.Linux.slc3.gcc3.2.3.tar.gz) |  37M |
+| Linux.slc3.gcc3.4.4 | [root_v5.13.02.Linux.slc3.gcc3.4.4.tar.gz](https://root.cern/download/root_v5.13.02.Linux.slc3.gcc3.4.4.tar.gz) |  33M |
+| Linux.slc3_amd64.gcc3.4.3 | [root_v5.13.02.Linux.slc3_amd64.gcc3.4.3.tar.gz](https://root.cern/download/root_v5.13.02.Linux.slc3_amd64.gcc3.4.3.tar.gz) |  42M |
+| Linux.slc4.gcc3.4.5 | [root_v5.13.02.Linux.slc4.gcc3.4.5.tar.gz](https://root.cern/download/root_v5.13.02.Linux.slc4.gcc3.4.5.tar.gz) |  33M |
+| Linux.slc4_amd64.gcc3.4.5 | [root_v5.13.02.Linux.slc4_amd64.gcc3.4.5.tar.gz](https://root.cern/download/root_v5.13.02.Linux.slc4_amd64.gcc3.4.5.tar.gz) |  34M |
+| macosx i386 gcc 4.0 | [root_v5.13.02.macosx-i386-gcc-4.0.tar.gz](https://root.cern/download/root_v5.13.02.macosx-i386-gcc-4.0.tar.gz) |  34M |
+| macosx i386 icc 9.1 | [root_v5.13.02.macosx-i386-icc-9.1.tar.gz](https://root.cern/download/root_v5.13.02.macosx-i386-icc-9.1.tar.gz) |  67M |
+| SunOS.5.9 | [root_v5.13.02.SunOS.5.9.tar.gz](https://root.cern/download/root_v5.13.02.SunOS.5.9.tar.gz) |  36M |
+| win32gcc | [root_v5.13.02.win32gcc.tar.gz](https://root.cern/download/root_v5.13.02.win32gcc.tar.gz) |  36M |
+| win32gdk (dbg) | [root_v5.13.02.win32gdk.debug.tar.gz](https://root.cern/download/root_v5.13.02.win32gdk.debug.tar.gz) |  69M |
+| win32gdk | [root_v5.13.02.win32gdk.tar.gz](https://root.cern/download/root_v5.13.02.win32gdk.tar.gz) |  39M |
 
 
 ## Git

--- a/_releases/release-51304.md
+++ b/_releases/release-51304.md
@@ -15,27 +15,27 @@ sidebar:
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v5.13.04.source.tar.gz](https://root.cern.ch/download/root_v5.13.04.source.tar.gz) |  18M |
-| root_v5.13.04a.source | [root_v5.13.04a.source.tar.gz](https://root.cern.ch/download/root_v5.13.04a.source.tar.gz) |  18M |
-| root_v5.13.04b.source | [root_v5.13.04b.source.tar.gz](https://root.cern.ch/download/root_v5.13.04b.source.tar.gz) |  18M |
-| root_v5.13.04c.source | [root_v5.13.04c.source.tar.gz](https://root.cern.ch/download/root_v5.13.04c.source.tar.gz) |  18M |
-| root_v5.13.04d.source | [root_v5.13.04d.source.tar.gz](https://root.cern.ch/download/root_v5.13.04d.source.tar.gz) |  18M |
-| root_v5.13.04e.source | [root_v5.13.04e.source.tar.gz](https://root.cern.ch/download/root_v5.13.04e.source.tar.gz) |  18M |
+| source | [root_v5.13.04.source.tar.gz](https://root.cern/download/root_v5.13.04.source.tar.gz) |  18M |
+| root_v5.13.04a.source | [root_v5.13.04a.source.tar.gz](https://root.cern/download/root_v5.13.04a.source.tar.gz) |  18M |
+| root_v5.13.04b.source | [root_v5.13.04b.source.tar.gz](https://root.cern/download/root_v5.13.04b.source.tar.gz) |  18M |
+| root_v5.13.04c.source | [root_v5.13.04c.source.tar.gz](https://root.cern/download/root_v5.13.04c.source.tar.gz) |  18M |
+| root_v5.13.04d.source | [root_v5.13.04d.source.tar.gz](https://root.cern/download/root_v5.13.04d.source.tar.gz) |  18M |
+| root_v5.13.04e.source | [root_v5.13.04e.source.tar.gz](https://root.cern/download/root_v5.13.04e.source.tar.gz) |  18M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| Linux.RH9.0.gcc32 | [root_v5.13.04.Linux.RH9.0.gcc32.tar.gz](https://root.cern.ch/download/root_v5.13.04.Linux.RH9.0.gcc32.tar.gz) |  41M |
-| Linux.slc3.gcc3.2.3 | [root_v5.13.04.Linux.slc3.gcc3.2.3.tar.gz](https://root.cern.ch/download/root_v5.13.04.Linux.slc3.gcc3.2.3.tar.gz) |  38M |
-| Linux.slc3_amd64.gcc3.4.3 | [root_v5.13.04.Linux.slc3_amd64.gcc3.4.3.tar.gz](https://root.cern.ch/download/root_v5.13.04.Linux.slc3_amd64.gcc3.4.3.tar.gz) |  44M |
-| macosx i386 gcc 4.0 | [root_v5.13.04.macosx-i386-gcc-4.0.tar.gz](https://root.cern.ch/download/root_v5.13.04.macosx-i386-gcc-4.0.tar.gz) |  35M |
-| macosx i386 icc 9.1 | [root_v5.13.04.macosx-i386-icc-9.1.tar.gz](https://root.cern.ch/download/root_v5.13.04.macosx-i386-icc-9.1.tar.gz) |  69M |
-| SunOS.5.9 | [root_v5.13.04.SunOS.5.9.tar.gz](https://root.cern.ch/download/root_v5.13.04.SunOS.5.9.tar.gz) |  39M |
-| win32gcc | [root_v5.13.04.win32gcc.tar.gz](https://root.cern.ch/download/root_v5.13.04.win32gcc.tar.gz) |  38M |
-| win32gdk (dbg) | [root_v5.13.04.win32gdk.debug.tar.gz](https://root.cern.ch/download/root_v5.13.04.win32gdk.debug.tar.gz) |  75M |
-| win32gdk | [root_v5.13.04.win32gdk.tar.gz](https://root.cern.ch/download/root_v5.13.04.win32gdk.tar.gz) |  40M |
+| Linux.RH9.0.gcc32 | [root_v5.13.04.Linux.RH9.0.gcc32.tar.gz](https://root.cern/download/root_v5.13.04.Linux.RH9.0.gcc32.tar.gz) |  41M |
+| Linux.slc3.gcc3.2.3 | [root_v5.13.04.Linux.slc3.gcc3.2.3.tar.gz](https://root.cern/download/root_v5.13.04.Linux.slc3.gcc3.2.3.tar.gz) |  38M |
+| Linux.slc3_amd64.gcc3.4.3 | [root_v5.13.04.Linux.slc3_amd64.gcc3.4.3.tar.gz](https://root.cern/download/root_v5.13.04.Linux.slc3_amd64.gcc3.4.3.tar.gz) |  44M |
+| macosx i386 gcc 4.0 | [root_v5.13.04.macosx-i386-gcc-4.0.tar.gz](https://root.cern/download/root_v5.13.04.macosx-i386-gcc-4.0.tar.gz) |  35M |
+| macosx i386 icc 9.1 | [root_v5.13.04.macosx-i386-icc-9.1.tar.gz](https://root.cern/download/root_v5.13.04.macosx-i386-icc-9.1.tar.gz) |  69M |
+| SunOS.5.9 | [root_v5.13.04.SunOS.5.9.tar.gz](https://root.cern/download/root_v5.13.04.SunOS.5.9.tar.gz) |  39M |
+| win32gcc | [root_v5.13.04.win32gcc.tar.gz](https://root.cern/download/root_v5.13.04.win32gcc.tar.gz) |  38M |
+| win32gdk (dbg) | [root_v5.13.04.win32gdk.debug.tar.gz](https://root.cern/download/root_v5.13.04.win32gdk.debug.tar.gz) |  75M |
+| win32gdk | [root_v5.13.04.win32gdk.tar.gz](https://root.cern/download/root_v5.13.04.win32gdk.tar.gz) |  40M |
 
 
 ## Git

--- a/_releases/release-51306.md
+++ b/_releases/release-51306.md
@@ -15,24 +15,24 @@ sidebar:
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v5.13.06.source.tar.gz](https://root.cern.ch/download/root_v5.13.06.source.tar.gz) |  19M |
+| source | [root_v5.13.06.source.tar.gz](https://root.cern/download/root_v5.13.06.source.tar.gz) |  19M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| Linux.RH9.0.gcc32 | [root_v5.13.06.Linux.RH9.0.gcc32.tar.gz](https://root.cern.ch/download/root_v5.13.06.Linux.RH9.0.gcc32.tar.gz) |  44M |
-| Linux.slc3.gcc3.2.3 | [root_v5.13.06.Linux.slc3.gcc3.2.3.tar.gz](https://root.cern.ch/download/root_v5.13.06.Linux.slc3.gcc3.2.3.tar.gz) |  41M |
-| Linux.slc3_amd64.gcc3.4.3 | [root_v5.13.06.Linux.slc3_amd64.gcc3.4.3.tar.gz](https://root.cern.ch/download/root_v5.13.06.Linux.slc3_amd64.gcc3.4.3.tar.gz) |  45M |
-| Linux.slc4.gcc3.4 | [root_v5.13.06.Linux.slc4.gcc3.4.tar.gz](https://root.cern.ch/download/root_v5.13.06.Linux.slc4.gcc3.4.tar.gz) |  36M |
-| Linux.slc4_amd64.gcc3.4 | [root_v5.13.06.Linux.slc4_amd64.gcc3.4.tar.gz](https://root.cern.ch/download/root_v5.13.06.Linux.slc4_amd64.gcc3.4.tar.gz) |  36M |
-| macosx i386 gcc 4.0 | [root_v5.13.06.macosx-i386-gcc-4.0.tar.gz](https://root.cern.ch/download/root_v5.13.06.macosx-i386-gcc-4.0.tar.gz) |  37M |
-| macosx i386 icc 9.1 | [root_v5.13.06.macosx-i386-icc-9.1.tar.gz](https://root.cern.ch/download/root_v5.13.06.macosx-i386-icc-9.1.tar.gz) |  72M |
-| SunOS.5.9 | [root_v5.13.06.SunOS.5.9.tar.gz](https://root.cern.ch/download/root_v5.13.06.SunOS.5.9.tar.gz) |  40M |
-| win32gcc | [root_v5.13.06.win32gcc.tar.gz](https://root.cern.ch/download/root_v5.13.06.win32gcc.tar.gz) |  38M |
-| win32gdk (dbg) | [root_v5.13.06.win32gdk.debug.tar.gz](https://root.cern.ch/download/root_v5.13.06.win32gdk.debug.tar.gz) |  76M |
-| win32gdk | [root_v5.13.06.win32gdk.tar.gz](https://root.cern.ch/download/root_v5.13.06.win32gdk.tar.gz) |  42M |
+| Linux.RH9.0.gcc32 | [root_v5.13.06.Linux.RH9.0.gcc32.tar.gz](https://root.cern/download/root_v5.13.06.Linux.RH9.0.gcc32.tar.gz) |  44M |
+| Linux.slc3.gcc3.2.3 | [root_v5.13.06.Linux.slc3.gcc3.2.3.tar.gz](https://root.cern/download/root_v5.13.06.Linux.slc3.gcc3.2.3.tar.gz) |  41M |
+| Linux.slc3_amd64.gcc3.4.3 | [root_v5.13.06.Linux.slc3_amd64.gcc3.4.3.tar.gz](https://root.cern/download/root_v5.13.06.Linux.slc3_amd64.gcc3.4.3.tar.gz) |  45M |
+| Linux.slc4.gcc3.4 | [root_v5.13.06.Linux.slc4.gcc3.4.tar.gz](https://root.cern/download/root_v5.13.06.Linux.slc4.gcc3.4.tar.gz) |  36M |
+| Linux.slc4_amd64.gcc3.4 | [root_v5.13.06.Linux.slc4_amd64.gcc3.4.tar.gz](https://root.cern/download/root_v5.13.06.Linux.slc4_amd64.gcc3.4.tar.gz) |  36M |
+| macosx i386 gcc 4.0 | [root_v5.13.06.macosx-i386-gcc-4.0.tar.gz](https://root.cern/download/root_v5.13.06.macosx-i386-gcc-4.0.tar.gz) |  37M |
+| macosx i386 icc 9.1 | [root_v5.13.06.macosx-i386-icc-9.1.tar.gz](https://root.cern/download/root_v5.13.06.macosx-i386-icc-9.1.tar.gz) |  72M |
+| SunOS.5.9 | [root_v5.13.06.SunOS.5.9.tar.gz](https://root.cern/download/root_v5.13.06.SunOS.5.9.tar.gz) |  40M |
+| win32gcc | [root_v5.13.06.win32gcc.tar.gz](https://root.cern/download/root_v5.13.06.win32gcc.tar.gz) |  38M |
+| win32gdk (dbg) | [root_v5.13.06.win32gdk.debug.tar.gz](https://root.cern/download/root_v5.13.06.win32gdk.debug.tar.gz) |  76M |
+| win32gdk | [root_v5.13.06.win32gdk.tar.gz](https://root.cern/download/root_v5.13.06.win32gdk.tar.gz) |  42M |
 
 
 ## Git

--- a/_releases/release-51400.md
+++ b/_releases/release-51400.md
@@ -15,42 +15,42 @@ sidebar:
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v5.14.00.source.tar.gz](https://root.cern.ch/download/root_v5.14.00.source.tar.gz) |  20M |
-| root_v5.14.00a.source | [root_v5.14.00a.source.tar.gz](https://root.cern.ch/download/root_v5.14.00a.source.tar.gz) |  20M |
-| root_v5.14.00b.source | [root_v5.14.00b.source.tar.gz](https://root.cern.ch/download/root_v5.14.00b.source.tar.gz) |  20M |
-| root_v5.14.00c.source | [root_v5.14.00c.source.tar.gz](https://root.cern.ch/download/root_v5.14.00c.source.tar.gz) |  20M |
-| root_v5.14.00d.source | [root_v5.14.00d.source.tar.gz](https://root.cern.ch/download/root_v5.14.00d.source.tar.gz) |  20M |
-| root_v5.14.00e.source | [root_v5.14.00e.source.tar.gz](https://root.cern.ch/download/root_v5.14.00e.source.tar.gz) |  20M |
-| root_v5.14.00f.source | [root_v5.14.00f.source.tar.gz](https://root.cern.ch/download/root_v5.14.00f.source.tar.gz) |  20M |
-| root_v5.14.00g.source | [root_v5.14.00g.source.tar.gz](https://root.cern.ch/download/root_v5.14.00g.source.tar.gz) |  20M |
-| root_v5.14.00h.source | [root_v5.14.00h.source.tar.gz](https://root.cern.ch/download/root_v5.14.00h.source.tar.gz) |  20M |
-| root_v5.14.00i.source | [root_v5.14.00i.source.tar.gz](https://root.cern.ch/download/root_v5.14.00i.source.tar.gz) |  20M |
+| source | [root_v5.14.00.source.tar.gz](https://root.cern/download/root_v5.14.00.source.tar.gz) |  20M |
+| root_v5.14.00a.source | [root_v5.14.00a.source.tar.gz](https://root.cern/download/root_v5.14.00a.source.tar.gz) |  20M |
+| root_v5.14.00b.source | [root_v5.14.00b.source.tar.gz](https://root.cern/download/root_v5.14.00b.source.tar.gz) |  20M |
+| root_v5.14.00c.source | [root_v5.14.00c.source.tar.gz](https://root.cern/download/root_v5.14.00c.source.tar.gz) |  20M |
+| root_v5.14.00d.source | [root_v5.14.00d.source.tar.gz](https://root.cern/download/root_v5.14.00d.source.tar.gz) |  20M |
+| root_v5.14.00e.source | [root_v5.14.00e.source.tar.gz](https://root.cern/download/root_v5.14.00e.source.tar.gz) |  20M |
+| root_v5.14.00f.source | [root_v5.14.00f.source.tar.gz](https://root.cern/download/root_v5.14.00f.source.tar.gz) |  20M |
+| root_v5.14.00g.source | [root_v5.14.00g.source.tar.gz](https://root.cern/download/root_v5.14.00g.source.tar.gz) |  20M |
+| root_v5.14.00h.source | [root_v5.14.00h.source.tar.gz](https://root.cern/download/root_v5.14.00h.source.tar.gz) |  20M |
+| root_v5.14.00i.source | [root_v5.14.00i.source.tar.gz](https://root.cern/download/root_v5.14.00i.source.tar.gz) |  20M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| Linux.RH9.0.gcc32 | [root_v5.14.00.Linux.RH9.0.gcc32.tar.gz](https://root.cern.ch/download/root_v5.14.00.Linux.RH9.0.gcc32.tar.gz) |  44M |
-| Linux.slc3.gcc3.2.3 | [root_v5.14.00.Linux.slc3.gcc3.2.3.tar.gz](https://root.cern.ch/download/root_v5.14.00.Linux.slc3.gcc3.2.3.tar.gz) |  41M |
-| Linux.slc3_amd64.gcc3.4.3 | [root_v5.14.00.Linux.slc3_amd64.gcc3.4.3.tar.gz](https://root.cern.ch/download/root_v5.14.00.Linux.slc3_amd64.gcc3.4.3.tar.gz) |  45M |
-| Linux.slc4.gcc3.4 | [root_v5.14.00.Linux.slc4.gcc3.4.tar.gz](https://root.cern.ch/download/root_v5.14.00.Linux.slc4.gcc3.4.tar.gz) |  37M |
-| Linux.slc4_amd64.gcc3.4 | [root_v5.14.00.Linux.slc4_amd64.gcc3.4.tar.gz](https://root.cern.ch/download/root_v5.14.00.Linux.slc4_amd64.gcc3.4.tar.gz) |  36M |
-| macosx i386 gcc 4.0 | [root_v5.14.00.macosx-i386-gcc-4.0.tar.gz](https://root.cern.ch/download/root_v5.14.00.macosx-i386-gcc-4.0.tar.gz) |  36M |
-| macosx i386 icc 9.1 | [root_v5.14.00.macosx-i386-icc-9.1.tar.gz](https://root.cern.ch/download/root_v5.14.00.macosx-i386-icc-9.1.tar.gz) |  71M |
-| macosx powerpc gcc 4.0 | [root_v5.14.00.macosx-powerpc-gcc-4.0.tar.gz](https://root.cern.ch/download/root_v5.14.00.macosx-powerpc-gcc-4.0.tar.gz) |  36M |
-| SunOS.5.9 | [root_v5.14.00.SunOS.5.9.tar.gz](https://root.cern.ch/download/root_v5.14.00.SunOS.5.9.tar.gz) |  41M |
-| win32gcc | [root_v5.14.00.win32gcc.tar.gz](https://root.cern.ch/download/root_v5.14.00.win32gcc.tar.gz) |  40M |
-| win32gdk (dbg) | [root_v5.14.00.win32gdk.debug.tar.gz](https://root.cern.ch/download/root_v5.14.00.win32gdk.debug.tar.gz) |  77M |
-| win32gdk | [root_v5.14.00.win32gdk.tar.gz](https://root.cern.ch/download/root_v5.14.00.win32gdk.tar.gz) |  41M |
-| root_v5.14.00d.Linux.slc3.gcc3.2.3 | [root_v5.14.00d.Linux.slc3.gcc3.2.3.tar.gz](https://root.cern.ch/download/root_v5.14.00d.Linux.slc3.gcc3.2.3.tar.gz) |  36M |
-| root_v5.14.00d.Linux.slc4.gcc3.4 | [root_v5.14.00d.Linux.slc4.gcc3.4.tar.gz](https://root.cern.ch/download/root_v5.14.00d.Linux.slc4.gcc3.4.tar.gz) |  37M |
-| root_v5.14.00d.Linux.slc4_amd64.gcc3.4 | [root_v5.14.00d.Linux.slc4_amd64.gcc3.4.tar.gz](https://root.cern.ch/download/root_v5.14.00d.Linux.slc4_amd64.gcc3.4.tar.gz) |  38M |
-| root_v5.14.00d.macosx powerpc gcc 4.0 | [root_v5.14.00d.macosx-powerpc-gcc-4.0.tar.gz](https://root.cern.ch/download/root_v5.14.00d.macosx-powerpc-gcc-4.0.tar.gz) |  36M |
-| root_v5.14.00e.Linux.slc3.gcc3.2.3 | [root_v5.14.00e.Linux.slc3.gcc3.2.3.tar.gz](https://root.cern.ch/download/root_v5.14.00e.Linux.slc3.gcc3.2.3.tar.gz) |  36M |
-| root_v5.14.00e.Linux.slc4.gcc3.4 | [root_v5.14.00e.Linux.slc4.gcc3.4.tar.gz](https://root.cern.ch/download/root_v5.14.00e.Linux.slc4.gcc3.4.tar.gz) |  37M |
-| root_v5.14.00e.Linux.slc4_amd64.gcc3.4 | [root_v5.14.00e.Linux.slc4_amd64.gcc3.4.tar.gz](https://root.cern.ch/download/root_v5.14.00e.Linux.slc4_amd64.gcc3.4.tar.gz) |  38M |
-| root_v5.14.00e.macosx powerpc gcc 4.0 | [root_v5.14.00e.macosx-powerpc-gcc-4.0.tar.gz](https://root.cern.ch/download/root_v5.14.00e.macosx-powerpc-gcc-4.0.tar.gz) |  36M |
+| Linux.RH9.0.gcc32 | [root_v5.14.00.Linux.RH9.0.gcc32.tar.gz](https://root.cern/download/root_v5.14.00.Linux.RH9.0.gcc32.tar.gz) |  44M |
+| Linux.slc3.gcc3.2.3 | [root_v5.14.00.Linux.slc3.gcc3.2.3.tar.gz](https://root.cern/download/root_v5.14.00.Linux.slc3.gcc3.2.3.tar.gz) |  41M |
+| Linux.slc3_amd64.gcc3.4.3 | [root_v5.14.00.Linux.slc3_amd64.gcc3.4.3.tar.gz](https://root.cern/download/root_v5.14.00.Linux.slc3_amd64.gcc3.4.3.tar.gz) |  45M |
+| Linux.slc4.gcc3.4 | [root_v5.14.00.Linux.slc4.gcc3.4.tar.gz](https://root.cern/download/root_v5.14.00.Linux.slc4.gcc3.4.tar.gz) |  37M |
+| Linux.slc4_amd64.gcc3.4 | [root_v5.14.00.Linux.slc4_amd64.gcc3.4.tar.gz](https://root.cern/download/root_v5.14.00.Linux.slc4_amd64.gcc3.4.tar.gz) |  36M |
+| macosx i386 gcc 4.0 | [root_v5.14.00.macosx-i386-gcc-4.0.tar.gz](https://root.cern/download/root_v5.14.00.macosx-i386-gcc-4.0.tar.gz) |  36M |
+| macosx i386 icc 9.1 | [root_v5.14.00.macosx-i386-icc-9.1.tar.gz](https://root.cern/download/root_v5.14.00.macosx-i386-icc-9.1.tar.gz) |  71M |
+| macosx powerpc gcc 4.0 | [root_v5.14.00.macosx-powerpc-gcc-4.0.tar.gz](https://root.cern/download/root_v5.14.00.macosx-powerpc-gcc-4.0.tar.gz) |  36M |
+| SunOS.5.9 | [root_v5.14.00.SunOS.5.9.tar.gz](https://root.cern/download/root_v5.14.00.SunOS.5.9.tar.gz) |  41M |
+| win32gcc | [root_v5.14.00.win32gcc.tar.gz](https://root.cern/download/root_v5.14.00.win32gcc.tar.gz) |  40M |
+| win32gdk (dbg) | [root_v5.14.00.win32gdk.debug.tar.gz](https://root.cern/download/root_v5.14.00.win32gdk.debug.tar.gz) |  77M |
+| win32gdk | [root_v5.14.00.win32gdk.tar.gz](https://root.cern/download/root_v5.14.00.win32gdk.tar.gz) |  41M |
+| root_v5.14.00d.Linux.slc3.gcc3.2.3 | [root_v5.14.00d.Linux.slc3.gcc3.2.3.tar.gz](https://root.cern/download/root_v5.14.00d.Linux.slc3.gcc3.2.3.tar.gz) |  36M |
+| root_v5.14.00d.Linux.slc4.gcc3.4 | [root_v5.14.00d.Linux.slc4.gcc3.4.tar.gz](https://root.cern/download/root_v5.14.00d.Linux.slc4.gcc3.4.tar.gz) |  37M |
+| root_v5.14.00d.Linux.slc4_amd64.gcc3.4 | [root_v5.14.00d.Linux.slc4_amd64.gcc3.4.tar.gz](https://root.cern/download/root_v5.14.00d.Linux.slc4_amd64.gcc3.4.tar.gz) |  38M |
+| root_v5.14.00d.macosx powerpc gcc 4.0 | [root_v5.14.00d.macosx-powerpc-gcc-4.0.tar.gz](https://root.cern/download/root_v5.14.00d.macosx-powerpc-gcc-4.0.tar.gz) |  36M |
+| root_v5.14.00e.Linux.slc3.gcc3.2.3 | [root_v5.14.00e.Linux.slc3.gcc3.2.3.tar.gz](https://root.cern/download/root_v5.14.00e.Linux.slc3.gcc3.2.3.tar.gz) |  36M |
+| root_v5.14.00e.Linux.slc4.gcc3.4 | [root_v5.14.00e.Linux.slc4.gcc3.4.tar.gz](https://root.cern/download/root_v5.14.00e.Linux.slc4.gcc3.4.tar.gz) |  37M |
+| root_v5.14.00e.Linux.slc4_amd64.gcc3.4 | [root_v5.14.00e.Linux.slc4_amd64.gcc3.4.tar.gz](https://root.cern/download/root_v5.14.00e.Linux.slc4_amd64.gcc3.4.tar.gz) |  38M |
+| root_v5.14.00e.macosx powerpc gcc 4.0 | [root_v5.14.00e.macosx-powerpc-gcc-4.0.tar.gz](https://root.cern/download/root_v5.14.00e.macosx-powerpc-gcc-4.0.tar.gz) |  36M |
 
 
 ## Git

--- a/_releases/release-51400d.md
+++ b/_releases/release-51400d.md
@@ -15,17 +15,17 @@ sidebar:
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v5.14.00d.source.tar.gz](https://root.cern.ch/download/root_v5.14.00d.source.tar.gz) |  20M |
+| source | [root_v5.14.00d.source.tar.gz](https://root.cern/download/root_v5.14.00d.source.tar.gz) |  20M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| Linux.slc3.gcc3.2.3 | [root_v5.14.00d.Linux.slc3.gcc3.2.3.tar.gz](https://root.cern.ch/download/root_v5.14.00d.Linux.slc3.gcc3.2.3.tar.gz) |  36M |
-| Linux.slc4.gcc3.4 | [root_v5.14.00d.Linux.slc4.gcc3.4.tar.gz](https://root.cern.ch/download/root_v5.14.00d.Linux.slc4.gcc3.4.tar.gz) |  37M |
-| Linux.slc4_amd64.gcc3.4 | [root_v5.14.00d.Linux.slc4_amd64.gcc3.4.tar.gz](https://root.cern.ch/download/root_v5.14.00d.Linux.slc4_amd64.gcc3.4.tar.gz) |  38M |
-| macosx powerpc gcc 4.0 | [root_v5.14.00d.macosx-powerpc-gcc-4.0.tar.gz](https://root.cern.ch/download/root_v5.14.00d.macosx-powerpc-gcc-4.0.tar.gz) |  36M |
+| Linux.slc3.gcc3.2.3 | [root_v5.14.00d.Linux.slc3.gcc3.2.3.tar.gz](https://root.cern/download/root_v5.14.00d.Linux.slc3.gcc3.2.3.tar.gz) |  36M |
+| Linux.slc4.gcc3.4 | [root_v5.14.00d.Linux.slc4.gcc3.4.tar.gz](https://root.cern/download/root_v5.14.00d.Linux.slc4.gcc3.4.tar.gz) |  37M |
+| Linux.slc4_amd64.gcc3.4 | [root_v5.14.00d.Linux.slc4_amd64.gcc3.4.tar.gz](https://root.cern/download/root_v5.14.00d.Linux.slc4_amd64.gcc3.4.tar.gz) |  38M |
+| macosx powerpc gcc 4.0 | [root_v5.14.00d.macosx-powerpc-gcc-4.0.tar.gz](https://root.cern/download/root_v5.14.00d.macosx-powerpc-gcc-4.0.tar.gz) |  36M |
 
 
 ## Git

--- a/_releases/release-51400e.md
+++ b/_releases/release-51400e.md
@@ -15,17 +15,17 @@ sidebar:
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v5.14.00e.source.tar.gz](https://root.cern.ch/download/root_v5.14.00e.source.tar.gz) |  20M |
+| source | [root_v5.14.00e.source.tar.gz](https://root.cern/download/root_v5.14.00e.source.tar.gz) |  20M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| Linux.slc3.gcc3.2.3 | [root_v5.14.00e.Linux.slc3.gcc3.2.3.tar.gz](https://root.cern.ch/download/root_v5.14.00e.Linux.slc3.gcc3.2.3.tar.gz) |  36M |
-| Linux.slc4.gcc3.4 | [root_v5.14.00e.Linux.slc4.gcc3.4.tar.gz](https://root.cern.ch/download/root_v5.14.00e.Linux.slc4.gcc3.4.tar.gz) |  37M |
-| Linux.slc4_amd64.gcc3.4 | [root_v5.14.00e.Linux.slc4_amd64.gcc3.4.tar.gz](https://root.cern.ch/download/root_v5.14.00e.Linux.slc4_amd64.gcc3.4.tar.gz) |  38M |
-| macosx powerpc gcc 4.0 | [root_v5.14.00e.macosx-powerpc-gcc-4.0.tar.gz](https://root.cern.ch/download/root_v5.14.00e.macosx-powerpc-gcc-4.0.tar.gz) |  36M |
+| Linux.slc3.gcc3.2.3 | [root_v5.14.00e.Linux.slc3.gcc3.2.3.tar.gz](https://root.cern/download/root_v5.14.00e.Linux.slc3.gcc3.2.3.tar.gz) |  36M |
+| Linux.slc4.gcc3.4 | [root_v5.14.00e.Linux.slc4.gcc3.4.tar.gz](https://root.cern/download/root_v5.14.00e.Linux.slc4.gcc3.4.tar.gz) |  37M |
+| Linux.slc4_amd64.gcc3.4 | [root_v5.14.00e.Linux.slc4_amd64.gcc3.4.tar.gz](https://root.cern/download/root_v5.14.00e.Linux.slc4_amd64.gcc3.4.tar.gz) |  38M |
+| macosx powerpc gcc 4.0 | [root_v5.14.00e.macosx-powerpc-gcc-4.0.tar.gz](https://root.cern/download/root_v5.14.00e.macosx-powerpc-gcc-4.0.tar.gz) |  36M |
 
 
 ## Git

--- a/_releases/release-51502.md
+++ b/_releases/release-51502.md
@@ -15,25 +15,25 @@ sidebar:
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v5.15.02.source.tar.gz](https://root.cern.ch/download/root_v5.15.02.source.tar.gz) |  20M |
+| source | [root_v5.15.02.source.tar.gz](https://root.cern/download/root_v5.15.02.source.tar.gz) |  20M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| Linux.RH9.0.gcc32 | [root_v5.15.02.Linux.RH9.0.gcc32.tar.gz](https://root.cern.ch/download/root_v5.15.02.Linux.RH9.0.gcc32.tar.gz) |  38M |
-| Linux.slc3.gcc3.2.3 | [root_v5.15.02.Linux.slc3.gcc3.2.3.tar.gz](https://root.cern.ch/download/root_v5.15.02.Linux.slc3.gcc3.2.3.tar.gz) |  36M |
-| Linux.slc4.amd64.gcc3.4 | [root_v5.15.02.Linux.slc4.amd64.gcc3.4.tar.gz](https://root.cern.ch/download/root_v5.15.02.Linux.slc4.amd64.gcc3.4.tar.gz) |  39M |
-| Linux.slc4.gcc3.4 | [root_v5.15.02.Linux.slc4.gcc3.4.tar.gz](https://root.cern.ch/download/root_v5.15.02.Linux.slc4.gcc3.4.tar.gz) |  37M |
-| Linux.slc4_amd64.gcc3.4 | [root_v5.15.02.Linux.slc4_amd64.gcc3.4.tar.gz](https://root.cern.ch/download/root_v5.15.02.Linux.slc4_amd64.gcc3.4.tar.gz) |  37M |
-| macosx i386 gcc 4.0 | [root_v5.15.02.macosx-i386-gcc-4.0.tar.gz](https://root.cern.ch/download/root_v5.15.02.macosx-i386-gcc-4.0.tar.gz) |  41M |
-| macosx i386 icc 9.1 | [root_v5.15.02.macosx-i386-icc-9.1.tar.gz](https://root.cern.ch/download/root_v5.15.02.macosx-i386-icc-9.1.tar.gz) |  71M |
-| macosx powerpc gcc 4.0 | [root_v5.15.02.macosx-powerpc-gcc-4.0.tar.gz](https://root.cern.ch/download/root_v5.15.02.macosx-powerpc-gcc-4.0.tar.gz) |  36M |
-| SunOS.5.9 | [root_v5.15.02.SunOS.5.9.tar.gz](https://root.cern.ch/download/root_v5.15.02.SunOS.5.9.tar.gz) |  41M |
-| win32gcc | [root_v5.15.02.win32gcc.tar.gz](https://root.cern.ch/download/root_v5.15.02.win32gcc.tar.gz) |  40M |
-| win32gdk (dbg) | [root_v5.15.02.win32gdk.debug.tar.gz](https://root.cern.ch/download/root_v5.15.02.win32gdk.debug.tar.gz) |  80M |
-| win32gdk | [root_v5.15.02.win32gdk.tar.gz](https://root.cern.ch/download/root_v5.15.02.win32gdk.tar.gz) |  41M |
+| Linux.RH9.0.gcc32 | [root_v5.15.02.Linux.RH9.0.gcc32.tar.gz](https://root.cern/download/root_v5.15.02.Linux.RH9.0.gcc32.tar.gz) |  38M |
+| Linux.slc3.gcc3.2.3 | [root_v5.15.02.Linux.slc3.gcc3.2.3.tar.gz](https://root.cern/download/root_v5.15.02.Linux.slc3.gcc3.2.3.tar.gz) |  36M |
+| Linux.slc4.amd64.gcc3.4 | [root_v5.15.02.Linux.slc4.amd64.gcc3.4.tar.gz](https://root.cern/download/root_v5.15.02.Linux.slc4.amd64.gcc3.4.tar.gz) |  39M |
+| Linux.slc4.gcc3.4 | [root_v5.15.02.Linux.slc4.gcc3.4.tar.gz](https://root.cern/download/root_v5.15.02.Linux.slc4.gcc3.4.tar.gz) |  37M |
+| Linux.slc4_amd64.gcc3.4 | [root_v5.15.02.Linux.slc4_amd64.gcc3.4.tar.gz](https://root.cern/download/root_v5.15.02.Linux.slc4_amd64.gcc3.4.tar.gz) |  37M |
+| macosx i386 gcc 4.0 | [root_v5.15.02.macosx-i386-gcc-4.0.tar.gz](https://root.cern/download/root_v5.15.02.macosx-i386-gcc-4.0.tar.gz) |  41M |
+| macosx i386 icc 9.1 | [root_v5.15.02.macosx-i386-icc-9.1.tar.gz](https://root.cern/download/root_v5.15.02.macosx-i386-icc-9.1.tar.gz) |  71M |
+| macosx powerpc gcc 4.0 | [root_v5.15.02.macosx-powerpc-gcc-4.0.tar.gz](https://root.cern/download/root_v5.15.02.macosx-powerpc-gcc-4.0.tar.gz) |  36M |
+| SunOS.5.9 | [root_v5.15.02.SunOS.5.9.tar.gz](https://root.cern/download/root_v5.15.02.SunOS.5.9.tar.gz) |  41M |
+| win32gcc | [root_v5.15.02.win32gcc.tar.gz](https://root.cern/download/root_v5.15.02.win32gcc.tar.gz) |  40M |
+| win32gdk (dbg) | [root_v5.15.02.win32gdk.debug.tar.gz](https://root.cern/download/root_v5.15.02.win32gdk.debug.tar.gz) |  80M |
+| win32gdk | [root_v5.15.02.win32gdk.tar.gz](https://root.cern/download/root_v5.15.02.win32gdk.tar.gz) |  41M |
 
 
 ## Git

--- a/_releases/release-51504.md
+++ b/_releases/release-51504.md
@@ -15,25 +15,25 @@ sidebar:
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v5.15.04.source.tar.gz](https://root.cern.ch/download/root_v5.15.04.source.tar.gz) |  21M |
+| source | [root_v5.15.04.source.tar.gz](https://root.cern/download/root_v5.15.04.source.tar.gz) |  21M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| Linux.RH9.0.gcc32 | [root_v5.15.04.Linux.RH9.0.gcc32.tar.gz](https://root.cern.ch/download/root_v5.15.04.Linux.RH9.0.gcc32.tar.gz) |  40M |
-| Linux.slc3.gcc3.2.3 | [root_v5.15.04.Linux.slc3.gcc3.2.3.tar.gz](https://root.cern.ch/download/root_v5.15.04.Linux.slc3.gcc3.2.3.tar.gz) |  36M |
-| Linux.slc4.amd64.gcc3.4 | [root_v5.15.04.Linux.slc4.amd64.gcc3.4.tar.gz](https://root.cern.ch/download/root_v5.15.04.Linux.slc4.amd64.gcc3.4.tar.gz) |  40M |
-| Linux.slc4.gcc3.4 | [root_v5.15.04.Linux.slc4.gcc3.4.tar.gz](https://root.cern.ch/download/root_v5.15.04.Linux.slc4.gcc3.4.tar.gz) |  38M |
-| Linux.slc4_amd64.gcc3.4 | [root_v5.15.04.Linux.slc4_amd64.gcc3.4.tar.gz](https://root.cern.ch/download/root_v5.15.04.Linux.slc4_amd64.gcc3.4.tar.gz) |  38M |
-| macosx i386 gcc 4.0 | [root_v5.15.04.macosx-i386-gcc-4.0.tar.gz](https://root.cern.ch/download/root_v5.15.04.macosx-i386-gcc-4.0.tar.gz) |  40M |
-| macosx i386 icc 9.1 | [root_v5.15.04.macosx-i386-icc-9.1.tar.gz](https://root.cern.ch/download/root_v5.15.04.macosx-i386-icc-9.1.tar.gz) |  72M |
-| macosx powerpc gcc 4.0 | [root_v5.15.04.macosx-powerpc-gcc-4.0.tar.gz](https://root.cern.ch/download/root_v5.15.04.macosx-powerpc-gcc-4.0.tar.gz) |  37M |
-| SunOS.5.9 | [root_v5.15.04.SunOS.5.9.tar.gz](https://root.cern.ch/download/root_v5.15.04.SunOS.5.9.tar.gz) |  41M |
-| win32gcc | [root_v5.15.04.win32gcc.tar.gz](https://root.cern.ch/download/root_v5.15.04.win32gcc.tar.gz) |  41M |
-| win32gdk (dbg) | [root_v5.15.04.win32gdk.debug.tar.gz](https://root.cern.ch/download/root_v5.15.04.win32gdk.debug.tar.gz) |  83M |
-| win32gdk | [root_v5.15.04.win32gdk.tar.gz](https://root.cern.ch/download/root_v5.15.04.win32gdk.tar.gz) |  43M |
+| Linux.RH9.0.gcc32 | [root_v5.15.04.Linux.RH9.0.gcc32.tar.gz](https://root.cern/download/root_v5.15.04.Linux.RH9.0.gcc32.tar.gz) |  40M |
+| Linux.slc3.gcc3.2.3 | [root_v5.15.04.Linux.slc3.gcc3.2.3.tar.gz](https://root.cern/download/root_v5.15.04.Linux.slc3.gcc3.2.3.tar.gz) |  36M |
+| Linux.slc4.amd64.gcc3.4 | [root_v5.15.04.Linux.slc4.amd64.gcc3.4.tar.gz](https://root.cern/download/root_v5.15.04.Linux.slc4.amd64.gcc3.4.tar.gz) |  40M |
+| Linux.slc4.gcc3.4 | [root_v5.15.04.Linux.slc4.gcc3.4.tar.gz](https://root.cern/download/root_v5.15.04.Linux.slc4.gcc3.4.tar.gz) |  38M |
+| Linux.slc4_amd64.gcc3.4 | [root_v5.15.04.Linux.slc4_amd64.gcc3.4.tar.gz](https://root.cern/download/root_v5.15.04.Linux.slc4_amd64.gcc3.4.tar.gz) |  38M |
+| macosx i386 gcc 4.0 | [root_v5.15.04.macosx-i386-gcc-4.0.tar.gz](https://root.cern/download/root_v5.15.04.macosx-i386-gcc-4.0.tar.gz) |  40M |
+| macosx i386 icc 9.1 | [root_v5.15.04.macosx-i386-icc-9.1.tar.gz](https://root.cern/download/root_v5.15.04.macosx-i386-icc-9.1.tar.gz) |  72M |
+| macosx powerpc gcc 4.0 | [root_v5.15.04.macosx-powerpc-gcc-4.0.tar.gz](https://root.cern/download/root_v5.15.04.macosx-powerpc-gcc-4.0.tar.gz) |  37M |
+| SunOS.5.9 | [root_v5.15.04.SunOS.5.9.tar.gz](https://root.cern/download/root_v5.15.04.SunOS.5.9.tar.gz) |  41M |
+| win32gcc | [root_v5.15.04.win32gcc.tar.gz](https://root.cern/download/root_v5.15.04.win32gcc.tar.gz) |  41M |
+| win32gdk (dbg) | [root_v5.15.04.win32gdk.debug.tar.gz](https://root.cern/download/root_v5.15.04.win32gdk.debug.tar.gz) |  83M |
+| win32gdk | [root_v5.15.04.win32gdk.tar.gz](https://root.cern/download/root_v5.15.04.win32gdk.tar.gz) |  43M |
 
 
 ## Git

--- a/_releases/release-51506.md
+++ b/_releases/release-51506.md
@@ -15,27 +15,27 @@ sidebar:
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v5.15.06.source.tar.gz](https://root.cern.ch/download/root_v5.15.06.source.tar.gz) |  21M |
+| source | [root_v5.15.06.source.tar.gz](https://root.cern/download/root_v5.15.06.source.tar.gz) |  21M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| Linux.RH9.0.gcc32 | [root_v5.15.06.Linux.RH9.0.gcc32.tar.gz](https://root.cern.ch/download/root_v5.15.06.Linux.RH9.0.gcc32.tar.gz) |  35M |
-| Linux.slc3.gcc3.2.3 | [root_v5.15.06.Linux.slc3.gcc3.2.3.tar.gz](https://root.cern.ch/download/root_v5.15.06.Linux.slc3.gcc3.2.3.tar.gz) |  34M |
-| Linux.slc4.amd64.gcc3.4 | [root_v5.15.06.Linux.slc4.amd64.gcc3.4.tar.gz](https://root.cern.ch/download/root_v5.15.06.Linux.slc4.amd64.gcc3.4.tar.gz) |  37M |
-| Linux.slc4.gcc3.4 | [root_v5.15.06.Linux.slc4.gcc3.4.tar.gz](https://root.cern.ch/download/root_v5.15.06.Linux.slc4.gcc3.4.tar.gz) |  35M |
-| Linux.slc4_amd64.gcc3.4 | [root_v5.15.06.Linux.slc4_amd64.gcc3.4.tar.gz](https://root.cern.ch/download/root_v5.15.06.Linux.slc4_amd64.gcc3.4.tar.gz) |  36M |
-| macosx i386 gcc 4.0 | [root_v5.15.06.macosx-i386-gcc-4.0.tar.gz](https://root.cern.ch/download/root_v5.15.06.macosx-i386-gcc-4.0.tar.gz) |  38M |
-| macosx i386 icc 9.1 | [root_v5.15.06.macosx-i386-icc-9.1.tar.gz](https://root.cern.ch/download/root_v5.15.06.macosx-i386-icc-9.1.tar.gz) |  71M |
-| macosx powerpc gcc 4.0 | [root_v5.15.06.macosx-powerpc-gcc-4.0.tar.gz](https://root.cern.ch/download/root_v5.15.06.macosx-powerpc-gcc-4.0.tar.gz) |  35M |
-| SunOS.5.9 | [root_v5.15.06.SunOS.5.9.tar.gz](https://root.cern.ch/download/root_v5.15.06.SunOS.5.9.tar.gz) |  41M |
-| win32.vc80 (dbg) | [root_v5.15.06.win32.vc80.debug.tar.gz](https://root.cern.ch/download/root_v5.15.06.win32.vc80.debug.tar.gz) |  88M |
-| win32.vc80 | [root_v5.15.06.win32.vc80.tar.gz](https://root.cern.ch/download/root_v5.15.06.win32.vc80.tar.gz) |  40M |
-| win32gcc | [root_v5.15.06.win32gcc.tar.gz](https://root.cern.ch/download/root_v5.15.06.win32gcc.tar.gz) |  42M |
-| win32gdk (dbg) | [root_v5.15.06.win32gdk.debug.tar.gz](https://root.cern.ch/download/root_v5.15.06.win32gdk.debug.tar.gz) |  85M |
-| win32gdk | [root_v5.15.06.win32gdk.tar.gz](https://root.cern.ch/download/root_v5.15.06.win32gdk.tar.gz) |  43M |
+| Linux.RH9.0.gcc32 | [root_v5.15.06.Linux.RH9.0.gcc32.tar.gz](https://root.cern/download/root_v5.15.06.Linux.RH9.0.gcc32.tar.gz) |  35M |
+| Linux.slc3.gcc3.2.3 | [root_v5.15.06.Linux.slc3.gcc3.2.3.tar.gz](https://root.cern/download/root_v5.15.06.Linux.slc3.gcc3.2.3.tar.gz) |  34M |
+| Linux.slc4.amd64.gcc3.4 | [root_v5.15.06.Linux.slc4.amd64.gcc3.4.tar.gz](https://root.cern/download/root_v5.15.06.Linux.slc4.amd64.gcc3.4.tar.gz) |  37M |
+| Linux.slc4.gcc3.4 | [root_v5.15.06.Linux.slc4.gcc3.4.tar.gz](https://root.cern/download/root_v5.15.06.Linux.slc4.gcc3.4.tar.gz) |  35M |
+| Linux.slc4_amd64.gcc3.4 | [root_v5.15.06.Linux.slc4_amd64.gcc3.4.tar.gz](https://root.cern/download/root_v5.15.06.Linux.slc4_amd64.gcc3.4.tar.gz) |  36M |
+| macosx i386 gcc 4.0 | [root_v5.15.06.macosx-i386-gcc-4.0.tar.gz](https://root.cern/download/root_v5.15.06.macosx-i386-gcc-4.0.tar.gz) |  38M |
+| macosx i386 icc 9.1 | [root_v5.15.06.macosx-i386-icc-9.1.tar.gz](https://root.cern/download/root_v5.15.06.macosx-i386-icc-9.1.tar.gz) |  71M |
+| macosx powerpc gcc 4.0 | [root_v5.15.06.macosx-powerpc-gcc-4.0.tar.gz](https://root.cern/download/root_v5.15.06.macosx-powerpc-gcc-4.0.tar.gz) |  35M |
+| SunOS.5.9 | [root_v5.15.06.SunOS.5.9.tar.gz](https://root.cern/download/root_v5.15.06.SunOS.5.9.tar.gz) |  41M |
+| win32.vc80 (dbg) | [root_v5.15.06.win32.vc80.debug.tar.gz](https://root.cern/download/root_v5.15.06.win32.vc80.debug.tar.gz) |  88M |
+| win32.vc80 | [root_v5.15.06.win32.vc80.tar.gz](https://root.cern/download/root_v5.15.06.win32.vc80.tar.gz) |  40M |
+| win32gcc | [root_v5.15.06.win32gcc.tar.gz](https://root.cern/download/root_v5.15.06.win32gcc.tar.gz) |  42M |
+| win32gdk (dbg) | [root_v5.15.06.win32gdk.debug.tar.gz](https://root.cern/download/root_v5.15.06.win32gdk.debug.tar.gz) |  85M |
+| win32gdk | [root_v5.15.06.win32gdk.tar.gz](https://root.cern/download/root_v5.15.06.win32gdk.tar.gz) |  43M |
 
 
 ## Git

--- a/_releases/release-51508.md
+++ b/_releases/release-51508.md
@@ -15,27 +15,27 @@ sidebar:
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v5.15.08.source.tar.gz](https://root.cern.ch/download/root_v5.15.08.source.tar.gz) |  21M |
+| source | [root_v5.15.08.source.tar.gz](https://root.cern/download/root_v5.15.08.source.tar.gz) |  21M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| Linux.RH9.0.gcc32 | [root_v5.15.08.Linux.RH9.0.gcc32.tar.gz](https://root.cern.ch/download/root_v5.15.08.Linux.RH9.0.gcc32.tar.gz) |  36M |
-| Linux.slc3.gcc3.2.3 | [root_v5.15.08.Linux.slc3.gcc3.2.3.tar.gz](https://root.cern.ch/download/root_v5.15.08.Linux.slc3.gcc3.2.3.tar.gz) |  37M |
-| Linux.slc4.amd64.gcc3.4 | [root_v5.15.08.Linux.slc4.amd64.gcc3.4.tar.gz](https://root.cern.ch/download/root_v5.15.08.Linux.slc4.amd64.gcc3.4.tar.gz) |  37M |
-| Linux.slc4.gcc3.4 | [root_v5.15.08.Linux.slc4.gcc3.4.tar.gz](https://root.cern.ch/download/root_v5.15.08.Linux.slc4.gcc3.4.tar.gz) |  35M |
-| Linux.slc4_amd64.gcc3.4 | [root_v5.15.08.Linux.slc4_amd64.gcc3.4.tar.gz](https://root.cern.ch/download/root_v5.15.08.Linux.slc4_amd64.gcc3.4.tar.gz) |  36M |
-| macosx i386 gcc 4.0 | [root_v5.15.08.macosx-i386-gcc-4.0.tar.gz](https://root.cern.ch/download/root_v5.15.08.macosx-i386-gcc-4.0.tar.gz) |  38M |
-| macosx i386 icc 9.1 | [root_v5.15.08.macosx-i386-icc-9.1.tar.gz](https://root.cern.ch/download/root_v5.15.08.macosx-i386-icc-9.1.tar.gz) |  71M |
-| macosx powerpc gcc 4.0 | [root_v5.15.08.macosx-powerpc-gcc-4.0.tar.gz](https://root.cern.ch/download/root_v5.15.08.macosx-powerpc-gcc-4.0.tar.gz) |  35M |
-| SunOS.5.9 | [root_v5.15.08.SunOS.5.9.tar.gz](https://root.cern.ch/download/root_v5.15.08.SunOS.5.9.tar.gz) |  41M |
-| win32.vc80 (dbg) | [root_v5.15.08.win32.vc80.debug.tar.gz](https://root.cern.ch/download/root_v5.15.08.win32.vc80.debug.tar.gz) |  92M |
-| win32.vc80 | [root_v5.15.08.win32.vc80.tar.gz](https://root.cern.ch/download/root_v5.15.08.win32.vc80.tar.gz) |  41M |
-| win32gcc | [root_v5.15.08.win32gcc.tar.gz](https://root.cern.ch/download/root_v5.15.08.win32gcc.tar.gz) |  43M |
-| win32gdk (dbg) | [root_v5.15.08.win32gdk.debug.tar.gz](https://root.cern.ch/download/root_v5.15.08.win32gdk.debug.tar.gz) |  87M |
-| win32gdk | [root_v5.15.08.win32gdk.tar.gz](https://root.cern.ch/download/root_v5.15.08.win32gdk.tar.gz) |  44M |
+| Linux.RH9.0.gcc32 | [root_v5.15.08.Linux.RH9.0.gcc32.tar.gz](https://root.cern/download/root_v5.15.08.Linux.RH9.0.gcc32.tar.gz) |  36M |
+| Linux.slc3.gcc3.2.3 | [root_v5.15.08.Linux.slc3.gcc3.2.3.tar.gz](https://root.cern/download/root_v5.15.08.Linux.slc3.gcc3.2.3.tar.gz) |  37M |
+| Linux.slc4.amd64.gcc3.4 | [root_v5.15.08.Linux.slc4.amd64.gcc3.4.tar.gz](https://root.cern/download/root_v5.15.08.Linux.slc4.amd64.gcc3.4.tar.gz) |  37M |
+| Linux.slc4.gcc3.4 | [root_v5.15.08.Linux.slc4.gcc3.4.tar.gz](https://root.cern/download/root_v5.15.08.Linux.slc4.gcc3.4.tar.gz) |  35M |
+| Linux.slc4_amd64.gcc3.4 | [root_v5.15.08.Linux.slc4_amd64.gcc3.4.tar.gz](https://root.cern/download/root_v5.15.08.Linux.slc4_amd64.gcc3.4.tar.gz) |  36M |
+| macosx i386 gcc 4.0 | [root_v5.15.08.macosx-i386-gcc-4.0.tar.gz](https://root.cern/download/root_v5.15.08.macosx-i386-gcc-4.0.tar.gz) |  38M |
+| macosx i386 icc 9.1 | [root_v5.15.08.macosx-i386-icc-9.1.tar.gz](https://root.cern/download/root_v5.15.08.macosx-i386-icc-9.1.tar.gz) |  71M |
+| macosx powerpc gcc 4.0 | [root_v5.15.08.macosx-powerpc-gcc-4.0.tar.gz](https://root.cern/download/root_v5.15.08.macosx-powerpc-gcc-4.0.tar.gz) |  35M |
+| SunOS.5.9 | [root_v5.15.08.SunOS.5.9.tar.gz](https://root.cern/download/root_v5.15.08.SunOS.5.9.tar.gz) |  41M |
+| win32.vc80 (dbg) | [root_v5.15.08.win32.vc80.debug.tar.gz](https://root.cern/download/root_v5.15.08.win32.vc80.debug.tar.gz) |  92M |
+| win32.vc80 | [root_v5.15.08.win32.vc80.tar.gz](https://root.cern/download/root_v5.15.08.win32.vc80.tar.gz) |  41M |
+| win32gcc | [root_v5.15.08.win32gcc.tar.gz](https://root.cern/download/root_v5.15.08.win32gcc.tar.gz) |  43M |
+| win32gdk (dbg) | [root_v5.15.08.win32gdk.debug.tar.gz](https://root.cern/download/root_v5.15.08.win32gdk.debug.tar.gz) |  87M |
+| win32gdk | [root_v5.15.08.win32gdk.tar.gz](https://root.cern/download/root_v5.15.08.win32gdk.tar.gz) |  44M |
 
 
 ## Git

--- a/_releases/release-51600.md
+++ b/_releases/release-51600.md
@@ -15,27 +15,27 @@ sidebar:
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v5.16.00.source.tar.gz](https://root.cern.ch/download/root_v5.16.00.source.tar.gz) |  21M |
+| source | [root_v5.16.00.source.tar.gz](https://root.cern/download/root_v5.16.00.source.tar.gz) |  21M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| Linux.RH9.0.gcc32 | [root_v5.16.00.Linux.RH9.0.gcc32.tar.gz](https://root.cern.ch/download/root_v5.16.00.Linux.RH9.0.gcc32.tar.gz) |  35M |
-| Linux.slc3.gcc3.2.3 | [root_v5.16.00.Linux.slc3.gcc3.2.3.tar.gz](https://root.cern.ch/download/root_v5.16.00.Linux.slc3.gcc3.2.3.tar.gz) |  34M |
-| Linux.slc4.amd64.gcc3.4 | [root_v5.16.00.Linux.slc4.amd64.gcc3.4.tar.gz](https://root.cern.ch/download/root_v5.16.00.Linux.slc4.amd64.gcc3.4.tar.gz) |  37M |
-| Linux.slc4.gcc3.4 | [root_v5.16.00.Linux.slc4.gcc3.4.tar.gz](https://root.cern.ch/download/root_v5.16.00.Linux.slc4.gcc3.4.tar.gz) |  34M |
-| Linux.slc4_amd64.gcc3.4 | [root_v5.16.00.Linux.slc4_amd64.gcc3.4.tar.gz](https://root.cern.ch/download/root_v5.16.00.Linux.slc4_amd64.gcc3.4.tar.gz) |  35M |
-| macosx i386 gcc 4.0 | [root_v5.16.00.macosx-i386-gcc-4.0.tar.gz](https://root.cern.ch/download/root_v5.16.00.macosx-i386-gcc-4.0.tar.gz) |  38M |
-| macosx i386 icc 9.1 | [root_v5.16.00.macosx-i386-icc-9.1.tar.gz](https://root.cern.ch/download/root_v5.16.00.macosx-i386-icc-9.1.tar.gz) |  70M |
-| macosx powerpc gcc 4.0 | [root_v5.16.00.macosx-powerpc-gcc-4.0.tar.gz](https://root.cern.ch/download/root_v5.16.00.macosx-powerpc-gcc-4.0.tar.gz) |  36M |
-| SunOS.5.9 | [root_v5.16.00.SunOS.5.9.tar.gz](https://root.cern.ch/download/root_v5.16.00.SunOS.5.9.tar.gz) |  40M |
-| win32.vc80 (dbg) | [root_v5.16.00.win32.vc80.debug.tar.gz](https://root.cern.ch/download/root_v5.16.00.win32.vc80.debug.tar.gz) |  89M |
-| win32.vc80 | [root_v5.16.00.win32.vc80.tar.gz](https://root.cern.ch/download/root_v5.16.00.win32.vc80.tar.gz) |  38M |
-| win32gcc | [root_v5.16.00.win32gcc.tar.gz](https://root.cern.ch/download/root_v5.16.00.win32gcc.tar.gz) |  43M |
-| win32gdk (dbg) | [root_v5.16.00.win32gdk.debug.tar.gz](https://root.cern.ch/download/root_v5.16.00.win32gdk.debug.tar.gz) |  82M |
-| win32gdk | [root_v5.16.00.win32gdk.tar.gz](https://root.cern.ch/download/root_v5.16.00.win32gdk.tar.gz) |  40M |
+| Linux.RH9.0.gcc32 | [root_v5.16.00.Linux.RH9.0.gcc32.tar.gz](https://root.cern/download/root_v5.16.00.Linux.RH9.0.gcc32.tar.gz) |  35M |
+| Linux.slc3.gcc3.2.3 | [root_v5.16.00.Linux.slc3.gcc3.2.3.tar.gz](https://root.cern/download/root_v5.16.00.Linux.slc3.gcc3.2.3.tar.gz) |  34M |
+| Linux.slc4.amd64.gcc3.4 | [root_v5.16.00.Linux.slc4.amd64.gcc3.4.tar.gz](https://root.cern/download/root_v5.16.00.Linux.slc4.amd64.gcc3.4.tar.gz) |  37M |
+| Linux.slc4.gcc3.4 | [root_v5.16.00.Linux.slc4.gcc3.4.tar.gz](https://root.cern/download/root_v5.16.00.Linux.slc4.gcc3.4.tar.gz) |  34M |
+| Linux.slc4_amd64.gcc3.4 | [root_v5.16.00.Linux.slc4_amd64.gcc3.4.tar.gz](https://root.cern/download/root_v5.16.00.Linux.slc4_amd64.gcc3.4.tar.gz) |  35M |
+| macosx i386 gcc 4.0 | [root_v5.16.00.macosx-i386-gcc-4.0.tar.gz](https://root.cern/download/root_v5.16.00.macosx-i386-gcc-4.0.tar.gz) |  38M |
+| macosx i386 icc 9.1 | [root_v5.16.00.macosx-i386-icc-9.1.tar.gz](https://root.cern/download/root_v5.16.00.macosx-i386-icc-9.1.tar.gz) |  70M |
+| macosx powerpc gcc 4.0 | [root_v5.16.00.macosx-powerpc-gcc-4.0.tar.gz](https://root.cern/download/root_v5.16.00.macosx-powerpc-gcc-4.0.tar.gz) |  36M |
+| SunOS.5.9 | [root_v5.16.00.SunOS.5.9.tar.gz](https://root.cern/download/root_v5.16.00.SunOS.5.9.tar.gz) |  40M |
+| win32.vc80 (dbg) | [root_v5.16.00.win32.vc80.debug.tar.gz](https://root.cern/download/root_v5.16.00.win32.vc80.debug.tar.gz) |  89M |
+| win32.vc80 | [root_v5.16.00.win32.vc80.tar.gz](https://root.cern/download/root_v5.16.00.win32.vc80.tar.gz) |  38M |
+| win32gcc | [root_v5.16.00.win32gcc.tar.gz](https://root.cern/download/root_v5.16.00.win32gcc.tar.gz) |  43M |
+| win32gdk (dbg) | [root_v5.16.00.win32gdk.debug.tar.gz](https://root.cern/download/root_v5.16.00.win32gdk.debug.tar.gz) |  82M |
+| win32gdk | [root_v5.16.00.win32gdk.tar.gz](https://root.cern/download/root_v5.16.00.win32gdk.tar.gz) |  40M |
 
 
 ## Git

--- a/_releases/release-51702.md
+++ b/_releases/release-51702.md
@@ -15,26 +15,26 @@ sidebar:
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v5.17.02.source.tar.gz](https://root.cern.ch/download/root_v5.17.02.source.tar.gz) |  21M |
+| source | [root_v5.17.02.source.tar.gz](https://root.cern/download/root_v5.17.02.source.tar.gz) |  21M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| Linux.slc3.gcc3.2.3 | [root_v5.17.02.Linux.slc3.gcc3.2.3.tar.gz](https://root.cern.ch/download/root_v5.17.02.Linux.slc3.gcc3.2.3.tar.gz) |  36M |
-| Linux.slc4.amd64.gcc3.4 | [root_v5.17.02.Linux.slc4.amd64.gcc3.4.tar.gz](https://root.cern.ch/download/root_v5.17.02.Linux.slc4.amd64.gcc3.4.tar.gz) |  39M |
-| Linux.slc4.gcc3.4 | [root_v5.17.02.Linux.slc4.gcc3.4.tar.gz](https://root.cern.ch/download/root_v5.17.02.Linux.slc4.gcc3.4.tar.gz) |  37M |
-| Linux.slc4_amd64.gcc3.4 | [root_v5.17.02.Linux.slc4_amd64.gcc3.4.tar.gz](https://root.cern.ch/download/root_v5.17.02.Linux.slc4_amd64.gcc3.4.tar.gz) |  38M |
-| macosx i386 gcc 4.0 | [root_v5.17.02.macosx-i386-gcc-4.0.tar.gz](https://root.cern.ch/download/root_v5.17.02.macosx-i386-gcc-4.0.tar.gz) |  40M |
-| macosx i386 icc 9.1 | [root_v5.17.02.macosx-i386-icc-9.1.tar.gz](https://root.cern.ch/download/root_v5.17.02.macosx-i386-icc-9.1.tar.gz) |  73M |
-| macosx powerpc gcc 4.0 | [root_v5.17.02.macosx-powerpc-gcc-4.0.tar.gz](https://root.cern.ch/download/root_v5.17.02.macosx-powerpc-gcc-4.0.tar.gz) |  36M |
-| SunOS.5.9 | [root_v5.17.02.SunOS.5.9.tar.gz](https://root.cern.ch/download/root_v5.17.02.SunOS.5.9.tar.gz) |  41M |
-| win32.vc80 (dbg) | [root_v5.17.02.win32.vc80.debug.tar.gz](https://root.cern.ch/download/root_v5.17.02.win32.vc80.debug.tar.gz) |  89M |
-| win32.vc80 | [root_v5.17.02.win32.vc80.tar.gz](https://root.cern.ch/download/root_v5.17.02.win32.vc80.tar.gz) |  38M |
-| win32gcc | [root_v5.17.02.win32gcc.tar.gz](https://root.cern.ch/download/root_v5.17.02.win32gcc.tar.gz) |  43M |
-| win32gdk (dbg) | [root_v5.17.02.win32gdk.debug.tar.gz](https://root.cern.ch/download/root_v5.17.02.win32gdk.debug.tar.gz) |  84M |
-| win32gdk | [root_v5.17.02.win32gdk.tar.gz](https://root.cern.ch/download/root_v5.17.02.win32gdk.tar.gz) |  42M |
+| Linux.slc3.gcc3.2.3 | [root_v5.17.02.Linux.slc3.gcc3.2.3.tar.gz](https://root.cern/download/root_v5.17.02.Linux.slc3.gcc3.2.3.tar.gz) |  36M |
+| Linux.slc4.amd64.gcc3.4 | [root_v5.17.02.Linux.slc4.amd64.gcc3.4.tar.gz](https://root.cern/download/root_v5.17.02.Linux.slc4.amd64.gcc3.4.tar.gz) |  39M |
+| Linux.slc4.gcc3.4 | [root_v5.17.02.Linux.slc4.gcc3.4.tar.gz](https://root.cern/download/root_v5.17.02.Linux.slc4.gcc3.4.tar.gz) |  37M |
+| Linux.slc4_amd64.gcc3.4 | [root_v5.17.02.Linux.slc4_amd64.gcc3.4.tar.gz](https://root.cern/download/root_v5.17.02.Linux.slc4_amd64.gcc3.4.tar.gz) |  38M |
+| macosx i386 gcc 4.0 | [root_v5.17.02.macosx-i386-gcc-4.0.tar.gz](https://root.cern/download/root_v5.17.02.macosx-i386-gcc-4.0.tar.gz) |  40M |
+| macosx i386 icc 9.1 | [root_v5.17.02.macosx-i386-icc-9.1.tar.gz](https://root.cern/download/root_v5.17.02.macosx-i386-icc-9.1.tar.gz) |  73M |
+| macosx powerpc gcc 4.0 | [root_v5.17.02.macosx-powerpc-gcc-4.0.tar.gz](https://root.cern/download/root_v5.17.02.macosx-powerpc-gcc-4.0.tar.gz) |  36M |
+| SunOS.5.9 | [root_v5.17.02.SunOS.5.9.tar.gz](https://root.cern/download/root_v5.17.02.SunOS.5.9.tar.gz) |  41M |
+| win32.vc80 (dbg) | [root_v5.17.02.win32.vc80.debug.tar.gz](https://root.cern/download/root_v5.17.02.win32.vc80.debug.tar.gz) |  89M |
+| win32.vc80 | [root_v5.17.02.win32.vc80.tar.gz](https://root.cern/download/root_v5.17.02.win32.vc80.tar.gz) |  38M |
+| win32gcc | [root_v5.17.02.win32gcc.tar.gz](https://root.cern/download/root_v5.17.02.win32gcc.tar.gz) |  43M |
+| win32gdk (dbg) | [root_v5.17.02.win32gdk.debug.tar.gz](https://root.cern/download/root_v5.17.02.win32gdk.debug.tar.gz) |  84M |
+| win32gdk | [root_v5.17.02.win32gdk.tar.gz](https://root.cern/download/root_v5.17.02.win32gdk.tar.gz) |  42M |
 
 
 ## Git

--- a/_releases/release-51704.md
+++ b/_releases/release-51704.md
@@ -15,26 +15,26 @@ sidebar:
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v5.17.04.source.tar.gz](https://root.cern.ch/download/root_v5.17.04.source.tar.gz) |  21M |
+| source | [root_v5.17.04.source.tar.gz](https://root.cern/download/root_v5.17.04.source.tar.gz) |  21M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| Linux.slc3.gcc3.2.3 | [root_v5.17.04.Linux.slc3.gcc3.2.3.tar.gz](https://root.cern.ch/download/root_v5.17.04.Linux.slc3.gcc3.2.3.tar.gz) |  39M |
-| Linux.slc4.amd64.gcc3.4 | [root_v5.17.04.Linux.slc4.amd64.gcc3.4.tar.gz](https://root.cern.ch/download/root_v5.17.04.Linux.slc4.amd64.gcc3.4.tar.gz) |  41M |
-| Linux.slc4.gcc3.4 | [root_v5.17.04.Linux.slc4.gcc3.4.tar.gz](https://root.cern.ch/download/root_v5.17.04.Linux.slc4.gcc3.4.tar.gz) |  39M |
-| Linux.slc4_amd64.gcc3.4 | [root_v5.17.04.Linux.slc4_amd64.gcc3.4.tar.gz](https://root.cern.ch/download/root_v5.17.04.Linux.slc4_amd64.gcc3.4.tar.gz) |  41M |
-| macosx i386 gcc 4.0 | [root_v5.17.04.macosx-i386-gcc-4.0.tar.gz](https://root.cern.ch/download/root_v5.17.04.macosx-i386-gcc-4.0.tar.gz) |  41M |
-| macosx i386 icc 9.1 | [root_v5.17.04.macosx-i386-icc-9.1.tar.gz](https://root.cern.ch/download/root_v5.17.04.macosx-i386-icc-9.1.tar.gz) |  76M |
-| macosx powerpc gcc 4.0 | [root_v5.17.04.macosx-powerpc-gcc-4.0.tar.gz](https://root.cern.ch/download/root_v5.17.04.macosx-powerpc-gcc-4.0.tar.gz) |  40M |
-| SunOS.5.9 | [root_v5.17.04.SunOS.5.9.tar.gz](https://root.cern.ch/download/root_v5.17.04.SunOS.5.9.tar.gz) |  44M |
-| win32.vc80 (dbg) | [root_v5.17.04.win32.vc80.debug.tar.gz](https://root.cern.ch/download/root_v5.17.04.win32.vc80.debug.tar.gz) |  91M |
-| win32.vc80 | [root_v5.17.04.win32.vc80.tar.gz](https://root.cern.ch/download/root_v5.17.04.win32.vc80.tar.gz) |  39M |
-| win32gcc | [root_v5.17.04.win32gcc.tar.gz](https://root.cern.ch/download/root_v5.17.04.win32gcc.tar.gz) |  44M |
-| win32gdk (dbg) | [root_v5.17.04.win32gdk.debug.tar.gz](https://root.cern.ch/download/root_v5.17.04.win32gdk.debug.tar.gz) |  67M |
-| win32gdk | [root_v5.17.04.win32gdk.tar.gz](https://root.cern.ch/download/root_v5.17.04.win32gdk.tar.gz) |  39M |
+| Linux.slc3.gcc3.2.3 | [root_v5.17.04.Linux.slc3.gcc3.2.3.tar.gz](https://root.cern/download/root_v5.17.04.Linux.slc3.gcc3.2.3.tar.gz) |  39M |
+| Linux.slc4.amd64.gcc3.4 | [root_v5.17.04.Linux.slc4.amd64.gcc3.4.tar.gz](https://root.cern/download/root_v5.17.04.Linux.slc4.amd64.gcc3.4.tar.gz) |  41M |
+| Linux.slc4.gcc3.4 | [root_v5.17.04.Linux.slc4.gcc3.4.tar.gz](https://root.cern/download/root_v5.17.04.Linux.slc4.gcc3.4.tar.gz) |  39M |
+| Linux.slc4_amd64.gcc3.4 | [root_v5.17.04.Linux.slc4_amd64.gcc3.4.tar.gz](https://root.cern/download/root_v5.17.04.Linux.slc4_amd64.gcc3.4.tar.gz) |  41M |
+| macosx i386 gcc 4.0 | [root_v5.17.04.macosx-i386-gcc-4.0.tar.gz](https://root.cern/download/root_v5.17.04.macosx-i386-gcc-4.0.tar.gz) |  41M |
+| macosx i386 icc 9.1 | [root_v5.17.04.macosx-i386-icc-9.1.tar.gz](https://root.cern/download/root_v5.17.04.macosx-i386-icc-9.1.tar.gz) |  76M |
+| macosx powerpc gcc 4.0 | [root_v5.17.04.macosx-powerpc-gcc-4.0.tar.gz](https://root.cern/download/root_v5.17.04.macosx-powerpc-gcc-4.0.tar.gz) |  40M |
+| SunOS.5.9 | [root_v5.17.04.SunOS.5.9.tar.gz](https://root.cern/download/root_v5.17.04.SunOS.5.9.tar.gz) |  44M |
+| win32.vc80 (dbg) | [root_v5.17.04.win32.vc80.debug.tar.gz](https://root.cern/download/root_v5.17.04.win32.vc80.debug.tar.gz) |  91M |
+| win32.vc80 | [root_v5.17.04.win32.vc80.tar.gz](https://root.cern/download/root_v5.17.04.win32.vc80.tar.gz) |  39M |
+| win32gcc | [root_v5.17.04.win32gcc.tar.gz](https://root.cern/download/root_v5.17.04.win32gcc.tar.gz) |  44M |
+| win32gdk (dbg) | [root_v5.17.04.win32gdk.debug.tar.gz](https://root.cern/download/root_v5.17.04.win32gdk.debug.tar.gz) |  67M |
+| win32gdk | [root_v5.17.04.win32gdk.tar.gz](https://root.cern/download/root_v5.17.04.win32gdk.tar.gz) |  39M |
 
 
 

--- a/_releases/release-51706.md
+++ b/_releases/release-51706.md
@@ -15,27 +15,27 @@ sidebar:
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v5.17.06.source.tar.gz](https://root.cern.ch/download/root_v5.17.06.source.tar.gz) |  22M |
+| source | [root_v5.17.06.source.tar.gz](https://root.cern/download/root_v5.17.06.source.tar.gz) |  22M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| Linux.slc4.amd64.gcc3.4 | [root_v5.17.06.Linux.slc4.amd64.gcc3.4.tar.gz](https://root.cern.ch/download/root_v5.17.06.Linux.slc4.amd64.gcc3.4.tar.gz) |  43M |
-| Linux.slc4.gcc3.4 | [root_v5.17.06.Linux.slc4.gcc3.4.tar.gz](https://root.cern.ch/download/root_v5.17.06.Linux.slc4.gcc3.4.tar.gz) |  41M |
-| Linux.slc4_amd64.gcc3.4 | [root_v5.17.06.Linux.slc4_amd64.gcc3.4.tar.gz](https://root.cern.ch/download/root_v5.17.06.Linux.slc4_amd64.gcc3.4.tar.gz) |  42M |
-| macosx i386 gcc 4.0 | [root_v5.17.06.macosx-i386-gcc-4.0.tar.gz](https://root.cern.ch/download/root_v5.17.06.macosx-i386-gcc-4.0.tar.gz) |  41M |
-| macosx i386 icc 9.1 | [root_v5.17.06.macosx-i386-icc-9.1.tar.gz](https://root.cern.ch/download/root_v5.17.06.macosx-i386-icc-9.1.tar.gz) |  79M |
-| macosx powerpc gcc 4.0 | [root_v5.17.06.macosx-powerpc-gcc-4.0.tar.gz](https://root.cern.ch/download/root_v5.17.06.macosx-powerpc-gcc-4.0.tar.gz) |  42M |
-| SunOS.5.9 | [root_v5.17.06.SunOS.5.9.tar.gz](https://root.cern.ch/download/root_v5.17.06.SunOS.5.9.tar.gz) |  45M |
-| win32 (dbg) | [root_v5.17.06.win32.debug.tar.gz](https://root.cern.ch/download/root_v5.17.06.win32.debug.tar.gz) |  80M |
-| win32 | [root_v5.17.06.win32.tar.gz](https://root.cern.ch/download/root_v5.17.06.win32.tar.gz) |  41M |
-| win32.vc80 (dbg) | [root_v5.17.06.win32.vc80.debug.tar.gz](https://root.cern.ch/download/root_v5.17.06.win32.vc80.debug.tar.gz) |  98M |
-| win32.vc80 | [root_v5.17.06.win32.vc80.tar.gz](https://root.cern.ch/download/root_v5.17.06.win32.vc80.tar.gz) |  42M |
-| win32gcc | [root_v5.17.06.win32gcc.tar.gz](https://root.cern.ch/download/root_v5.17.06.win32gcc.tar.gz) |  45M |
-| win32gdk (dbg) | [root_v5.17.06.win32gdk.debug.tar.gz](https://root.cern.ch/download/root_v5.17.06.win32gdk.debug.tar.gz) |  71M |
-| win32gdk | [root_v5.17.06.win32gdk.tar.gz](https://root.cern.ch/download/root_v5.17.06.win32gdk.tar.gz) |  41M |
+| Linux.slc4.amd64.gcc3.4 | [root_v5.17.06.Linux.slc4.amd64.gcc3.4.tar.gz](https://root.cern/download/root_v5.17.06.Linux.slc4.amd64.gcc3.4.tar.gz) |  43M |
+| Linux.slc4.gcc3.4 | [root_v5.17.06.Linux.slc4.gcc3.4.tar.gz](https://root.cern/download/root_v5.17.06.Linux.slc4.gcc3.4.tar.gz) |  41M |
+| Linux.slc4_amd64.gcc3.4 | [root_v5.17.06.Linux.slc4_amd64.gcc3.4.tar.gz](https://root.cern/download/root_v5.17.06.Linux.slc4_amd64.gcc3.4.tar.gz) |  42M |
+| macosx i386 gcc 4.0 | [root_v5.17.06.macosx-i386-gcc-4.0.tar.gz](https://root.cern/download/root_v5.17.06.macosx-i386-gcc-4.0.tar.gz) |  41M |
+| macosx i386 icc 9.1 | [root_v5.17.06.macosx-i386-icc-9.1.tar.gz](https://root.cern/download/root_v5.17.06.macosx-i386-icc-9.1.tar.gz) |  79M |
+| macosx powerpc gcc 4.0 | [root_v5.17.06.macosx-powerpc-gcc-4.0.tar.gz](https://root.cern/download/root_v5.17.06.macosx-powerpc-gcc-4.0.tar.gz) |  42M |
+| SunOS.5.9 | [root_v5.17.06.SunOS.5.9.tar.gz](https://root.cern/download/root_v5.17.06.SunOS.5.9.tar.gz) |  45M |
+| win32 (dbg) | [root_v5.17.06.win32.debug.tar.gz](https://root.cern/download/root_v5.17.06.win32.debug.tar.gz) |  80M |
+| win32 | [root_v5.17.06.win32.tar.gz](https://root.cern/download/root_v5.17.06.win32.tar.gz) |  41M |
+| win32.vc80 (dbg) | [root_v5.17.06.win32.vc80.debug.tar.gz](https://root.cern/download/root_v5.17.06.win32.vc80.debug.tar.gz) |  98M |
+| win32.vc80 | [root_v5.17.06.win32.vc80.tar.gz](https://root.cern/download/root_v5.17.06.win32.vc80.tar.gz) |  42M |
+| win32gcc | [root_v5.17.06.win32gcc.tar.gz](https://root.cern/download/root_v5.17.06.win32gcc.tar.gz) |  45M |
+| win32gdk (dbg) | [root_v5.17.06.win32gdk.debug.tar.gz](https://root.cern/download/root_v5.17.06.win32gdk.debug.tar.gz) |  71M |
+| win32gdk | [root_v5.17.06.win32gdk.tar.gz](https://root.cern/download/root_v5.17.06.win32gdk.tar.gz) |  41M |
 
 
 ## Git

--- a/_releases/release-51708.md
+++ b/_releases/release-51708.md
@@ -15,26 +15,26 @@ sidebar:
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v5.17.08.source.tar.gz](https://root.cern.ch/download/root_v5.17.08.source.tar.gz) |  23M |
+| source | [root_v5.17.08.source.tar.gz](https://root.cern/download/root_v5.17.08.source.tar.gz) |  23M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| Linux.slc4.amd64.gcc3.4 | [root_v5.17.08.Linux.slc4.amd64.gcc3.4.tar.gz](https://root.cern.ch/download/root_v5.17.08.Linux.slc4.amd64.gcc3.4.tar.gz) |  44M |
-| Linux.slc4.gcc3.4 | [root_v5.17.08.Linux.slc4.gcc3.4.tar.gz](https://root.cern.ch/download/root_v5.17.08.Linux.slc4.gcc3.4.tar.gz) |  41M |
-| Linux.slc4_amd64.gcc3.4 | [root_v5.17.08.Linux.slc4_amd64.gcc3.4.tar.gz](https://root.cern.ch/download/root_v5.17.08.Linux.slc4_amd64.gcc3.4.tar.gz) |  43M |
-| macosx i386 gcc 4.0 | [root_v5.17.08.macosx-i386-gcc-4.0.tar.gz](https://root.cern.ch/download/root_v5.17.08.macosx-i386-gcc-4.0.tar.gz) |  42M |
-| macosx i386 icc 9.1 | [root_v5.17.08.macosx-i386-icc-9.1.tar.gz](https://root.cern.ch/download/root_v5.17.08.macosx-i386-icc-9.1.tar.gz) |  80M |
-| macosx powerpc gcc 4.0 | [root_v5.17.08.macosx-powerpc-gcc-4.0.tar.gz](https://root.cern.ch/download/root_v5.17.08.macosx-powerpc-gcc-4.0.tar.gz) |  43M |
-| SunOS.5.9 | [root_v5.17.08.SunOS.5.9.tar.gz](https://root.cern.ch/download/root_v5.17.08.SunOS.5.9.tar.gz) |  45M |
-| win32 (dbg) | [root_v5.17.08.win32.debug.tar.gz](https://root.cern.ch/download/root_v5.17.08.win32.debug.tar.gz) |  79M |
-| win32 | [root_v5.17.08.win32.tar.gz](https://root.cern.ch/download/root_v5.17.08.win32.tar.gz) |  41M |
-| win32.vc80 (dbg) | [root_v5.17.08.win32.vc80.debug.tar.gz](https://root.cern.ch/download/root_v5.17.08.win32.vc80.debug.tar.gz) |  97M |
-| win32.vc80 | [root_v5.17.08.win32.vc80.tar.gz](https://root.cern.ch/download/root_v5.17.08.win32.vc80.tar.gz) |  42M |
-| win32gcc | [root_v5.17.08.win32gcc.tar.gz](https://root.cern.ch/download/root_v5.17.08.win32gcc.tar.gz) |  45M |
-| win32gdk | [root_v5.17.08.win32gdk.tar.gz](https://root.cern.ch/download/root_v5.17.08.win32gdk.tar.gz) |  41M |
+| Linux.slc4.amd64.gcc3.4 | [root_v5.17.08.Linux.slc4.amd64.gcc3.4.tar.gz](https://root.cern/download/root_v5.17.08.Linux.slc4.amd64.gcc3.4.tar.gz) |  44M |
+| Linux.slc4.gcc3.4 | [root_v5.17.08.Linux.slc4.gcc3.4.tar.gz](https://root.cern/download/root_v5.17.08.Linux.slc4.gcc3.4.tar.gz) |  41M |
+| Linux.slc4_amd64.gcc3.4 | [root_v5.17.08.Linux.slc4_amd64.gcc3.4.tar.gz](https://root.cern/download/root_v5.17.08.Linux.slc4_amd64.gcc3.4.tar.gz) |  43M |
+| macosx i386 gcc 4.0 | [root_v5.17.08.macosx-i386-gcc-4.0.tar.gz](https://root.cern/download/root_v5.17.08.macosx-i386-gcc-4.0.tar.gz) |  42M |
+| macosx i386 icc 9.1 | [root_v5.17.08.macosx-i386-icc-9.1.tar.gz](https://root.cern/download/root_v5.17.08.macosx-i386-icc-9.1.tar.gz) |  80M |
+| macosx powerpc gcc 4.0 | [root_v5.17.08.macosx-powerpc-gcc-4.0.tar.gz](https://root.cern/download/root_v5.17.08.macosx-powerpc-gcc-4.0.tar.gz) |  43M |
+| SunOS.5.9 | [root_v5.17.08.SunOS.5.9.tar.gz](https://root.cern/download/root_v5.17.08.SunOS.5.9.tar.gz) |  45M |
+| win32 (dbg) | [root_v5.17.08.win32.debug.tar.gz](https://root.cern/download/root_v5.17.08.win32.debug.tar.gz) |  79M |
+| win32 | [root_v5.17.08.win32.tar.gz](https://root.cern/download/root_v5.17.08.win32.tar.gz) |  41M |
+| win32.vc80 (dbg) | [root_v5.17.08.win32.vc80.debug.tar.gz](https://root.cern/download/root_v5.17.08.win32.vc80.debug.tar.gz) |  97M |
+| win32.vc80 | [root_v5.17.08.win32.vc80.tar.gz](https://root.cern/download/root_v5.17.08.win32.vc80.tar.gz) |  42M |
+| win32gcc | [root_v5.17.08.win32gcc.tar.gz](https://root.cern/download/root_v5.17.08.win32gcc.tar.gz) |  45M |
+| win32gdk | [root_v5.17.08.win32gdk.tar.gz](https://root.cern/download/root_v5.17.08.win32gdk.tar.gz) |  41M |
 
 
 

--- a/_releases/release-51800.md
+++ b/_releases/release-51800.md
@@ -15,33 +15,33 @@ sidebar:
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v5.18.00.source.tar.gz](https://root.cern.ch/download/root_v5.18.00.source.tar.gz) |  23M |
-| root_v5.18.00a.source | [root_v5.18.00a.source.tar.gz](https://root.cern.ch/download/root_v5.18.00a.source.tar.gz) |  22M |
-| root_v5.18.00b.source | [root_v5.18.00b.source.tar.gz](https://root.cern.ch/download/root_v5.18.00b.source.tar.gz) |  22M |
-| root_v5.18.00c.source | [root_v5.18.00c.source.tar.gz](https://root.cern.ch/download/root_v5.18.00c.source.tar.gz) |  22M |
-| root_v5.18.00d.source | [root_v5.18.00d.source.tar.gz](https://root.cern.ch/download/root_v5.18.00d.source.tar.gz) |  22M |
-| root_v5.18.00e.source | [root_v5.18.00e.source.tar.gz](https://root.cern.ch/download/root_v5.18.00e.source.tar.gz) |  23M |
-| root_v5.18.00f.source | [root_v5.18.00f.source.tar.gz](https://root.cern.ch/download/root_v5.18.00f.source.tar.gz) |  23M |
+| source | [root_v5.18.00.source.tar.gz](https://root.cern/download/root_v5.18.00.source.tar.gz) |  23M |
+| root_v5.18.00a.source | [root_v5.18.00a.source.tar.gz](https://root.cern/download/root_v5.18.00a.source.tar.gz) |  22M |
+| root_v5.18.00b.source | [root_v5.18.00b.source.tar.gz](https://root.cern/download/root_v5.18.00b.source.tar.gz) |  22M |
+| root_v5.18.00c.source | [root_v5.18.00c.source.tar.gz](https://root.cern/download/root_v5.18.00c.source.tar.gz) |  22M |
+| root_v5.18.00d.source | [root_v5.18.00d.source.tar.gz](https://root.cern/download/root_v5.18.00d.source.tar.gz) |  22M |
+| root_v5.18.00e.source | [root_v5.18.00e.source.tar.gz](https://root.cern/download/root_v5.18.00e.source.tar.gz) |  23M |
+| root_v5.18.00f.source | [root_v5.18.00f.source.tar.gz](https://root.cern/download/root_v5.18.00f.source.tar.gz) |  23M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| Linux.slc4.amd64.gcc3.4 | [root_v5.18.00.Linux.slc4.amd64.gcc3.4.tar.gz](https://root.cern.ch/download/root_v5.18.00.Linux.slc4.amd64.gcc3.4.tar.gz) |  43M |
-| Linux.slc4.gcc3.4 | [root_v5.18.00.Linux.slc4.gcc3.4.tar.gz](https://root.cern.ch/download/root_v5.18.00.Linux.slc4.gcc3.4.tar.gz) |  42M |
-| Linux.slc4_amd64.gcc3.4 | [root_v5.18.00.Linux.slc4_amd64.gcc3.4.tar.gz](https://root.cern.ch/download/root_v5.18.00.Linux.slc4_amd64.gcc3.4.tar.gz) |  44M |
-| macosx i386 gcc 4.0 | [root_v5.18.00.macosx-i386-gcc-4.0.tar.gz](https://root.cern.ch/download/root_v5.18.00.macosx-i386-gcc-4.0.tar.gz) |  42M |
-| macosx i386 icc 9.1 | [root_v5.18.00.macosx-i386-icc-9.1.tar.gz](https://root.cern.ch/download/root_v5.18.00.macosx-i386-icc-9.1.tar.gz) |  46M |
-| macosx powerpc gcc 4.0 | [root_v5.18.00.macosx-powerpc-gcc-4.0.tar.gz](https://root.cern.ch/download/root_v5.18.00.macosx-powerpc-gcc-4.0.tar.gz) |  43M |
-| SunOS.5.9 | [root_v5.18.00.SunOS.5.9.tar.gz](https://root.cern.ch/download/root_v5.18.00.SunOS.5.9.tar.gz) |  45M |
-| win32 (dbg) | [root_v5.18.00.win32.debug.tar.gz](https://root.cern.ch/download/root_v5.18.00.win32.debug.tar.gz) |  78M |
-| win32 | [root_v5.18.00.win32.tar.gz](https://root.cern.ch/download/root_v5.18.00.win32.tar.gz) |  40M |
-| win32.vc80 (dbg) | [root_v5.18.00.win32.vc80.debug.tar.gz](https://root.cern.ch/download/root_v5.18.00.win32.vc80.debug.tar.gz) |  95M |
-| win32.vc80 | [root_v5.18.00.win32.vc80.tar.gz](https://root.cern.ch/download/root_v5.18.00.win32.vc80.tar.gz) |  42M |
-| win32gcc | [root_v5.18.00.win32gcc.tar.gz](https://root.cern.ch/download/root_v5.18.00.win32gcc.tar.gz) |  45M |
-| win32gdk (dbg) | [root_v5.18.00.win32gdk.debug.tar.gz](https://root.cern.ch/download/root_v5.18.00.win32gdk.debug.tar.gz) |  71M |
-| win32gdk | [root_v5.18.00.win32gdk.tar.gz](https://root.cern.ch/download/root_v5.18.00.win32gdk.tar.gz) |  41M |
+| Linux.slc4.amd64.gcc3.4 | [root_v5.18.00.Linux.slc4.amd64.gcc3.4.tar.gz](https://root.cern/download/root_v5.18.00.Linux.slc4.amd64.gcc3.4.tar.gz) |  43M |
+| Linux.slc4.gcc3.4 | [root_v5.18.00.Linux.slc4.gcc3.4.tar.gz](https://root.cern/download/root_v5.18.00.Linux.slc4.gcc3.4.tar.gz) |  42M |
+| Linux.slc4_amd64.gcc3.4 | [root_v5.18.00.Linux.slc4_amd64.gcc3.4.tar.gz](https://root.cern/download/root_v5.18.00.Linux.slc4_amd64.gcc3.4.tar.gz) |  44M |
+| macosx i386 gcc 4.0 | [root_v5.18.00.macosx-i386-gcc-4.0.tar.gz](https://root.cern/download/root_v5.18.00.macosx-i386-gcc-4.0.tar.gz) |  42M |
+| macosx i386 icc 9.1 | [root_v5.18.00.macosx-i386-icc-9.1.tar.gz](https://root.cern/download/root_v5.18.00.macosx-i386-icc-9.1.tar.gz) |  46M |
+| macosx powerpc gcc 4.0 | [root_v5.18.00.macosx-powerpc-gcc-4.0.tar.gz](https://root.cern/download/root_v5.18.00.macosx-powerpc-gcc-4.0.tar.gz) |  43M |
+| SunOS.5.9 | [root_v5.18.00.SunOS.5.9.tar.gz](https://root.cern/download/root_v5.18.00.SunOS.5.9.tar.gz) |  45M |
+| win32 (dbg) | [root_v5.18.00.win32.debug.tar.gz](https://root.cern/download/root_v5.18.00.win32.debug.tar.gz) |  78M |
+| win32 | [root_v5.18.00.win32.tar.gz](https://root.cern/download/root_v5.18.00.win32.tar.gz) |  40M |
+| win32.vc80 (dbg) | [root_v5.18.00.win32.vc80.debug.tar.gz](https://root.cern/download/root_v5.18.00.win32.vc80.debug.tar.gz) |  95M |
+| win32.vc80 | [root_v5.18.00.win32.vc80.tar.gz](https://root.cern/download/root_v5.18.00.win32.vc80.tar.gz) |  42M |
+| win32gcc | [root_v5.18.00.win32gcc.tar.gz](https://root.cern/download/root_v5.18.00.win32gcc.tar.gz) |  45M |
+| win32gdk (dbg) | [root_v5.18.00.win32gdk.debug.tar.gz](https://root.cern/download/root_v5.18.00.win32gdk.debug.tar.gz) |  71M |
+| win32gdk | [root_v5.18.00.win32gdk.tar.gz](https://root.cern/download/root_v5.18.00.win32gdk.tar.gz) |  41M |
 
 
 ## Git

--- a/_releases/release-51902.md
+++ b/_releases/release-51902.md
@@ -15,24 +15,24 @@ sidebar:
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v5.19.02.source.tar.gz](https://root.cern.ch/download/root_v5.19.02.source.tar.gz) |  23M |
+| source | [root_v5.19.02.source.tar.gz](https://root.cern/download/root_v5.19.02.source.tar.gz) |  23M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| Linux.slc4.gcc3.4 | [root_v5.19.02.Linux.slc4.gcc3.4.tar.gz](https://root.cern.ch/download/root_v5.19.02.Linux.slc4.gcc3.4.tar.gz) |  42M |
-| Linux.slc4_amd64.gcc3.4 | [root_v5.19.02.Linux.slc4_amd64.gcc3.4.tar.gz](https://root.cern.ch/download/root_v5.19.02.Linux.slc4_amd64.gcc3.4.tar.gz) |  44M |
-| macosx i386 gcc 4.0 | [root_v5.19.02.macosx-i386-gcc-4.0.tar.gz](https://root.cern.ch/download/root_v5.19.02.macosx-i386-gcc-4.0.tar.gz) |  42M |
-| macosx i386 icc 9.1 | [root_v5.19.02.macosx-i386-icc-9.1.tar.gz](https://root.cern.ch/download/root_v5.19.02.macosx-i386-icc-9.1.tar.gz) |  47M |
-| macosx powerpc gcc 4.0 | [root_v5.19.02.macosx-powerpc-gcc-4.0.tar.gz](https://root.cern.ch/download/root_v5.19.02.macosx-powerpc-gcc-4.0.tar.gz) |  43M |
-| SunOS.5.9 | [root_v5.19.02.SunOS.5.9.tar.gz](https://root.cern.ch/download/root_v5.19.02.SunOS.5.9.tar.gz) |  46M |
-| win32 (dbg) | [root_v5.19.02.win32.debug.tar.gz](https://root.cern.ch/download/root_v5.19.02.win32.debug.tar.gz) |  80M |
-| win32 | [root_v5.19.02.win32.tar.gz](https://root.cern.ch/download/root_v5.19.02.win32.tar.gz) |  42M |
-| win32.vc80 (dbg) | [root_v5.19.02.win32.vc80.debug.tar.gz](https://root.cern.ch/download/root_v5.19.02.win32.vc80.debug.tar.gz) |  98M |
-| win32.vc80 | [root_v5.19.02.win32.vc80.tar.gz](https://root.cern.ch/download/root_v5.19.02.win32.vc80.tar.gz) |  43M |
-| win32gcc | [root_v5.19.02.win32gcc.tar.gz](https://root.cern.ch/download/root_v5.19.02.win32gcc.tar.gz) |  46M |
+| Linux.slc4.gcc3.4 | [root_v5.19.02.Linux.slc4.gcc3.4.tar.gz](https://root.cern/download/root_v5.19.02.Linux.slc4.gcc3.4.tar.gz) |  42M |
+| Linux.slc4_amd64.gcc3.4 | [root_v5.19.02.Linux.slc4_amd64.gcc3.4.tar.gz](https://root.cern/download/root_v5.19.02.Linux.slc4_amd64.gcc3.4.tar.gz) |  44M |
+| macosx i386 gcc 4.0 | [root_v5.19.02.macosx-i386-gcc-4.0.tar.gz](https://root.cern/download/root_v5.19.02.macosx-i386-gcc-4.0.tar.gz) |  42M |
+| macosx i386 icc 9.1 | [root_v5.19.02.macosx-i386-icc-9.1.tar.gz](https://root.cern/download/root_v5.19.02.macosx-i386-icc-9.1.tar.gz) |  47M |
+| macosx powerpc gcc 4.0 | [root_v5.19.02.macosx-powerpc-gcc-4.0.tar.gz](https://root.cern/download/root_v5.19.02.macosx-powerpc-gcc-4.0.tar.gz) |  43M |
+| SunOS.5.9 | [root_v5.19.02.SunOS.5.9.tar.gz](https://root.cern/download/root_v5.19.02.SunOS.5.9.tar.gz) |  46M |
+| win32 (dbg) | [root_v5.19.02.win32.debug.tar.gz](https://root.cern/download/root_v5.19.02.win32.debug.tar.gz) |  80M |
+| win32 | [root_v5.19.02.win32.tar.gz](https://root.cern/download/root_v5.19.02.win32.tar.gz) |  42M |
+| win32.vc80 (dbg) | [root_v5.19.02.win32.vc80.debug.tar.gz](https://root.cern/download/root_v5.19.02.win32.vc80.debug.tar.gz) |  98M |
+| win32.vc80 | [root_v5.19.02.win32.vc80.tar.gz](https://root.cern/download/root_v5.19.02.win32.vc80.tar.gz) |  43M |
+| win32gcc | [root_v5.19.02.win32gcc.tar.gz](https://root.cern/download/root_v5.19.02.win32gcc.tar.gz) |  46M |
 
 
 ## Git

--- a/_releases/release-51904.md
+++ b/_releases/release-51904.md
@@ -15,24 +15,24 @@ sidebar:
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v5.19.04.source.tar.gz](https://root.cern.ch/download/root_v5.19.04.source.tar.gz) |  24M |
+| source | [root_v5.19.04.source.tar.gz](https://root.cern/download/root_v5.19.04.source.tar.gz) |  24M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| Linux.slc4.gcc3.4 | [root_v5.19.04.Linux.slc4.gcc3.4.tar.gz](https://root.cern.ch/download/root_v5.19.04.Linux.slc4.gcc3.4.tar.gz) |  43M |
-| Linux.slc4_amd64.gcc3.4 | [root_v5.19.04.Linux.slc4_amd64.gcc3.4.tar.gz](https://root.cern.ch/download/root_v5.19.04.Linux.slc4_amd64.gcc3.4.tar.gz) |  44M |
-| macosx i386 gcc 4.0 | [root_v5.19.04.macosx-i386-gcc-4.0.tar.gz](https://root.cern.ch/download/root_v5.19.04.macosx-i386-gcc-4.0.tar.gz) |  43M |
-| macosx i386 icc 9.1 | [root_v5.19.04.macosx-i386-icc-9.1.tar.gz](https://root.cern.ch/download/root_v5.19.04.macosx-i386-icc-9.1.tar.gz) |  46M |
-| macosx powerpc gcc 4.0 | [root_v5.19.04.macosx-powerpc-gcc-4.0.tar.gz](https://root.cern.ch/download/root_v5.19.04.macosx-powerpc-gcc-4.0.tar.gz) |  43M |
-| SunOS.5.9 | [root_v5.19.04.SunOS.5.9.tar.gz](https://root.cern.ch/download/root_v5.19.04.SunOS.5.9.tar.gz) |  47M |
-| win32 (dbg) | [root_v5.19.04.win32.debug.tar.gz](https://root.cern.ch/download/root_v5.19.04.win32.debug.tar.gz) |  80M |
-| win32 | [root_v5.19.04.win32.tar.gz](https://root.cern.ch/download/root_v5.19.04.win32.tar.gz) |  42M |
-| Windows Visual Studio 90 (dbg) | [root_v5.19.04.win32.vc90.debug.tar.gz](https://root.cern.ch/download/root_v5.19.04.win32.vc90.debug.tar.gz) | 100M |
-| Windows Visual Studio 90 | [root_v5.19.04.win32.vc90.tar.gz](https://root.cern.ch/download/root_v5.19.04.win32.vc90.tar.gz) |  42M |
-| win32gcc | [root_v5.19.04.win32gcc.tar.gz](https://root.cern.ch/download/root_v5.19.04.win32gcc.tar.gz) |  46M |
+| Linux.slc4.gcc3.4 | [root_v5.19.04.Linux.slc4.gcc3.4.tar.gz](https://root.cern/download/root_v5.19.04.Linux.slc4.gcc3.4.tar.gz) |  43M |
+| Linux.slc4_amd64.gcc3.4 | [root_v5.19.04.Linux.slc4_amd64.gcc3.4.tar.gz](https://root.cern/download/root_v5.19.04.Linux.slc4_amd64.gcc3.4.tar.gz) |  44M |
+| macosx i386 gcc 4.0 | [root_v5.19.04.macosx-i386-gcc-4.0.tar.gz](https://root.cern/download/root_v5.19.04.macosx-i386-gcc-4.0.tar.gz) |  43M |
+| macosx i386 icc 9.1 | [root_v5.19.04.macosx-i386-icc-9.1.tar.gz](https://root.cern/download/root_v5.19.04.macosx-i386-icc-9.1.tar.gz) |  46M |
+| macosx powerpc gcc 4.0 | [root_v5.19.04.macosx-powerpc-gcc-4.0.tar.gz](https://root.cern/download/root_v5.19.04.macosx-powerpc-gcc-4.0.tar.gz) |  43M |
+| SunOS.5.9 | [root_v5.19.04.SunOS.5.9.tar.gz](https://root.cern/download/root_v5.19.04.SunOS.5.9.tar.gz) |  47M |
+| win32 (dbg) | [root_v5.19.04.win32.debug.tar.gz](https://root.cern/download/root_v5.19.04.win32.debug.tar.gz) |  80M |
+| win32 | [root_v5.19.04.win32.tar.gz](https://root.cern/download/root_v5.19.04.win32.tar.gz) |  42M |
+| Windows Visual Studio 90 (dbg) | [root_v5.19.04.win32.vc90.debug.tar.gz](https://root.cern/download/root_v5.19.04.win32.vc90.debug.tar.gz) | 100M |
+| Windows Visual Studio 90 | [root_v5.19.04.win32.vc90.tar.gz](https://root.cern/download/root_v5.19.04.win32.vc90.tar.gz) |  42M |
+| win32gcc | [root_v5.19.04.win32gcc.tar.gz](https://root.cern/download/root_v5.19.04.win32gcc.tar.gz) |  46M |
 
 
 ## Git

--- a/_releases/release-52000.md
+++ b/_releases/release-52000.md
@@ -15,26 +15,26 @@ sidebar:
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v5.20.00.source.tar.gz](https://root.cern.ch/download/root_v5.20.00.source.tar.gz) |  24M |
+| source | [root_v5.20.00.source.tar.gz](https://root.cern/download/root_v5.20.00.source.tar.gz) |  24M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| Linux.slc4.gcc3.4 | [root_v5.20.00.Linux.slc4.gcc3.4.tar.gz](https://root.cern.ch/download/root_v5.20.00.Linux.slc4.gcc3.4.tar.gz) |  44M |
-| Linux.slc4_amd64.gcc3.4 | [root_v5.20.00.Linux.slc4_amd64.gcc3.4.tar.gz](https://root.cern.ch/download/root_v5.20.00.Linux.slc4_amd64.gcc3.4.tar.gz) |  45M |
-| macosx i386 icc 9.1 | [root_v5.20.00.macosx-i386-icc-9.1.tar.gz](https://root.cern.ch/download/root_v5.20.00.macosx-i386-icc-9.1.tar.gz) |  44M |
-| macosx powerpc gcc 4.0 | [root_v5.20.00.macosx-powerpc-gcc-4.0.tar.gz](https://root.cern.ch/download/root_v5.20.00.macosx-powerpc-gcc-4.0.tar.gz) |  42M |
-| macosx104 i386 gcc 4.0 | [root_v5.20.00.macosx104-i386-gcc-4.0.tar.gz](https://root.cern.ch/download/root_v5.20.00.macosx104-i386-gcc-4.0.tar.gz) |  41M |
-| macosx105 i386 gcc 4.0 | [root_v5.20.00.macosx105-i386-gcc-4.0.tar.gz](https://root.cern.ch/download/root_v5.20.00.macosx105-i386-gcc-4.0.tar.gz) |  34M |
-| SunOS.5.9 | [root_v5.20.00.SunOS.5.9.tar.gz](https://root.cern.ch/download/root_v5.20.00.SunOS.5.9.tar.gz) |  48M |
-| win32 (dbg) | [root_v5.20.00.win32.debug.tar.gz](https://root.cern.ch/download/root_v5.20.00.win32.debug.tar.gz) |  81M |
-| win32 | [root_v5.20.00.win32.tar.gz](https://root.cern.ch/download/root_v5.20.00.win32.tar.gz) |  42M |
-| Windows Visual Studio 90 (dbg) | [root_v5.20.00.win32.vc90.debug.tar.gz](https://root.cern.ch/download/root_v5.20.00.win32.vc90.debug.tar.gz) |  99M |
-| Windows Visual Studio 90 | [root_v5.20.00.win32.vc90.tar.gz](https://root.cern.ch/download/root_v5.20.00.win32.vc90.tar.gz) |  43M |
-| win32gcc | [root_v5.20.00.win32gcc.tar.gz](https://root.cern.ch/download/root_v5.20.00.win32gcc.tar.gz) |  47M |
-| win32gdk | [root_v5.20.00.win32gdk.tar.gz](https://root.cern.ch/download/root_v5.20.00.win32gdk.tar.gz) |  43M |
+| Linux.slc4.gcc3.4 | [root_v5.20.00.Linux.slc4.gcc3.4.tar.gz](https://root.cern/download/root_v5.20.00.Linux.slc4.gcc3.4.tar.gz) |  44M |
+| Linux.slc4_amd64.gcc3.4 | [root_v5.20.00.Linux.slc4_amd64.gcc3.4.tar.gz](https://root.cern/download/root_v5.20.00.Linux.slc4_amd64.gcc3.4.tar.gz) |  45M |
+| macosx i386 icc 9.1 | [root_v5.20.00.macosx-i386-icc-9.1.tar.gz](https://root.cern/download/root_v5.20.00.macosx-i386-icc-9.1.tar.gz) |  44M |
+| macosx powerpc gcc 4.0 | [root_v5.20.00.macosx-powerpc-gcc-4.0.tar.gz](https://root.cern/download/root_v5.20.00.macosx-powerpc-gcc-4.0.tar.gz) |  42M |
+| macosx104 i386 gcc 4.0 | [root_v5.20.00.macosx104-i386-gcc-4.0.tar.gz](https://root.cern/download/root_v5.20.00.macosx104-i386-gcc-4.0.tar.gz) |  41M |
+| macosx105 i386 gcc 4.0 | [root_v5.20.00.macosx105-i386-gcc-4.0.tar.gz](https://root.cern/download/root_v5.20.00.macosx105-i386-gcc-4.0.tar.gz) |  34M |
+| SunOS.5.9 | [root_v5.20.00.SunOS.5.9.tar.gz](https://root.cern/download/root_v5.20.00.SunOS.5.9.tar.gz) |  48M |
+| win32 (dbg) | [root_v5.20.00.win32.debug.tar.gz](https://root.cern/download/root_v5.20.00.win32.debug.tar.gz) |  81M |
+| win32 | [root_v5.20.00.win32.tar.gz](https://root.cern/download/root_v5.20.00.win32.tar.gz) |  42M |
+| Windows Visual Studio 90 (dbg) | [root_v5.20.00.win32.vc90.debug.tar.gz](https://root.cern/download/root_v5.20.00.win32.vc90.debug.tar.gz) |  99M |
+| Windows Visual Studio 90 | [root_v5.20.00.win32.vc90.tar.gz](https://root.cern/download/root_v5.20.00.win32.vc90.tar.gz) |  43M |
+| win32gcc | [root_v5.20.00.win32gcc.tar.gz](https://root.cern/download/root_v5.20.00.win32gcc.tar.gz) |  47M |
+| win32gdk | [root_v5.20.00.win32gdk.tar.gz](https://root.cern/download/root_v5.20.00.win32gdk.tar.gz) |  43M |
 
 
 ## Git

--- a/_releases/release-52102.md
+++ b/_releases/release-52102.md
@@ -15,25 +15,25 @@ sidebar:
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v5.21.02.source.tar.gz](https://root.cern.ch/download/root_v5.21.02.source.tar.gz) |  24M |
+| source | [root_v5.21.02.source.tar.gz](https://root.cern/download/root_v5.21.02.source.tar.gz) |  24M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| Linux.slc4.gcc3.4 | [root_v5.21.02.Linux.slc4.gcc3.4.tar.gz](https://root.cern.ch/download/root_v5.21.02.Linux.slc4.gcc3.4.tar.gz) |  45M |
-| Linux.slc4_amd64.gcc3.4 | [root_v5.21.02.Linux.slc4_amd64.gcc3.4.tar.gz](https://root.cern.ch/download/root_v5.21.02.Linux.slc4_amd64.gcc3.4.tar.gz) |  46M |
-| macosx i386 icc 9.1 | [root_v5.21.02.macosx-i386-icc-9.1.tar.gz](https://root.cern.ch/download/root_v5.21.02.macosx-i386-icc-9.1.tar.gz) |  45M |
-| macosx powerpc gcc 4.0 | [root_v5.21.02.macosx-powerpc-gcc-4.0.tar.gz](https://root.cern.ch/download/root_v5.21.02.macosx-powerpc-gcc-4.0.tar.gz) |  43M |
-| macosx104 i386 gcc 4.0 | [root_v5.21.02.macosx104-i386-gcc-4.0.tar.gz](https://root.cern.ch/download/root_v5.21.02.macosx104-i386-gcc-4.0.tar.gz) |  42M |
-| macosx105 i386 gcc 4.0 | [root_v5.21.02.macosx105-i386-gcc-4.0.tar.gz](https://root.cern.ch/download/root_v5.21.02.macosx105-i386-gcc-4.0.tar.gz) |  35M |
-| SunOS.5.9 | [root_v5.21.02.SunOS.5.9.tar.gz](https://root.cern.ch/download/root_v5.21.02.SunOS.5.9.tar.gz) |  49M |
-| win32 (dbg) | [root_v5.21.02.win32.debug.tar.gz](https://root.cern.ch/download/root_v5.21.02.win32.debug.tar.gz) |  84M |
-| win32 | [root_v5.21.02.win32.tar.gz](https://root.cern.ch/download/root_v5.21.02.win32.tar.gz) |  44M |
-| Windows Visual Studio 90 (dbg) | [root_v5.21.02.win32.vc90.debug.tar.gz](https://root.cern.ch/download/root_v5.21.02.win32.vc90.debug.tar.gz) | 102M |
-| Windows Visual Studio 90 | [root_v5.21.02.win32.vc90.tar.gz](https://root.cern.ch/download/root_v5.21.02.win32.vc90.tar.gz) |  44M |
-| win32gcc | [root_v5.21.02.win32gcc.tar.gz](https://root.cern.ch/download/root_v5.21.02.win32gcc.tar.gz) |  48M |
+| Linux.slc4.gcc3.4 | [root_v5.21.02.Linux.slc4.gcc3.4.tar.gz](https://root.cern/download/root_v5.21.02.Linux.slc4.gcc3.4.tar.gz) |  45M |
+| Linux.slc4_amd64.gcc3.4 | [root_v5.21.02.Linux.slc4_amd64.gcc3.4.tar.gz](https://root.cern/download/root_v5.21.02.Linux.slc4_amd64.gcc3.4.tar.gz) |  46M |
+| macosx i386 icc 9.1 | [root_v5.21.02.macosx-i386-icc-9.1.tar.gz](https://root.cern/download/root_v5.21.02.macosx-i386-icc-9.1.tar.gz) |  45M |
+| macosx powerpc gcc 4.0 | [root_v5.21.02.macosx-powerpc-gcc-4.0.tar.gz](https://root.cern/download/root_v5.21.02.macosx-powerpc-gcc-4.0.tar.gz) |  43M |
+| macosx104 i386 gcc 4.0 | [root_v5.21.02.macosx104-i386-gcc-4.0.tar.gz](https://root.cern/download/root_v5.21.02.macosx104-i386-gcc-4.0.tar.gz) |  42M |
+| macosx105 i386 gcc 4.0 | [root_v5.21.02.macosx105-i386-gcc-4.0.tar.gz](https://root.cern/download/root_v5.21.02.macosx105-i386-gcc-4.0.tar.gz) |  35M |
+| SunOS.5.9 | [root_v5.21.02.SunOS.5.9.tar.gz](https://root.cern/download/root_v5.21.02.SunOS.5.9.tar.gz) |  49M |
+| win32 (dbg) | [root_v5.21.02.win32.debug.tar.gz](https://root.cern/download/root_v5.21.02.win32.debug.tar.gz) |  84M |
+| win32 | [root_v5.21.02.win32.tar.gz](https://root.cern/download/root_v5.21.02.win32.tar.gz) |  44M |
+| Windows Visual Studio 90 (dbg) | [root_v5.21.02.win32.vc90.debug.tar.gz](https://root.cern/download/root_v5.21.02.win32.vc90.debug.tar.gz) | 102M |
+| Windows Visual Studio 90 | [root_v5.21.02.win32.vc90.tar.gz](https://root.cern/download/root_v5.21.02.win32.vc90.tar.gz) |  44M |
+| win32gcc | [root_v5.21.02.win32gcc.tar.gz](https://root.cern/download/root_v5.21.02.win32gcc.tar.gz) |  48M |
 
 
 ## Git

--- a/_releases/release-52104.md
+++ b/_releases/release-52104.md
@@ -15,25 +15,25 @@ sidebar:
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v5.21.04.source.tar.gz](https://root.cern.ch/download/root_v5.21.04.source.tar.gz) |  25M |
+| source | [root_v5.21.04.source.tar.gz](https://root.cern/download/root_v5.21.04.source.tar.gz) |  25M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| Linux.slc4.gcc3.4 | [root_v5.21.04.Linux.slc4.gcc3.4.tar.gz](https://root.cern.ch/download/root_v5.21.04.Linux.slc4.gcc3.4.tar.gz) |  47M |
-| Linux.slc4_amd64.gcc3.4 | [root_v5.21.04.Linux.slc4_amd64.gcc3.4.tar.gz](https://root.cern.ch/download/root_v5.21.04.Linux.slc4_amd64.gcc3.4.tar.gz) |  49M |
-| macosx i386 icc 9.1 | [root_v5.21.04.macosx-i386-icc-9.1.tar.gz](https://root.cern.ch/download/root_v5.21.04.macosx-i386-icc-9.1.tar.gz) |  48M |
-| macosx powerpc gcc 4.0 | [root_v5.21.04.macosx-powerpc-gcc-4.0.tar.gz](https://root.cern.ch/download/root_v5.21.04.macosx-powerpc-gcc-4.0.tar.gz) |  45M |
-| macosx104 i386 gcc 4.0 | [root_v5.21.04.macosx104-i386-gcc-4.0.tar.gz](https://root.cern.ch/download/root_v5.21.04.macosx104-i386-gcc-4.0.tar.gz) |  44M |
-| macosx105 i386 gcc 4.0 | [root_v5.21.04.macosx105-i386-gcc-4.0.tar.gz](https://root.cern.ch/download/root_v5.21.04.macosx105-i386-gcc-4.0.tar.gz) |  36M |
-| SunOS.5.9 | [root_v5.21.04.SunOS.5.9.tar.gz](https://root.cern.ch/download/root_v5.21.04.SunOS.5.9.tar.gz) |  51M |
-| win32 (dbg) | [root_v5.21.04.win32.debug.tar.gz](https://root.cern.ch/download/root_v5.21.04.win32.debug.tar.gz) |  86M |
-| win32 | [root_v5.21.04.win32.tar.gz](https://root.cern.ch/download/root_v5.21.04.win32.tar.gz) |  45M |
-| Windows Visual Studio 90 (dbg) | [root_v5.21.04.win32.vc90.debug.tar.gz](https://root.cern.ch/download/root_v5.21.04.win32.vc90.debug.tar.gz) | 104M |
-| Windows Visual Studio 90 | [root_v5.21.04.win32.vc90.tar.gz](https://root.cern.ch/download/root_v5.21.04.win32.vc90.tar.gz) |  46M |
-| win32gcc gcc 3.4 | [root_v5.21.04.win32gcc-gcc-3.4.tar.gz](https://root.cern.ch/download/root_v5.21.04.win32gcc-gcc-3.4.tar.gz) |  48M |
+| Linux.slc4.gcc3.4 | [root_v5.21.04.Linux.slc4.gcc3.4.tar.gz](https://root.cern/download/root_v5.21.04.Linux.slc4.gcc3.4.tar.gz) |  47M |
+| Linux.slc4_amd64.gcc3.4 | [root_v5.21.04.Linux.slc4_amd64.gcc3.4.tar.gz](https://root.cern/download/root_v5.21.04.Linux.slc4_amd64.gcc3.4.tar.gz) |  49M |
+| macosx i386 icc 9.1 | [root_v5.21.04.macosx-i386-icc-9.1.tar.gz](https://root.cern/download/root_v5.21.04.macosx-i386-icc-9.1.tar.gz) |  48M |
+| macosx powerpc gcc 4.0 | [root_v5.21.04.macosx-powerpc-gcc-4.0.tar.gz](https://root.cern/download/root_v5.21.04.macosx-powerpc-gcc-4.0.tar.gz) |  45M |
+| macosx104 i386 gcc 4.0 | [root_v5.21.04.macosx104-i386-gcc-4.0.tar.gz](https://root.cern/download/root_v5.21.04.macosx104-i386-gcc-4.0.tar.gz) |  44M |
+| macosx105 i386 gcc 4.0 | [root_v5.21.04.macosx105-i386-gcc-4.0.tar.gz](https://root.cern/download/root_v5.21.04.macosx105-i386-gcc-4.0.tar.gz) |  36M |
+| SunOS.5.9 | [root_v5.21.04.SunOS.5.9.tar.gz](https://root.cern/download/root_v5.21.04.SunOS.5.9.tar.gz) |  51M |
+| win32 (dbg) | [root_v5.21.04.win32.debug.tar.gz](https://root.cern/download/root_v5.21.04.win32.debug.tar.gz) |  86M |
+| win32 | [root_v5.21.04.win32.tar.gz](https://root.cern/download/root_v5.21.04.win32.tar.gz) |  45M |
+| Windows Visual Studio 90 (dbg) | [root_v5.21.04.win32.vc90.debug.tar.gz](https://root.cern/download/root_v5.21.04.win32.vc90.debug.tar.gz) | 104M |
+| Windows Visual Studio 90 | [root_v5.21.04.win32.vc90.tar.gz](https://root.cern/download/root_v5.21.04.win32.vc90.tar.gz) |  46M |
+| win32gcc gcc 3.4 | [root_v5.21.04.win32gcc-gcc-3.4.tar.gz](https://root.cern/download/root_v5.21.04.win32gcc-gcc-3.4.tar.gz) |  48M |
 
 
 ## Git

--- a/_releases/release-52106.md
+++ b/_releases/release-52106.md
@@ -15,31 +15,31 @@ sidebar:
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v5.21.06.source.tar.gz](https://root.cern.ch/download/root_v5.21.06.source.tar.gz) |  25M |
+| source | [root_v5.21.06.source.tar.gz](https://root.cern/download/root_v5.21.06.source.tar.gz) |  25M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| Linux slc4 gcc4.3 | [root_v5.21.06.Linux-slc4-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.21.06.Linux-slc4-gcc4.3.tar.gz) |  48M |
-| Linux slc4_amd64 gcc4.3 | [root_v5.21.06.Linux-slc4_amd64-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.21.06.Linux-slc4_amd64-gcc4.3.tar.gz) |  49M |
-| Linux slc5 gcc3.4 | [root_v5.21.06.Linux-slc5-gcc3.4.tar.gz](https://root.cern.ch/download/root_v5.21.06.Linux-slc5-gcc3.4.tar.gz) |  47M |
-| Linux slc5 gcc4.3 | [root_v5.21.06.Linux-slc5-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.21.06.Linux-slc5-gcc4.3.tar.gz) |  48M |
-| Linux slc5_amd64 gcc3.4 | [root_v5.21.06.Linux-slc5_amd64-gcc3.4.tar.gz](https://root.cern.ch/download/root_v5.21.06.Linux-slc5_amd64-gcc3.4.tar.gz) |  49M |
-| Linux slc5_amd64 gcc4.3 | [root_v5.21.06.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.21.06.Linux-slc5_amd64-gcc4.3.tar.gz) |  49M |
-| Linux.slc4.gcc3.4 | [root_v5.21.06.Linux.slc4.gcc3.4.tar.gz](https://root.cern.ch/download/root_v5.21.06.Linux.slc4.gcc3.4.tar.gz) |  48M |
-| Linux.slc4_amd64.gcc3.4 | [root_v5.21.06.Linux.slc4_amd64.gcc3.4.tar.gz](https://root.cern.ch/download/root_v5.21.06.Linux.slc4_amd64.gcc3.4.tar.gz) |  49M |
-| macosx i386 icc 9.1 | [root_v5.21.06.macosx-i386-icc-9.1.tar.gz](https://root.cern.ch/download/root_v5.21.06.macosx-i386-icc-9.1.tar.gz) |  48M |
-| macosx powerpc gcc 4.0 | [root_v5.21.06.macosx-powerpc-gcc-4.0.tar.gz](https://root.cern.ch/download/root_v5.21.06.macosx-powerpc-gcc-4.0.tar.gz) |  45M |
-| macosx104 i386 gcc 4.0 | [root_v5.21.06.macosx104-i386-gcc-4.0.tar.gz](https://root.cern.ch/download/root_v5.21.06.macosx104-i386-gcc-4.0.tar.gz) |  45M |
-| macosx105 i386 gcc 4.0 | [root_v5.21.06.macosx105-i386-gcc-4.0.tar.gz](https://root.cern.ch/download/root_v5.21.06.macosx105-i386-gcc-4.0.tar.gz) |  36M |
-| SunOS.5.9 | [root_v5.21.06.SunOS.5.9.tar.gz](https://root.cern.ch/download/root_v5.21.06.SunOS.5.9.tar.gz) |  51M |
-| win32 (dbg) | [root_v5.21.06.win32.debug.tar.gz](https://root.cern.ch/download/root_v5.21.06.win32.debug.tar.gz) |  85M |
-| win32 | [root_v5.21.06.win32.tar.gz](https://root.cern.ch/download/root_v5.21.06.win32.tar.gz) |  45M |
-| Windows Visual Studio 90 (dbg) | [root_v5.21.06.win32.vc90.debug.tar.gz](https://root.cern.ch/download/root_v5.21.06.win32.vc90.debug.tar.gz) | 109M |
-| Windows Visual Studio 90 | [root_v5.21.06.win32.vc90.tar.gz](https://root.cern.ch/download/root_v5.21.06.win32.vc90.tar.gz) |  47M |
-| win32gcc | [root_v5.21.06.win32gcc.tar.gz](https://root.cern.ch/download/root_v5.21.06.win32gcc.tar.gz) |  49M |
+| Linux slc4 gcc4.3 | [root_v5.21.06.Linux-slc4-gcc4.3.tar.gz](https://root.cern/download/root_v5.21.06.Linux-slc4-gcc4.3.tar.gz) |  48M |
+| Linux slc4_amd64 gcc4.3 | [root_v5.21.06.Linux-slc4_amd64-gcc4.3.tar.gz](https://root.cern/download/root_v5.21.06.Linux-slc4_amd64-gcc4.3.tar.gz) |  49M |
+| Linux slc5 gcc3.4 | [root_v5.21.06.Linux-slc5-gcc3.4.tar.gz](https://root.cern/download/root_v5.21.06.Linux-slc5-gcc3.4.tar.gz) |  47M |
+| Linux slc5 gcc4.3 | [root_v5.21.06.Linux-slc5-gcc4.3.tar.gz](https://root.cern/download/root_v5.21.06.Linux-slc5-gcc4.3.tar.gz) |  48M |
+| Linux slc5_amd64 gcc3.4 | [root_v5.21.06.Linux-slc5_amd64-gcc3.4.tar.gz](https://root.cern/download/root_v5.21.06.Linux-slc5_amd64-gcc3.4.tar.gz) |  49M |
+| Linux slc5_amd64 gcc4.3 | [root_v5.21.06.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern/download/root_v5.21.06.Linux-slc5_amd64-gcc4.3.tar.gz) |  49M |
+| Linux.slc4.gcc3.4 | [root_v5.21.06.Linux.slc4.gcc3.4.tar.gz](https://root.cern/download/root_v5.21.06.Linux.slc4.gcc3.4.tar.gz) |  48M |
+| Linux.slc4_amd64.gcc3.4 | [root_v5.21.06.Linux.slc4_amd64.gcc3.4.tar.gz](https://root.cern/download/root_v5.21.06.Linux.slc4_amd64.gcc3.4.tar.gz) |  49M |
+| macosx i386 icc 9.1 | [root_v5.21.06.macosx-i386-icc-9.1.tar.gz](https://root.cern/download/root_v5.21.06.macosx-i386-icc-9.1.tar.gz) |  48M |
+| macosx powerpc gcc 4.0 | [root_v5.21.06.macosx-powerpc-gcc-4.0.tar.gz](https://root.cern/download/root_v5.21.06.macosx-powerpc-gcc-4.0.tar.gz) |  45M |
+| macosx104 i386 gcc 4.0 | [root_v5.21.06.macosx104-i386-gcc-4.0.tar.gz](https://root.cern/download/root_v5.21.06.macosx104-i386-gcc-4.0.tar.gz) |  45M |
+| macosx105 i386 gcc 4.0 | [root_v5.21.06.macosx105-i386-gcc-4.0.tar.gz](https://root.cern/download/root_v5.21.06.macosx105-i386-gcc-4.0.tar.gz) |  36M |
+| SunOS.5.9 | [root_v5.21.06.SunOS.5.9.tar.gz](https://root.cern/download/root_v5.21.06.SunOS.5.9.tar.gz) |  51M |
+| win32 (dbg) | [root_v5.21.06.win32.debug.tar.gz](https://root.cern/download/root_v5.21.06.win32.debug.tar.gz) |  85M |
+| win32 | [root_v5.21.06.win32.tar.gz](https://root.cern/download/root_v5.21.06.win32.tar.gz) |  45M |
+| Windows Visual Studio 90 (dbg) | [root_v5.21.06.win32.vc90.debug.tar.gz](https://root.cern/download/root_v5.21.06.win32.vc90.debug.tar.gz) | 109M |
+| Windows Visual Studio 90 | [root_v5.21.06.win32.vc90.tar.gz](https://root.cern/download/root_v5.21.06.win32.vc90.tar.gz) |  47M |
+| win32gcc | [root_v5.21.06.win32gcc.tar.gz](https://root.cern/download/root_v5.21.06.win32gcc.tar.gz) |  49M |
 
 
 ## Git

--- a/_releases/release-52200.md
+++ b/_releases/release-52200.md
@@ -15,42 +15,42 @@ sidebar:
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| old_root_v5.22.00h.source | [old_root_v5.22.00h.source.tar.gz](https://root.cern.ch/download/old_root_v5.22.00h.source.tar.gz) |  25M |
-| source | [root_v5.22.00.source.tar.gz](https://root.cern.ch/download/root_v5.22.00.source.tar.gz) |  25M |
-| root_v5.22.00a.source | [root_v5.22.00a.source.tar.gz](https://root.cern.ch/download/root_v5.22.00a.source.tar.gz) |  25M |
-| root_v5.22.00b.source | [root_v5.22.00b.source.tar.gz](https://root.cern.ch/download/root_v5.22.00b.source.tar.gz) |  25M |
-| root_v5.22.00c.source | [root_v5.22.00c.source.tar.gz](https://root.cern.ch/download/root_v5.22.00c.source.tar.gz) |  25M |
-| root_v5.22.00d.source | [root_v5.22.00d.source.tar.gz](https://root.cern.ch/download/root_v5.22.00d.source.tar.gz) |  25M |
-| root_v5.22.00e.source | [root_v5.22.00e.source.tar.gz](https://root.cern.ch/download/root_v5.22.00e.source.tar.gz) |  25M |
-| root_v5.22.00f.source | [root_v5.22.00f.source.tar.gz](https://root.cern.ch/download/root_v5.22.00f.source.tar.gz) |  25M |
-| root_v5.22.00g.source | [root_v5.22.00g.source.tar.gz](https://root.cern.ch/download/root_v5.22.00g.source.tar.gz) |  25M |
-| root_v5.22.00h.source | [root_v5.22.00h.source.tar.gz](https://root.cern.ch/download/root_v5.22.00h.source.tar.gz) |  25M |
-| root_v5.22.00i.source | [root_v5.22.00i.source.tar.gz](https://root.cern.ch/download/root_v5.22.00i.source.tar.gz) |  25M |
-| root_v5.22.00j.source | [root_v5.22.00j.source.tar.gz](https://root.cern.ch/download/root_v5.22.00j.source.tar.gz) |  25M |
+| old_root_v5.22.00h.source | [old_root_v5.22.00h.source.tar.gz](https://root.cern/download/old_root_v5.22.00h.source.tar.gz) |  25M |
+| source | [root_v5.22.00.source.tar.gz](https://root.cern/download/root_v5.22.00.source.tar.gz) |  25M |
+| root_v5.22.00a.source | [root_v5.22.00a.source.tar.gz](https://root.cern/download/root_v5.22.00a.source.tar.gz) |  25M |
+| root_v5.22.00b.source | [root_v5.22.00b.source.tar.gz](https://root.cern/download/root_v5.22.00b.source.tar.gz) |  25M |
+| root_v5.22.00c.source | [root_v5.22.00c.source.tar.gz](https://root.cern/download/root_v5.22.00c.source.tar.gz) |  25M |
+| root_v5.22.00d.source | [root_v5.22.00d.source.tar.gz](https://root.cern/download/root_v5.22.00d.source.tar.gz) |  25M |
+| root_v5.22.00e.source | [root_v5.22.00e.source.tar.gz](https://root.cern/download/root_v5.22.00e.source.tar.gz) |  25M |
+| root_v5.22.00f.source | [root_v5.22.00f.source.tar.gz](https://root.cern/download/root_v5.22.00f.source.tar.gz) |  25M |
+| root_v5.22.00g.source | [root_v5.22.00g.source.tar.gz](https://root.cern/download/root_v5.22.00g.source.tar.gz) |  25M |
+| root_v5.22.00h.source | [root_v5.22.00h.source.tar.gz](https://root.cern/download/root_v5.22.00h.source.tar.gz) |  25M |
+| root_v5.22.00i.source | [root_v5.22.00i.source.tar.gz](https://root.cern/download/root_v5.22.00i.source.tar.gz) |  25M |
+| root_v5.22.00j.source | [root_v5.22.00j.source.tar.gz](https://root.cern/download/root_v5.22.00j.source.tar.gz) |  25M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| Linux slc4 gcc3.4 | [root_v5.22.00.Linux-slc4-gcc3.4.tar.gz](https://root.cern.ch/download/root_v5.22.00.Linux-slc4-gcc3.4.tar.gz) |  48M |
-| Linux slc4 gcc4.3 | [root_v5.22.00.Linux-slc4-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.22.00.Linux-slc4-gcc4.3.tar.gz) |  48M |
-| Linux slc4_amd64 gcc3.4 | [root_v5.22.00.Linux-slc4_amd64-gcc3.4.tar.gz](https://root.cern.ch/download/root_v5.22.00.Linux-slc4_amd64-gcc3.4.tar.gz) |  50M |
-| Linux slc4_amd64 gcc4.3 | [root_v5.22.00.Linux-slc4_amd64-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.22.00.Linux-slc4_amd64-gcc4.3.tar.gz) |  49M |
-| Linux slc5 gcc3.4 | [root_v5.22.00.Linux-slc5-gcc3.4.tar.gz](https://root.cern.ch/download/root_v5.22.00.Linux-slc5-gcc3.4.tar.gz) |  48M |
-| Linux slc5 gcc4.3 | [root_v5.22.00.Linux-slc5-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.22.00.Linux-slc5-gcc4.3.tar.gz) |  48M |
-| Linux slc5_amd64 gcc3.4 | [root_v5.22.00.Linux-slc5_amd64-gcc3.4.tar.gz](https://root.cern.ch/download/root_v5.22.00.Linux-slc5_amd64-gcc3.4.tar.gz) |  49M |
-| Linux slc5_amd64 gcc4.3 | [root_v5.22.00.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.22.00.Linux-slc5_amd64-gcc4.3.tar.gz) |  49M |
-| macosx i386 gcc 4.0 | [root_v5.22.00.macosx-i386-gcc-4.0.tar.gz](https://root.cern.ch/download/root_v5.22.00.macosx-i386-gcc-4.0.tar.gz) |  47M |
-| macosx i386 icc 9.1 | [root_v5.22.00.macosx-i386-icc-9.1.tar.gz](https://root.cern.ch/download/root_v5.22.00.macosx-i386-icc-9.1.tar.gz) |  49M |
-| macosx powerpc gcc 4.0 | [root_v5.22.00.macosx-powerpc-gcc-4.0.tar.gz](https://root.cern.ch/download/root_v5.22.00.macosx-powerpc-gcc-4.0.tar.gz) |  46M |
-| macosx105 i386 gcc 4.0 | [root_v5.22.00.macosx105-i386-gcc-4.0.tar.gz](https://root.cern.ch/download/root_v5.22.00.macosx105-i386-gcc-4.0.tar.gz) |  37M |
-| SunOS.5.9 | [root_v5.22.00.SunOS.5.9.tar.gz](https://root.cern.ch/download/root_v5.22.00.SunOS.5.9.tar.gz) |  52M |
-| win32 (dbg) | [root_v5.22.00.win32.debug.tar.gz](https://root.cern.ch/download/root_v5.22.00.win32.debug.tar.gz) |  89M |
-| win32 | [root_v5.22.00.win32.tar.gz](https://root.cern.ch/download/root_v5.22.00.win32.tar.gz) |  47M |
-| Windows Visual Studio 90 (dbg) | [root_v5.22.00.win32.vc90.debug.tar.gz](https://root.cern.ch/download/root_v5.22.00.win32.vc90.debug.tar.gz) | 110M |
-| Windows Visual Studio 90 | [root_v5.22.00.win32.vc90.tar.gz](https://root.cern.ch/download/root_v5.22.00.win32.vc90.tar.gz) |  47M |
-| win32gcc | [root_v5.22.00.win32gcc.tar.gz](https://root.cern.ch/download/root_v5.22.00.win32gcc.tar.gz) |  49M |
+| Linux slc4 gcc3.4 | [root_v5.22.00.Linux-slc4-gcc3.4.tar.gz](https://root.cern/download/root_v5.22.00.Linux-slc4-gcc3.4.tar.gz) |  48M |
+| Linux slc4 gcc4.3 | [root_v5.22.00.Linux-slc4-gcc4.3.tar.gz](https://root.cern/download/root_v5.22.00.Linux-slc4-gcc4.3.tar.gz) |  48M |
+| Linux slc4_amd64 gcc3.4 | [root_v5.22.00.Linux-slc4_amd64-gcc3.4.tar.gz](https://root.cern/download/root_v5.22.00.Linux-slc4_amd64-gcc3.4.tar.gz) |  50M |
+| Linux slc4_amd64 gcc4.3 | [root_v5.22.00.Linux-slc4_amd64-gcc4.3.tar.gz](https://root.cern/download/root_v5.22.00.Linux-slc4_amd64-gcc4.3.tar.gz) |  49M |
+| Linux slc5 gcc3.4 | [root_v5.22.00.Linux-slc5-gcc3.4.tar.gz](https://root.cern/download/root_v5.22.00.Linux-slc5-gcc3.4.tar.gz) |  48M |
+| Linux slc5 gcc4.3 | [root_v5.22.00.Linux-slc5-gcc4.3.tar.gz](https://root.cern/download/root_v5.22.00.Linux-slc5-gcc4.3.tar.gz) |  48M |
+| Linux slc5_amd64 gcc3.4 | [root_v5.22.00.Linux-slc5_amd64-gcc3.4.tar.gz](https://root.cern/download/root_v5.22.00.Linux-slc5_amd64-gcc3.4.tar.gz) |  49M |
+| Linux slc5_amd64 gcc4.3 | [root_v5.22.00.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern/download/root_v5.22.00.Linux-slc5_amd64-gcc4.3.tar.gz) |  49M |
+| macosx i386 gcc 4.0 | [root_v5.22.00.macosx-i386-gcc-4.0.tar.gz](https://root.cern/download/root_v5.22.00.macosx-i386-gcc-4.0.tar.gz) |  47M |
+| macosx i386 icc 9.1 | [root_v5.22.00.macosx-i386-icc-9.1.tar.gz](https://root.cern/download/root_v5.22.00.macosx-i386-icc-9.1.tar.gz) |  49M |
+| macosx powerpc gcc 4.0 | [root_v5.22.00.macosx-powerpc-gcc-4.0.tar.gz](https://root.cern/download/root_v5.22.00.macosx-powerpc-gcc-4.0.tar.gz) |  46M |
+| macosx105 i386 gcc 4.0 | [root_v5.22.00.macosx105-i386-gcc-4.0.tar.gz](https://root.cern/download/root_v5.22.00.macosx105-i386-gcc-4.0.tar.gz) |  37M |
+| SunOS.5.9 | [root_v5.22.00.SunOS.5.9.tar.gz](https://root.cern/download/root_v5.22.00.SunOS.5.9.tar.gz) |  52M |
+| win32 (dbg) | [root_v5.22.00.win32.debug.tar.gz](https://root.cern/download/root_v5.22.00.win32.debug.tar.gz) |  89M |
+| win32 | [root_v5.22.00.win32.tar.gz](https://root.cern/download/root_v5.22.00.win32.tar.gz) |  47M |
+| Windows Visual Studio 90 (dbg) | [root_v5.22.00.win32.vc90.debug.tar.gz](https://root.cern/download/root_v5.22.00.win32.vc90.debug.tar.gz) | 110M |
+| Windows Visual Studio 90 | [root_v5.22.00.win32.vc90.tar.gz](https://root.cern/download/root_v5.22.00.win32.vc90.tar.gz) |  47M |
+| win32gcc | [root_v5.22.00.win32gcc.tar.gz](https://root.cern/download/root_v5.22.00.win32gcc.tar.gz) |  49M |
 
 
 ## Git

--- a/_releases/release-52200a.md
+++ b/_releases/release-52200a.md
@@ -15,7 +15,7 @@ sidebar:
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v5.22.00a.source.tar.gz](https://root.cern.ch/download/root_v5.22.00a.source.tar.gz) |  25M |
+| source | [root_v5.22.00a.source.tar.gz](https://root.cern/download/root_v5.22.00a.source.tar.gz) |  25M |
 
 
 
@@ -62,7 +62,7 @@ To use ROOT directly from AFS:
 The entire ROOT source can be obtained from our public Git repository:
 
 ~~~
-git clone http://root.cern.ch/git/root.git
+git clone http://root.cern/git/root.git
 ~~~
 The release specific tag can be obtained using:
 ~~~

--- a/_releases/release-52200b.md
+++ b/_releases/release-52200b.md
@@ -15,7 +15,7 @@ sidebar:
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v5.22.00b.source.tar.gz](https://root.cern.ch/download/root_v5.22.00b.source.tar.gz) |  25M |
+| source | [root_v5.22.00b.source.tar.gz](https://root.cern/download/root_v5.22.00b.source.tar.gz) |  25M |
 
 
 
@@ -60,7 +60,7 @@ To use ROOT directly from AFS:
 The entire ROOT source can be obtained from our public Git repository:
 
 ~~~
-git clone http://root.cern.ch/git/root.git
+git clone http://root.cern/git/root.git
 ~~~
 The release specific tag can be obtained using:
 ~~~

--- a/_releases/release-52200c.md
+++ b/_releases/release-52200c.md
@@ -15,7 +15,7 @@ sidebar:
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v5.22.00c.source.tar.gz](https://root.cern.ch/download/root_v5.22.00c.source.tar.gz) |  25M |
+| source | [root_v5.22.00c.source.tar.gz](https://root.cern/download/root_v5.22.00c.source.tar.gz) |  25M |
 
 
 
@@ -60,7 +60,7 @@ To use ROOT directly from AFS:
 The entire ROOT source can be obtained from our public Git repository:
 
 ~~~
-git clone http://root.cern.ch/git/root.git
+git clone http://root.cern/git/root.git
 ~~~
 The release specific tag can be obtained using:
 ~~~

--- a/_releases/release-52200d.md
+++ b/_releases/release-52200d.md
@@ -15,7 +15,7 @@ sidebar:
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v5.22.00d.source.tar.gz](https://root.cern.ch/download/root_v5.22.00d.source.tar.gz) |  25M |
+| source | [root_v5.22.00d.source.tar.gz](https://root.cern/download/root_v5.22.00d.source.tar.gz) |  25M |
 
 
 
@@ -60,7 +60,7 @@ To use ROOT directly from AFS:
 The entire ROOT source can be obtained from our public Git repository:
 
 ~~~
-git clone http://root.cern.ch/git/root.git
+git clone http://root.cern/git/root.git
 ~~~
 The release specific tag can be obtained using:
 ~~~

--- a/_releases/release-52200f.md
+++ b/_releases/release-52200f.md
@@ -15,7 +15,7 @@ sidebar:
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v5.22.00f.source.tar.gz](https://root.cern.ch/download/root_v5.22.00f.source.tar.gz) |  25M |
+| source | [root_v5.22.00f.source.tar.gz](https://root.cern/download/root_v5.22.00f.source.tar.gz) |  25M |
 
 
 
@@ -62,7 +62,7 @@ To use ROOT directly from AFS:
 The entire ROOT source can be obtained from our public Git repository:
 
 ~~~
-git clone http://root.cern.ch/git/root.git
+git clone http://root.cern/git/root.git
 ~~~
 The release specific tag can be obtained using:
 ~~~

--- a/_releases/release-52200g.md
+++ b/_releases/release-52200g.md
@@ -15,7 +15,7 @@ sidebar:
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v5.22.00g.source.tar.gz](https://root.cern.ch/download/root_v5.22.00g.source.tar.gz) |  25M |
+| source | [root_v5.22.00g.source.tar.gz](https://root.cern/download/root_v5.22.00g.source.tar.gz) |  25M |
 
 
 
@@ -51,7 +51,7 @@ To use ROOT directly from AFS:
 The entire ROOT source can be obtained from our public Git repository:
 
 ~~~
-git clone http://root.cern.ch/git/root.git
+git clone http://root.cern/git/root.git
 ~~~
 The release specific tag can be obtained using:
 ~~~

--- a/_releases/release-52200h.md
+++ b/_releases/release-52200h.md
@@ -15,8 +15,8 @@ sidebar:
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| old_source | [old_root_v5.22.00h.source.tar.gz](https://root.cern.ch/download/old_root_v5.22.00h.source.tar.gz) |  25M |
-| source | [root_v5.22.00h.source.tar.gz](https://root.cern.ch/download/root_v5.22.00h.source.tar.gz) |  25M |
+| old_source | [old_root_v5.22.00h.source.tar.gz](https://root.cern/download/old_root_v5.22.00h.source.tar.gz) |  25M |
+| source | [root_v5.22.00h.source.tar.gz](https://root.cern/download/root_v5.22.00h.source.tar.gz) |  25M |
 
 
 
@@ -51,7 +51,7 @@ To use ROOT directly from AFS:
 The entire ROOT source can be obtained from our public Git repository:
 
 ~~~
-git clone http://root.cern.ch/git/root.git
+git clone http://root.cern/git/root.git
 ~~~
 The release specific tag can be obtained using:
 ~~~

--- a/_releases/release-52200i.md
+++ b/_releases/release-52200i.md
@@ -15,7 +15,7 @@ sidebar:
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v5.22.00i.source.tar.gz](https://root.cern.ch/download/root_v5.22.00i.source.tar.gz) |  25M |
+| source | [root_v5.22.00i.source.tar.gz](https://root.cern/download/root_v5.22.00i.source.tar.gz) |  25M |
 
 
 
@@ -49,7 +49,7 @@ To use ROOT directly from AFS:
 The entire ROOT source can be obtained from our public Git repository:
 
 ~~~
-git clone http://root.cern.ch/git/root.git
+git clone http://root.cern/git/root.git
 ~~~
 The release specific tag can be obtained using:
 ~~~

--- a/_releases/release-52200j.md
+++ b/_releases/release-52200j.md
@@ -15,7 +15,7 @@ sidebar:
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v5.22.00j.source.tar.gz](https://root.cern.ch/download/root_v5.22.00j.source.tar.gz) |  25M |
+| source | [root_v5.22.00j.source.tar.gz](https://root.cern/download/root_v5.22.00j.source.tar.gz) |  25M |
 
 
 
@@ -53,7 +53,7 @@ To use ROOT directly from AFS:
 The entire ROOT source can be obtained from our public Git repository:
 
 ~~~
-git clone http://root.cern.ch/git/root.git
+git clone http://root.cern/git/root.git
 ~~~
 The release specific tag can be obtained using:
 ~~~

--- a/_releases/release-52302.md
+++ b/_releases/release-52302.md
@@ -15,30 +15,30 @@ sidebar:
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v5.23.02.source.tar.gz](https://root.cern.ch/download/root_v5.23.02.source.tar.gz) |  25M |
+| source | [root_v5.23.02.source.tar.gz](https://root.cern/download/root_v5.23.02.source.tar.gz) |  25M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| Linux slc4 gcc3.4 | [root_v5.23.02.Linux-slc4-gcc3.4.tar.gz](https://root.cern.ch/download/root_v5.23.02.Linux-slc4-gcc3.4.tar.gz) |  48M |
-| Linux slc4 gcc4.3 | [root_v5.23.02.Linux-slc4-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.23.02.Linux-slc4-gcc4.3.tar.gz) |  48M |
-| Linux slc4_amd64 gcc3.4 | [root_v5.23.02.Linux-slc4_amd64-gcc3.4.tar.gz](https://root.cern.ch/download/root_v5.23.02.Linux-slc4_amd64-gcc3.4.tar.gz) |  50M |
-| Linux slc4_amd64 gcc4.3 | [root_v5.23.02.Linux-slc4_amd64-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.23.02.Linux-slc4_amd64-gcc4.3.tar.gz) |  49M |
-| Linux slc5 gcc3.4 | [root_v5.23.02.Linux-slc5-gcc3.4.tar.gz](https://root.cern.ch/download/root_v5.23.02.Linux-slc5-gcc3.4.tar.gz) |  48M |
-| Linux slc5 gcc4.3 | [root_v5.23.02.Linux-slc5-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.23.02.Linux-slc5-gcc4.3.tar.gz) |  48M |
-| Linux slc5_amd64 gcc3.4 | [root_v5.23.02.Linux-slc5_amd64-gcc3.4.tar.gz](https://root.cern.ch/download/root_v5.23.02.Linux-slc5_amd64-gcc3.4.tar.gz) |  47M |
-| Linux slc5_amd64 gcc4.3 | [root_v5.23.02.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.23.02.Linux-slc5_amd64-gcc4.3.tar.gz) |  47M |
-| macosx i386 icc 9.1 | [root_v5.23.02.macosx-i386-icc-9.1.tar.gz](https://root.cern.ch/download/root_v5.23.02.macosx-i386-icc-9.1.tar.gz) |  47M |
-| macosx powerpc gcc 4.0 | [root_v5.23.02.macosx-powerpc-gcc-4.0.tar.gz](https://root.cern.ch/download/root_v5.23.02.macosx-powerpc-gcc-4.0.tar.gz) |  46M |
-| macosx105 i386 gcc 4.0 | [root_v5.23.02.macosx105-i386-gcc-4.0.tar.gz](https://root.cern.ch/download/root_v5.23.02.macosx105-i386-gcc-4.0.tar.gz) |  36M |
-| SunOS.5.9 | [root_v5.23.02.SunOS.5.9.tar.gz](https://root.cern.ch/download/root_v5.23.02.SunOS.5.9.tar.gz) |  52M |
-| win32 (dbg) | [root_v5.23.02.win32.debug.tar.gz](https://root.cern.ch/download/root_v5.23.02.win32.debug.tar.gz) |  88M |
-| win32 | [root_v5.23.02.win32.tar.gz](https://root.cern.ch/download/root_v5.23.02.win32.tar.gz) |  46M |
-| win32.vc90 (dbg) | [root_v5.23.02.win32.vc90.debug.tar.gz](https://root.cern.ch/download/root_v5.23.02.win32.vc90.debug.tar.gz) | 112M |
-| win32.vc90 | [root_v5.23.02.win32.vc90.tar.gz](https://root.cern.ch/download/root_v5.23.02.win32.vc90.tar.gz) |  48M |
-| win32gcc | [root_v5.23.02.win32gcc.tar.gz](https://root.cern.ch/download/root_v5.23.02.win32gcc.tar.gz) |  49M |
+| Linux slc4 gcc3.4 | [root_v5.23.02.Linux-slc4-gcc3.4.tar.gz](https://root.cern/download/root_v5.23.02.Linux-slc4-gcc3.4.tar.gz) |  48M |
+| Linux slc4 gcc4.3 | [root_v5.23.02.Linux-slc4-gcc4.3.tar.gz](https://root.cern/download/root_v5.23.02.Linux-slc4-gcc4.3.tar.gz) |  48M |
+| Linux slc4_amd64 gcc3.4 | [root_v5.23.02.Linux-slc4_amd64-gcc3.4.tar.gz](https://root.cern/download/root_v5.23.02.Linux-slc4_amd64-gcc3.4.tar.gz) |  50M |
+| Linux slc4_amd64 gcc4.3 | [root_v5.23.02.Linux-slc4_amd64-gcc4.3.tar.gz](https://root.cern/download/root_v5.23.02.Linux-slc4_amd64-gcc4.3.tar.gz) |  49M |
+| Linux slc5 gcc3.4 | [root_v5.23.02.Linux-slc5-gcc3.4.tar.gz](https://root.cern/download/root_v5.23.02.Linux-slc5-gcc3.4.tar.gz) |  48M |
+| Linux slc5 gcc4.3 | [root_v5.23.02.Linux-slc5-gcc4.3.tar.gz](https://root.cern/download/root_v5.23.02.Linux-slc5-gcc4.3.tar.gz) |  48M |
+| Linux slc5_amd64 gcc3.4 | [root_v5.23.02.Linux-slc5_amd64-gcc3.4.tar.gz](https://root.cern/download/root_v5.23.02.Linux-slc5_amd64-gcc3.4.tar.gz) |  47M |
+| Linux slc5_amd64 gcc4.3 | [root_v5.23.02.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern/download/root_v5.23.02.Linux-slc5_amd64-gcc4.3.tar.gz) |  47M |
+| macosx i386 icc 9.1 | [root_v5.23.02.macosx-i386-icc-9.1.tar.gz](https://root.cern/download/root_v5.23.02.macosx-i386-icc-9.1.tar.gz) |  47M |
+| macosx powerpc gcc 4.0 | [root_v5.23.02.macosx-powerpc-gcc-4.0.tar.gz](https://root.cern/download/root_v5.23.02.macosx-powerpc-gcc-4.0.tar.gz) |  46M |
+| macosx105 i386 gcc 4.0 | [root_v5.23.02.macosx105-i386-gcc-4.0.tar.gz](https://root.cern/download/root_v5.23.02.macosx105-i386-gcc-4.0.tar.gz) |  36M |
+| SunOS.5.9 | [root_v5.23.02.SunOS.5.9.tar.gz](https://root.cern/download/root_v5.23.02.SunOS.5.9.tar.gz) |  52M |
+| win32 (dbg) | [root_v5.23.02.win32.debug.tar.gz](https://root.cern/download/root_v5.23.02.win32.debug.tar.gz) |  88M |
+| win32 | [root_v5.23.02.win32.tar.gz](https://root.cern/download/root_v5.23.02.win32.tar.gz) |  46M |
+| win32.vc90 (dbg) | [root_v5.23.02.win32.vc90.debug.tar.gz](https://root.cern/download/root_v5.23.02.win32.vc90.debug.tar.gz) | 112M |
+| win32.vc90 | [root_v5.23.02.win32.vc90.tar.gz](https://root.cern/download/root_v5.23.02.win32.vc90.tar.gz) |  48M |
+| win32gcc | [root_v5.23.02.win32gcc.tar.gz](https://root.cern/download/root_v5.23.02.win32gcc.tar.gz) |  49M |
 
 
 
@@ -78,7 +78,7 @@ Standalone installations with minimal external dependencies are available at:
 The entire ROOT source can be obtained from our public Git repository:
 
 ~~~
-git clone http://root.cern.ch/git/root.git
+git clone http://root.cern/git/root.git
 ~~~
 The release specific tag can be obtained using:
 ~~~

--- a/_releases/release-52304.md
+++ b/_releases/release-52304.md
@@ -15,29 +15,29 @@ sidebar:
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v5.23.04.source.tar.gz](https://root.cern.ch/download/root_v5.23.04.source.tar.gz) |  25M |
+| source | [root_v5.23.04.source.tar.gz](https://root.cern/download/root_v5.23.04.source.tar.gz) |  25M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| Linux slc4 gcc3.4 | [root_v5.23.04.Linux-slc4-gcc3.4.tar.gz](https://root.cern.ch/download/root_v5.23.04.Linux-slc4-gcc3.4.tar.gz) |  50M |
-| Linux slc4 gcc4.3 | [root_v5.23.04.Linux-slc4-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.23.04.Linux-slc4-gcc4.3.tar.gz) |  49M |
-| Linux slc4_amd64 gcc3.4 | [root_v5.23.04.Linux-slc4_amd64-gcc3.4.tar.gz](https://root.cern.ch/download/root_v5.23.04.Linux-slc4_amd64-gcc3.4.tar.gz) |  51M |
-| Linux slc4_amd64 gcc4.3 | [root_v5.23.04.Linux-slc4_amd64-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.23.04.Linux-slc4_amd64-gcc4.3.tar.gz) |  51M |
-| Linux slc5 gcc3.4 | [root_v5.23.04.Linux-slc5-gcc3.4.tar.gz](https://root.cern.ch/download/root_v5.23.04.Linux-slc5-gcc3.4.tar.gz) |  49M |
-| Linux slc5 gcc4.3 | [root_v5.23.04.Linux-slc5-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.23.04.Linux-slc5-gcc4.3.tar.gz) |  49M |
-| Linux slc5_amd64 gcc3.4 | [root_v5.23.04.Linux-slc5_amd64-gcc3.4.tar.gz](https://root.cern.ch/download/root_v5.23.04.Linux-slc5_amd64-gcc3.4.tar.gz) |  51M |
-| Linux slc5_amd64 gcc4.3 | [root_v5.23.04.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.23.04.Linux-slc5_amd64-gcc4.3.tar.gz) |  51M |
-| macosx powerpc gcc 4.0 | [root_v5.23.04.macosx-powerpc-gcc-4.0.tar.gz](https://root.cern.ch/download/root_v5.23.04.macosx-powerpc-gcc-4.0.tar.gz) |  46M |
-| macosx105 i386 gcc 4.0 | [root_v5.23.04.macosx105-i386-gcc-4.0.tar.gz](https://root.cern.ch/download/root_v5.23.04.macosx105-i386-gcc-4.0.tar.gz) |  37M |
-| solarisCC5 | [root_v5.23.04.solarisCC5.tar.gz](https://root.cern.ch/download/root_v5.23.04.solarisCC5.tar.gz) |  53M |
-| win32 (dbg) | [root_v5.23.04.win32.debug.tar.gz](https://root.cern.ch/download/root_v5.23.04.win32.debug.tar.gz) |  89M |
-| win32 | [root_v5.23.04.win32.tar.gz](https://root.cern.ch/download/root_v5.23.04.win32.tar.gz) |  48M |
-| Windows Visual Studio 90 (dbg) | [root_v5.23.04.win32.vc90.debug.tar.gz](https://root.cern.ch/download/root_v5.23.04.win32.vc90.debug.tar.gz) | 116M |
-| Windows Visual Studio 90 | [root_v5.23.04.win32.vc90.tar.gz](https://root.cern.ch/download/root_v5.23.04.win32.vc90.tar.gz) |  49M |
-| win32gcc gcc 3.4 | [root_v5.23.04.win32gcc-gcc-3.4.tar.gz](https://root.cern.ch/download/root_v5.23.04.win32gcc-gcc-3.4.tar.gz) |  50M |
+| Linux slc4 gcc3.4 | [root_v5.23.04.Linux-slc4-gcc3.4.tar.gz](https://root.cern/download/root_v5.23.04.Linux-slc4-gcc3.4.tar.gz) |  50M |
+| Linux slc4 gcc4.3 | [root_v5.23.04.Linux-slc4-gcc4.3.tar.gz](https://root.cern/download/root_v5.23.04.Linux-slc4-gcc4.3.tar.gz) |  49M |
+| Linux slc4_amd64 gcc3.4 | [root_v5.23.04.Linux-slc4_amd64-gcc3.4.tar.gz](https://root.cern/download/root_v5.23.04.Linux-slc4_amd64-gcc3.4.tar.gz) |  51M |
+| Linux slc4_amd64 gcc4.3 | [root_v5.23.04.Linux-slc4_amd64-gcc4.3.tar.gz](https://root.cern/download/root_v5.23.04.Linux-slc4_amd64-gcc4.3.tar.gz) |  51M |
+| Linux slc5 gcc3.4 | [root_v5.23.04.Linux-slc5-gcc3.4.tar.gz](https://root.cern/download/root_v5.23.04.Linux-slc5-gcc3.4.tar.gz) |  49M |
+| Linux slc5 gcc4.3 | [root_v5.23.04.Linux-slc5-gcc4.3.tar.gz](https://root.cern/download/root_v5.23.04.Linux-slc5-gcc4.3.tar.gz) |  49M |
+| Linux slc5_amd64 gcc3.4 | [root_v5.23.04.Linux-slc5_amd64-gcc3.4.tar.gz](https://root.cern/download/root_v5.23.04.Linux-slc5_amd64-gcc3.4.tar.gz) |  51M |
+| Linux slc5_amd64 gcc4.3 | [root_v5.23.04.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern/download/root_v5.23.04.Linux-slc5_amd64-gcc4.3.tar.gz) |  51M |
+| macosx powerpc gcc 4.0 | [root_v5.23.04.macosx-powerpc-gcc-4.0.tar.gz](https://root.cern/download/root_v5.23.04.macosx-powerpc-gcc-4.0.tar.gz) |  46M |
+| macosx105 i386 gcc 4.0 | [root_v5.23.04.macosx105-i386-gcc-4.0.tar.gz](https://root.cern/download/root_v5.23.04.macosx105-i386-gcc-4.0.tar.gz) |  37M |
+| solarisCC5 | [root_v5.23.04.solarisCC5.tar.gz](https://root.cern/download/root_v5.23.04.solarisCC5.tar.gz) |  53M |
+| win32 (dbg) | [root_v5.23.04.win32.debug.tar.gz](https://root.cern/download/root_v5.23.04.win32.debug.tar.gz) |  89M |
+| win32 | [root_v5.23.04.win32.tar.gz](https://root.cern/download/root_v5.23.04.win32.tar.gz) |  48M |
+| Windows Visual Studio 90 (dbg) | [root_v5.23.04.win32.vc90.debug.tar.gz](https://root.cern/download/root_v5.23.04.win32.vc90.debug.tar.gz) | 116M |
+| Windows Visual Studio 90 | [root_v5.23.04.win32.vc90.tar.gz](https://root.cern/download/root_v5.23.04.win32.vc90.tar.gz) |  49M |
+| win32gcc gcc 3.4 | [root_v5.23.04.win32gcc-gcc-3.4.tar.gz](https://root.cern/download/root_v5.23.04.win32gcc-gcc-3.4.tar.gz) |  50M |
 
 
 
@@ -80,7 +80,7 @@ To use ROOT directly from AFS:
 The entire ROOT source can be obtained from our public Git repository:
 
 ~~~
-git clone http://root.cern.ch/git/root.git
+git clone http://root.cern/git/root.git
 ~~~
 The release specific tag can be obtained using:
 ~~~

--- a/_releases/release-52400.md
+++ b/_releases/release-52400.md
@@ -15,31 +15,31 @@ sidebar:
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v5.24.00.source.tar.gz](https://root.cern.ch/download/root_v5.24.00.source.tar.gz) |  26M |
-| root_v5.24.00a.source | [root_v5.24.00a.source.tar.gz](https://root.cern.ch/download/root_v5.24.00a.source.tar.gz) |  26M |
-| root_v5.24.00b.source | [root_v5.24.00b.source.tar.gz](https://root.cern.ch/download/root_v5.24.00b.source.tar.gz) |  26M |
+| source | [root_v5.24.00.source.tar.gz](https://root.cern/download/root_v5.24.00.source.tar.gz) |  26M |
+| root_v5.24.00a.source | [root_v5.24.00a.source.tar.gz](https://root.cern/download/root_v5.24.00a.source.tar.gz) |  26M |
+| root_v5.24.00b.source | [root_v5.24.00b.source.tar.gz](https://root.cern/download/root_v5.24.00b.source.tar.gz) |  26M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| Linux slc4 gcc3.4 | [root_v5.24.00.Linux-slc4-gcc3.4.tar.gz](https://root.cern.ch/download/root_v5.24.00.Linux-slc4-gcc3.4.tar.gz) |  51M |
-| Linux slc4 gcc4.3 | [root_v5.24.00.Linux-slc4-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.24.00.Linux-slc4-gcc4.3.tar.gz) |  51M |
-| Linux slc4_amd64 gcc3.4 | [root_v5.24.00.Linux-slc4_amd64-gcc3.4.tar.gz](https://root.cern.ch/download/root_v5.24.00.Linux-slc4_amd64-gcc3.4.tar.gz) |  53M |
-| Linux slc4_amd64 gcc4.3 | [root_v5.24.00.Linux-slc4_amd64-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.24.00.Linux-slc4_amd64-gcc4.3.tar.gz) |  52M |
-| Linux slc5 gcc3.4 | [root_v5.24.00.Linux-slc5-gcc3.4.tar.gz](https://root.cern.ch/download/root_v5.24.00.Linux-slc5-gcc3.4.tar.gz) |  52M |
-| Linux slc5 gcc4.3 | [root_v5.24.00.Linux-slc5-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.24.00.Linux-slc5-gcc4.3.tar.gz) |  51M |
-| Linux slc5_amd64 gcc3.4 | [root_v5.24.00.Linux-slc5_amd64-gcc3.4.tar.gz](https://root.cern.ch/download/root_v5.24.00.Linux-slc5_amd64-gcc3.4.tar.gz) |  54M |
-| Linux slc5_amd64 gcc4.3 | [root_v5.24.00.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.24.00.Linux-slc5_amd64-gcc4.3.tar.gz) |  52M |
-| macosx powerpc gcc 4.0 | [root_v5.24.00.macosx-powerpc-gcc-4.0.tar.gz](https://root.cern.ch/download/root_v5.24.00.macosx-powerpc-gcc-4.0.tar.gz) |  48M |
-| macosx105 i386 gcc 4.0 | [root_v5.24.00.macosx105-i386-gcc-4.0.tar.gz](https://root.cern.ch/download/root_v5.24.00.macosx105-i386-gcc-4.0.tar.gz) |  39M |
-| solarisCC5 | [root_v5.24.00.solarisCC5.tar.gz](https://root.cern.ch/download/root_v5.24.00.solarisCC5.tar.gz) |  60M |
-| win32 (dbg) | [root_v5.24.00.win32.debug.tar.gz](https://root.cern.ch/download/root_v5.24.00.win32.debug.tar.gz) |  93M |
-| win32 | [root_v5.24.00.win32.tar.gz](https://root.cern.ch/download/root_v5.24.00.win32.tar.gz) |  49M |
-| Windows Visual Studio 90 (dbg) | [root_v5.24.00.win32.vc90.debug.tar.gz](https://root.cern.ch/download/root_v5.24.00.win32.vc90.debug.tar.gz) | 122M |
-| Windows Visual Studio 90 | [root_v5.24.00.win32.vc90.tar.gz](https://root.cern.ch/download/root_v5.24.00.win32.vc90.tar.gz) |  51M |
-| win32gcc gcc 3.4 | [root_v5.24.00.win32gcc-gcc-3.4.tar.gz](https://root.cern.ch/download/root_v5.24.00.win32gcc-gcc-3.4.tar.gz) |  52M |
+| Linux slc4 gcc3.4 | [root_v5.24.00.Linux-slc4-gcc3.4.tar.gz](https://root.cern/download/root_v5.24.00.Linux-slc4-gcc3.4.tar.gz) |  51M |
+| Linux slc4 gcc4.3 | [root_v5.24.00.Linux-slc4-gcc4.3.tar.gz](https://root.cern/download/root_v5.24.00.Linux-slc4-gcc4.3.tar.gz) |  51M |
+| Linux slc4_amd64 gcc3.4 | [root_v5.24.00.Linux-slc4_amd64-gcc3.4.tar.gz](https://root.cern/download/root_v5.24.00.Linux-slc4_amd64-gcc3.4.tar.gz) |  53M |
+| Linux slc4_amd64 gcc4.3 | [root_v5.24.00.Linux-slc4_amd64-gcc4.3.tar.gz](https://root.cern/download/root_v5.24.00.Linux-slc4_amd64-gcc4.3.tar.gz) |  52M |
+| Linux slc5 gcc3.4 | [root_v5.24.00.Linux-slc5-gcc3.4.tar.gz](https://root.cern/download/root_v5.24.00.Linux-slc5-gcc3.4.tar.gz) |  52M |
+| Linux slc5 gcc4.3 | [root_v5.24.00.Linux-slc5-gcc4.3.tar.gz](https://root.cern/download/root_v5.24.00.Linux-slc5-gcc4.3.tar.gz) |  51M |
+| Linux slc5_amd64 gcc3.4 | [root_v5.24.00.Linux-slc5_amd64-gcc3.4.tar.gz](https://root.cern/download/root_v5.24.00.Linux-slc5_amd64-gcc3.4.tar.gz) |  54M |
+| Linux slc5_amd64 gcc4.3 | [root_v5.24.00.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern/download/root_v5.24.00.Linux-slc5_amd64-gcc4.3.tar.gz) |  52M |
+| macosx powerpc gcc 4.0 | [root_v5.24.00.macosx-powerpc-gcc-4.0.tar.gz](https://root.cern/download/root_v5.24.00.macosx-powerpc-gcc-4.0.tar.gz) |  48M |
+| macosx105 i386 gcc 4.0 | [root_v5.24.00.macosx105-i386-gcc-4.0.tar.gz](https://root.cern/download/root_v5.24.00.macosx105-i386-gcc-4.0.tar.gz) |  39M |
+| solarisCC5 | [root_v5.24.00.solarisCC5.tar.gz](https://root.cern/download/root_v5.24.00.solarisCC5.tar.gz) |  60M |
+| win32 (dbg) | [root_v5.24.00.win32.debug.tar.gz](https://root.cern/download/root_v5.24.00.win32.debug.tar.gz) |  93M |
+| win32 | [root_v5.24.00.win32.tar.gz](https://root.cern/download/root_v5.24.00.win32.tar.gz) |  49M |
+| Windows Visual Studio 90 (dbg) | [root_v5.24.00.win32.vc90.debug.tar.gz](https://root.cern/download/root_v5.24.00.win32.vc90.debug.tar.gz) | 122M |
+| Windows Visual Studio 90 | [root_v5.24.00.win32.vc90.tar.gz](https://root.cern/download/root_v5.24.00.win32.vc90.tar.gz) |  51M |
+| win32gcc gcc 3.4 | [root_v5.24.00.win32gcc-gcc-3.4.tar.gz](https://root.cern/download/root_v5.24.00.win32gcc-gcc-3.4.tar.gz) |  52M |
 
 
 
@@ -79,7 +79,7 @@ Standalone installations with minimal external dependencies are available at:
 The entire ROOT source can be obtained from our public Git repository:
 
 ~~~
-git clone http://root.cern.ch/git/root.git
+git clone http://root.cern/git/root.git
 ~~~
 The release specific tag can be obtained using:
 ~~~

--- a/_releases/release-52400b.md
+++ b/_releases/release-52400b.md
@@ -15,7 +15,7 @@ sidebar:
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v5.24.00b.source.tar.gz](https://root.cern.ch/download/root_v5.24.00b.source.tar.gz) |  26M |
+| source | [root_v5.24.00b.source.tar.gz](https://root.cern/download/root_v5.24.00b.source.tar.gz) |  26M |
 
 
 
@@ -60,7 +60,7 @@ To use ROOT directly from AFS:
 The entire ROOT source can be obtained from our public Git repository:
 
 ~~~
-git clone http://root.cern.ch/git/root.git
+git clone http://root.cern/git/root.git
 ~~~
 The release specific tag can be obtained using:
 ~~~

--- a/_releases/release-52502.md
+++ b/_releases/release-52502.md
@@ -15,30 +15,30 @@ sidebar:
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v5.25.02.source.tar.gz](https://root.cern.ch/download/root_v5.25.02.source.tar.gz) |  26M |
+| source | [root_v5.25.02.source.tar.gz](https://root.cern/download/root_v5.25.02.source.tar.gz) |  26M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| Linux slc4 gcc3.4 | [root_v5.25.02.Linux-slc4-gcc3.4.tar.gz](https://root.cern.ch/download/root_v5.25.02.Linux-slc4-gcc3.4.tar.gz) |  52M |
-| Linux slc4 gcc4.3 | [root_v5.25.02.Linux-slc4-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.25.02.Linux-slc4-gcc4.3.tar.gz) |  52M |
-| Linux slc4_amd64 gcc3.4 | [root_v5.25.02.Linux-slc4_amd64-gcc3.4.tar.gz](https://root.cern.ch/download/root_v5.25.02.Linux-slc4_amd64-gcc3.4.tar.gz) |  54M |
-| Linux slc4_amd64 gcc4.3 | [root_v5.25.02.Linux-slc4_amd64-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.25.02.Linux-slc4_amd64-gcc4.3.tar.gz) |  53M |
-| Linux slc5 gcc3.4 | [root_v5.25.02.Linux-slc5-gcc3.4.tar.gz](https://root.cern.ch/download/root_v5.25.02.Linux-slc5-gcc3.4.tar.gz) |  53M |
-| Linux slc5 gcc4.3 | [root_v5.25.02.Linux-slc5-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.25.02.Linux-slc5-gcc4.3.tar.gz) |  52M |
-| Linux slc5_amd64 gcc3.4 | [root_v5.25.02.Linux-slc5_amd64-gcc3.4.tar.gz](https://root.cern.ch/download/root_v5.25.02.Linux-slc5_amd64-gcc3.4.tar.gz) |  54M |
-| Linux slc5_amd64 gcc4.3 | [root_v5.25.02.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.25.02.Linux-slc5_amd64-gcc4.3.tar.gz) |  53M |
-| macosx powerpc gcc 4.0 | [root_v5.25.02.macosx-powerpc-gcc-4.0.tar.gz](https://root.cern.ch/download/root_v5.25.02.macosx-powerpc-gcc-4.0.tar.gz) |  49M |
-| macosx105 i386 gcc 4.0 | [root_v5.25.02.macosx105-i386-gcc-4.0.tar.gz](https://root.cern.ch/download/root_v5.25.02.macosx105-i386-gcc-4.0.tar.gz) |  39M |
-| macosxicc | [root_v5.25.02.macosxicc.tar.gz](https://root.cern.ch/download/root_v5.25.02.macosxicc.tar.gz) |  53M |
-| solarisCC5 | [root_v5.25.02.solarisCC5.tar.gz](https://root.cern.ch/download/root_v5.25.02.solarisCC5.tar.gz) |  61M |
-| win32 (dbg) | [root_v5.25.02.win32.debug.tar.gz](https://root.cern.ch/download/root_v5.25.02.win32.debug.tar.gz) |  95M |
-| win32 | [root_v5.25.02.win32.tar.gz](https://root.cern.ch/download/root_v5.25.02.win32.tar.gz) |  50M |
-| Windows Visual Studio 90 (dbg) | [root_v5.25.02.win32.vc90.debug.tar.gz](https://root.cern.ch/download/root_v5.25.02.win32.vc90.debug.tar.gz) | 124M |
-| Windows Visual Studio 90 | [root_v5.25.02.win32.vc90.tar.gz](https://root.cern.ch/download/root_v5.25.02.win32.vc90.tar.gz) |  52M |
-| win32gcc gcc 3.4 | [root_v5.25.02.win32gcc-gcc-3.4.tar.gz](https://root.cern.ch/download/root_v5.25.02.win32gcc-gcc-3.4.tar.gz) |  52M |
+| Linux slc4 gcc3.4 | [root_v5.25.02.Linux-slc4-gcc3.4.tar.gz](https://root.cern/download/root_v5.25.02.Linux-slc4-gcc3.4.tar.gz) |  52M |
+| Linux slc4 gcc4.3 | [root_v5.25.02.Linux-slc4-gcc4.3.tar.gz](https://root.cern/download/root_v5.25.02.Linux-slc4-gcc4.3.tar.gz) |  52M |
+| Linux slc4_amd64 gcc3.4 | [root_v5.25.02.Linux-slc4_amd64-gcc3.4.tar.gz](https://root.cern/download/root_v5.25.02.Linux-slc4_amd64-gcc3.4.tar.gz) |  54M |
+| Linux slc4_amd64 gcc4.3 | [root_v5.25.02.Linux-slc4_amd64-gcc4.3.tar.gz](https://root.cern/download/root_v5.25.02.Linux-slc4_amd64-gcc4.3.tar.gz) |  53M |
+| Linux slc5 gcc3.4 | [root_v5.25.02.Linux-slc5-gcc3.4.tar.gz](https://root.cern/download/root_v5.25.02.Linux-slc5-gcc3.4.tar.gz) |  53M |
+| Linux slc5 gcc4.3 | [root_v5.25.02.Linux-slc5-gcc4.3.tar.gz](https://root.cern/download/root_v5.25.02.Linux-slc5-gcc4.3.tar.gz) |  52M |
+| Linux slc5_amd64 gcc3.4 | [root_v5.25.02.Linux-slc5_amd64-gcc3.4.tar.gz](https://root.cern/download/root_v5.25.02.Linux-slc5_amd64-gcc3.4.tar.gz) |  54M |
+| Linux slc5_amd64 gcc4.3 | [root_v5.25.02.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern/download/root_v5.25.02.Linux-slc5_amd64-gcc4.3.tar.gz) |  53M |
+| macosx powerpc gcc 4.0 | [root_v5.25.02.macosx-powerpc-gcc-4.0.tar.gz](https://root.cern/download/root_v5.25.02.macosx-powerpc-gcc-4.0.tar.gz) |  49M |
+| macosx105 i386 gcc 4.0 | [root_v5.25.02.macosx105-i386-gcc-4.0.tar.gz](https://root.cern/download/root_v5.25.02.macosx105-i386-gcc-4.0.tar.gz) |  39M |
+| macosxicc | [root_v5.25.02.macosxicc.tar.gz](https://root.cern/download/root_v5.25.02.macosxicc.tar.gz) |  53M |
+| solarisCC5 | [root_v5.25.02.solarisCC5.tar.gz](https://root.cern/download/root_v5.25.02.solarisCC5.tar.gz) |  61M |
+| win32 (dbg) | [root_v5.25.02.win32.debug.tar.gz](https://root.cern/download/root_v5.25.02.win32.debug.tar.gz) |  95M |
+| win32 | [root_v5.25.02.win32.tar.gz](https://root.cern/download/root_v5.25.02.win32.tar.gz) |  50M |
+| Windows Visual Studio 90 (dbg) | [root_v5.25.02.win32.vc90.debug.tar.gz](https://root.cern/download/root_v5.25.02.win32.vc90.debug.tar.gz) | 124M |
+| Windows Visual Studio 90 | [root_v5.25.02.win32.vc90.tar.gz](https://root.cern/download/root_v5.25.02.win32.vc90.tar.gz) |  52M |
+| win32gcc gcc 3.4 | [root_v5.25.02.win32gcc-gcc-3.4.tar.gz](https://root.cern/download/root_v5.25.02.win32gcc-gcc-3.4.tar.gz) |  52M |
 
 
 
@@ -81,7 +81,7 @@ To use ROOT directly from AFS:
 The entire ROOT source can be obtained from our public Git repository:
 
 ~~~
-git clone http://root.cern.ch/git/root.git
+git clone http://root.cern/git/root.git
 ~~~
 The release specific tag can be obtained using:
 ~~~

--- a/_releases/release-52504.md
+++ b/_releases/release-52504.md
@@ -15,30 +15,30 @@ sidebar:
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v5.25.04.source.tar.gz](https://root.cern.ch/download/root_v5.25.04.source.tar.gz) |  27M |
+| source | [root_v5.25.04.source.tar.gz](https://root.cern/download/root_v5.25.04.source.tar.gz) |  27M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| Linux slc4 gcc3.4 | [root_v5.25.04.Linux-slc4-gcc3.4.tar.gz](https://root.cern.ch/download/root_v5.25.04.Linux-slc4-gcc3.4.tar.gz) |  54M |
-| Linux slc4 gcc4.3 | [root_v5.25.04.Linux-slc4-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.25.04.Linux-slc4-gcc4.3.tar.gz) |  53M |
-| Linux slc4_amd64 gcc3.4 | [root_v5.25.04.Linux-slc4_amd64-gcc3.4.tar.gz](https://root.cern.ch/download/root_v5.25.04.Linux-slc4_amd64-gcc3.4.tar.gz) |  55M |
-| Linux slc4_amd64 gcc4.3 | [root_v5.25.04.Linux-slc4_amd64-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.25.04.Linux-slc4_amd64-gcc4.3.tar.gz) |  54M |
-| Linux slc5 gcc3.4 | [root_v5.25.04.Linux-slc5-gcc3.4.tar.gz](https://root.cern.ch/download/root_v5.25.04.Linux-slc5-gcc3.4.tar.gz) |  54M |
-| Linux slc5 gcc4.3 | [root_v5.25.04.Linux-slc5-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.25.04.Linux-slc5-gcc4.3.tar.gz) |  53M |
-| Linux slc5_amd64 gcc3.4 | [root_v5.25.04.Linux-slc5_amd64-gcc3.4.tar.gz](https://root.cern.ch/download/root_v5.25.04.Linux-slc5_amd64-gcc3.4.tar.gz) |  56M |
-| Linux slc5_amd64 gcc4.3 | [root_v5.25.04.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.25.04.Linux-slc5_amd64-gcc4.3.tar.gz) |  54M |
-| macosx powerpc gcc 4.0 | [root_v5.25.04.macosx-powerpc-gcc-4.0.tar.gz](https://root.cern.ch/download/root_v5.25.04.macosx-powerpc-gcc-4.0.tar.gz) |  50M |
-| OsX 10.6 i386 gcc 4.2 | [root_v5.25.04.macosx64-10.6-i386-gcc-4.2.tar.gz](https://root.cern.ch/download/root_v5.25.04.macosx64-10.6-i386-gcc-4.2.tar.gz) |  42M |
-| macosx105 i386 gcc 4.0 | [root_v5.25.04.macosx105-i386-gcc-4.0.tar.gz](https://root.cern.ch/download/root_v5.25.04.macosx105-i386-gcc-4.0.tar.gz) |  40M |
-| solarisCC5 | [root_v5.25.04.solarisCC5.tar.gz](https://root.cern.ch/download/root_v5.25.04.solarisCC5.tar.gz) |  61M |
-| win32 (dbg) | [root_v5.25.04.win32.debug.tar.gz](https://root.cern.ch/download/root_v5.25.04.win32.debug.tar.gz) |  96M |
-| win32 | [root_v5.25.04.win32.tar.gz](https://root.cern.ch/download/root_v5.25.04.win32.tar.gz) |  51M |
-| Windows Visual Studio 90 (dbg) | [root_v5.25.04.win32.vc90.debug.tar.gz](https://root.cern.ch/download/root_v5.25.04.win32.vc90.debug.tar.gz) | 126M |
-| Windows Visual Studio 90 | [root_v5.25.04.win32.vc90.tar.gz](https://root.cern.ch/download/root_v5.25.04.win32.vc90.tar.gz) |  52M |
-| win32gcc gcc 3.4 | [root_v5.25.04.win32gcc-gcc-3.4.tar.gz](https://root.cern.ch/download/root_v5.25.04.win32gcc-gcc-3.4.tar.gz) |  53M |
+| Linux slc4 gcc3.4 | [root_v5.25.04.Linux-slc4-gcc3.4.tar.gz](https://root.cern/download/root_v5.25.04.Linux-slc4-gcc3.4.tar.gz) |  54M |
+| Linux slc4 gcc4.3 | [root_v5.25.04.Linux-slc4-gcc4.3.tar.gz](https://root.cern/download/root_v5.25.04.Linux-slc4-gcc4.3.tar.gz) |  53M |
+| Linux slc4_amd64 gcc3.4 | [root_v5.25.04.Linux-slc4_amd64-gcc3.4.tar.gz](https://root.cern/download/root_v5.25.04.Linux-slc4_amd64-gcc3.4.tar.gz) |  55M |
+| Linux slc4_amd64 gcc4.3 | [root_v5.25.04.Linux-slc4_amd64-gcc4.3.tar.gz](https://root.cern/download/root_v5.25.04.Linux-slc4_amd64-gcc4.3.tar.gz) |  54M |
+| Linux slc5 gcc3.4 | [root_v5.25.04.Linux-slc5-gcc3.4.tar.gz](https://root.cern/download/root_v5.25.04.Linux-slc5-gcc3.4.tar.gz) |  54M |
+| Linux slc5 gcc4.3 | [root_v5.25.04.Linux-slc5-gcc4.3.tar.gz](https://root.cern/download/root_v5.25.04.Linux-slc5-gcc4.3.tar.gz) |  53M |
+| Linux slc5_amd64 gcc3.4 | [root_v5.25.04.Linux-slc5_amd64-gcc3.4.tar.gz](https://root.cern/download/root_v5.25.04.Linux-slc5_amd64-gcc3.4.tar.gz) |  56M |
+| Linux slc5_amd64 gcc4.3 | [root_v5.25.04.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern/download/root_v5.25.04.Linux-slc5_amd64-gcc4.3.tar.gz) |  54M |
+| macosx powerpc gcc 4.0 | [root_v5.25.04.macosx-powerpc-gcc-4.0.tar.gz](https://root.cern/download/root_v5.25.04.macosx-powerpc-gcc-4.0.tar.gz) |  50M |
+| OsX 10.6 i386 gcc 4.2 | [root_v5.25.04.macosx64-10.6-i386-gcc-4.2.tar.gz](https://root.cern/download/root_v5.25.04.macosx64-10.6-i386-gcc-4.2.tar.gz) |  42M |
+| macosx105 i386 gcc 4.0 | [root_v5.25.04.macosx105-i386-gcc-4.0.tar.gz](https://root.cern/download/root_v5.25.04.macosx105-i386-gcc-4.0.tar.gz) |  40M |
+| solarisCC5 | [root_v5.25.04.solarisCC5.tar.gz](https://root.cern/download/root_v5.25.04.solarisCC5.tar.gz) |  61M |
+| win32 (dbg) | [root_v5.25.04.win32.debug.tar.gz](https://root.cern/download/root_v5.25.04.win32.debug.tar.gz) |  96M |
+| win32 | [root_v5.25.04.win32.tar.gz](https://root.cern/download/root_v5.25.04.win32.tar.gz) |  51M |
+| Windows Visual Studio 90 (dbg) | [root_v5.25.04.win32.vc90.debug.tar.gz](https://root.cern/download/root_v5.25.04.win32.vc90.debug.tar.gz) | 126M |
+| Windows Visual Studio 90 | [root_v5.25.04.win32.vc90.tar.gz](https://root.cern/download/root_v5.25.04.win32.vc90.tar.gz) |  52M |
+| win32gcc gcc 3.4 | [root_v5.25.04.win32gcc-gcc-3.4.tar.gz](https://root.cern/download/root_v5.25.04.win32gcc-gcc-3.4.tar.gz) |  53M |
 
 
 ## Git

--- a/_releases/release-52600.md
+++ b/_releases/release-52600.md
@@ -15,67 +15,67 @@ sidebar:
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| old_root_v5.26.00b.source | [old_root_v5.26.00b.source.tar.gz](https://root.cern.ch/download/old_root_v5.26.00b.source.tar.gz) |  28M |
-| root_v5.26.00 proof 02.source | [root_v5.26.00-proof-02.source.tar.gz](https://root.cern.ch/download/root_v5.26.00-proof-02.source.tar.gz) |  56M |
-| root_v5.26.00 proof 04.source | [root_v5.26.00-proof-04.source.tar.gz](https://root.cern.ch/download/root_v5.26.00-proof-04.source.tar.gz) |  28M |
-| source | [root_v5.26.00.source.tar.gz](https://root.cern.ch/download/root_v5.26.00.source.tar.gz) |  28M |
-| root_v5.26.00a.source | [root_v5.26.00a.source.tar.gz](https://root.cern.ch/download/root_v5.26.00a.source.tar.gz) |  27M |
-| root_v5.26.00b.source | [root_v5.26.00b.source.tar.gz](https://root.cern.ch/download/root_v5.26.00b.source.tar.gz) |  28M |
-| root_v5.26.00c.source | [root_v5.26.00c.source.tar.gz](https://root.cern.ch/download/root_v5.26.00c.source.tar.gz) |  28M |
-| root_v5.26.00d.source | [root_v5.26.00d.source.tar.gz](https://root.cern.ch/download/root_v5.26.00d.source.tar.gz) |  28M |
-| root_v5.26.00e.source | [root_v5.26.00e.source.tar.gz](https://root.cern.ch/download/root_v5.26.00e.source.tar.gz) |  28M |
-| root_v5.26.00f.source | [root_v5.26.00f.source.tar.gz](https://root.cern.ch/download/root_v5.26.00f.source.tar.gz) |  28M |
-| root_v5.26.00g.source | [root_v5.26.00g.source.tar.gz](https://root.cern.ch/download/root_v5.26.00g.source.tar.gz) |  28M |
+| old_root_v5.26.00b.source | [old_root_v5.26.00b.source.tar.gz](https://root.cern/download/old_root_v5.26.00b.source.tar.gz) |  28M |
+| root_v5.26.00 proof 02.source | [root_v5.26.00-proof-02.source.tar.gz](https://root.cern/download/root_v5.26.00-proof-02.source.tar.gz) |  56M |
+| root_v5.26.00 proof 04.source | [root_v5.26.00-proof-04.source.tar.gz](https://root.cern/download/root_v5.26.00-proof-04.source.tar.gz) |  28M |
+| source | [root_v5.26.00.source.tar.gz](https://root.cern/download/root_v5.26.00.source.tar.gz) |  28M |
+| root_v5.26.00a.source | [root_v5.26.00a.source.tar.gz](https://root.cern/download/root_v5.26.00a.source.tar.gz) |  27M |
+| root_v5.26.00b.source | [root_v5.26.00b.source.tar.gz](https://root.cern/download/root_v5.26.00b.source.tar.gz) |  28M |
+| root_v5.26.00c.source | [root_v5.26.00c.source.tar.gz](https://root.cern/download/root_v5.26.00c.source.tar.gz) |  28M |
+| root_v5.26.00d.source | [root_v5.26.00d.source.tar.gz](https://root.cern/download/root_v5.26.00d.source.tar.gz) |  28M |
+| root_v5.26.00e.source | [root_v5.26.00e.source.tar.gz](https://root.cern/download/root_v5.26.00e.source.tar.gz) |  28M |
+| root_v5.26.00f.source | [root_v5.26.00f.source.tar.gz](https://root.cern/download/root_v5.26.00f.source.tar.gz) |  28M |
+| root_v5.26.00g.source | [root_v5.26.00g.source.tar.gz](https://root.cern/download/root_v5.26.00g.source.tar.gz) |  28M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| root_v5.26.00 proof 02.Linux slc5_amd64 gcc4.3 | [root_v5.26.00-proof-02.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.26.00-proof-02.Linux-slc5_amd64-gcc4.3.tar.gz) |  53M |
-| root_v5.26.00 proof 04.Linux slc5_amd64 gcc4.3 | [root_v5.26.00-proof-04.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.26.00-proof-04.Linux-slc5_amd64-gcc4.3.tar.gz) |  52M |
-| Linux slc4 gcc3.4 | [root_v5.26.00.Linux-slc4-gcc3.4.tar.gz](https://root.cern.ch/download/root_v5.26.00.Linux-slc4-gcc3.4.tar.gz) |  54M |
-| Linux slc4 gcc4.3 | [root_v5.26.00.Linux-slc4-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.26.00.Linux-slc4-gcc4.3.tar.gz) |  54M |
-| Linux slc4_amd64 gcc3.4 | [root_v5.26.00.Linux-slc4_amd64-gcc3.4.tar.gz](https://root.cern.ch/download/root_v5.26.00.Linux-slc4_amd64-gcc3.4.tar.gz) |  55M |
-| Linux slc4_amd64 gcc4.3 | [root_v5.26.00.Linux-slc4_amd64-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.26.00.Linux-slc4_amd64-gcc4.3.tar.gz) |  55M |
-| Linux slc5 gcc3.4 | [root_v5.26.00.Linux-slc5-gcc3.4.tar.gz](https://root.cern.ch/download/root_v5.26.00.Linux-slc5-gcc3.4.tar.gz) |  54M |
-| Linux slc5 gcc4.3 | [root_v5.26.00.Linux-slc5-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.26.00.Linux-slc5-gcc4.3.tar.gz) |  54M |
-| Linux slc5_amd64 gcc3.4 | [root_v5.26.00.Linux-slc5_amd64-gcc3.4.tar.gz](https://root.cern.ch/download/root_v5.26.00.Linux-slc5_amd64-gcc3.4.tar.gz) |  56M |
-| Linux slc5_amd64 gcc4.3 | [root_v5.26.00.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.26.00.Linux-slc5_amd64-gcc4.3.tar.gz) |  55M |
-| macosx powerpc gcc 4.0 | [root_v5.26.00.macosx-powerpc-gcc-4.0.tar.gz](https://root.cern.ch/download/root_v5.26.00.macosx-powerpc-gcc-4.0.tar.gz) |  51M |
-| macosx105 i386 gcc 4.0 | [root_v5.26.00.macosx105-i386-gcc-4.0.tar.gz](https://root.cern.ch/download/root_v5.26.00.macosx105-i386-gcc-4.0.tar.gz) |  40M |
-| solarisCC5 5.11 i386 | [root_v5.26.00.solarisCC5-5.11-i386.tar.gz](https://root.cern.ch/download/root_v5.26.00.solarisCC5-5.11-i386.tar.gz) |  72M |
-| win32 (dbg) | [root_v5.26.00.win32.debug.tar.gz](https://root.cern.ch/download/root_v5.26.00.win32.debug.tar.gz) |  97M |
-| win32 | [root_v5.26.00.win32.tar.gz](https://root.cern.ch/download/root_v5.26.00.win32.tar.gz) |  51M |
-| Windows Visual Studio 90 (dbg) | [root_v5.26.00.win32.vc90.debug.tar.gz](https://root.cern.ch/download/root_v5.26.00.win32.vc90.debug.tar.gz) | 127M |
-| Windows Visual Studio 90 | [root_v5.26.00.win32.vc90.tar.gz](https://root.cern.ch/download/root_v5.26.00.win32.vc90.tar.gz) |  52M |
-| win32gcc gcc 3.4 | [root_v5.26.00.win32gcc-gcc-3.4.tar.gz](https://root.cern.ch/download/root_v5.26.00.win32gcc-gcc-3.4.tar.gz) |  53M |
-| root_v5.26.00b.Linux slc4 gcc3.4 | [root_v5.26.00b.Linux-slc4-gcc3.4.tar.gz](https://root.cern.ch/download/root_v5.26.00b.Linux-slc4-gcc3.4.tar.gz) |  54M |
-| root_v5.26.00b.Linux slc4 gcc4.3 | [root_v5.26.00b.Linux-slc4-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.26.00b.Linux-slc4-gcc4.3.tar.gz) |  54M |
-| root_v5.26.00b.Linux slc4_amd64 gcc3.4 | [root_v5.26.00b.Linux-slc4_amd64-gcc3.4.tar.gz](https://root.cern.ch/download/root_v5.26.00b.Linux-slc4_amd64-gcc3.4.tar.gz) |  56M |
-| root_v5.26.00b.Linux slc4_amd64 gcc4.3 | [root_v5.26.00b.Linux-slc4_amd64-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.26.00b.Linux-slc4_amd64-gcc4.3.tar.gz) |  55M |
-| root_v5.26.00b.Linux slc5 gcc3.4 | [root_v5.26.00b.Linux-slc5-gcc3.4.tar.gz](https://root.cern.ch/download/root_v5.26.00b.Linux-slc5-gcc3.4.tar.gz) |  55M |
-| root_v5.26.00b.Linux slc5 gcc4.3 | [root_v5.26.00b.Linux-slc5-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.26.00b.Linux-slc5-gcc4.3.tar.gz) |  54M |
-| root_v5.26.00b.Linux slc5_amd64 gcc3.4 | [root_v5.26.00b.Linux-slc5_amd64-gcc3.4.tar.gz](https://root.cern.ch/download/root_v5.26.00b.Linux-slc5_amd64-gcc3.4.tar.gz) |  56M |
-| root_v5.26.00b.Linux slc5_amd64 gcc4.3 | [root_v5.26.00b.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.26.00b.Linux-slc5_amd64-gcc4.3.tar.gz) |  55M |
-| root_v5.26.00b.macosx powerpc gcc 4.0 | [root_v5.26.00b.macosx-powerpc-gcc-4.0.tar.gz](https://root.cern.ch/download/root_v5.26.00b.macosx-powerpc-gcc-4.0.tar.gz) |  51M |
-| root_v5.26.00b.macosx105 i386 gcc 4.0 | [root_v5.26.00b.macosx105-i386-gcc-4.0.tar.gz](https://root.cern.ch/download/root_v5.26.00b.macosx105-i386-gcc-4.0.tar.gz) |  40M |
-| root_v5.26.00b.win32 (dbg) | [root_v5.26.00b.win32.debug.tar.gz](https://root.cern.ch/download/root_v5.26.00b.win32.debug.tar.gz) |  97M |
-| root_v5.26.00b.win32 | [root_v5.26.00b.win32.tar.gz](https://root.cern.ch/download/root_v5.26.00b.win32.tar.gz) |  51M |
-| root_v5.26.00b.Windows Visual Studio 90 (dbg) | [root_v5.26.00b.win32.vc90.debug.tar.gz](https://root.cern.ch/download/root_v5.26.00b.win32.vc90.debug.tar.gz) | 127M |
-| root_v5.26.00b.Windows Visual Studio 90 | [root_v5.26.00b.win32.vc90.tar.gz](https://root.cern.ch/download/root_v5.26.00b.win32.vc90.tar.gz) |  52M |
-| root_v5.26.00c.Linux slc4 gcc3.4 | [root_v5.26.00c.Linux-slc4-gcc3.4.tar.gz](https://root.cern.ch/download/root_v5.26.00c.Linux-slc4-gcc3.4.tar.gz) |  54M |
-| root_v5.26.00c.Linux slc4_amd64 gcc3.4 | [root_v5.26.00c.Linux-slc4_amd64-gcc3.4.tar.gz](https://root.cern.ch/download/root_v5.26.00c.Linux-slc4_amd64-gcc3.4.tar.gz) |  56M |
-| root_v5.26.00c.Linux slc5 gcc4.3 | [root_v5.26.00c.Linux-slc5-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.26.00c.Linux-slc5-gcc4.3.tar.gz) |  54M |
-| root_v5.26.00c.Linux slc5_amd64 gcc4.3 | [root_v5.26.00c.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.26.00c.Linux-slc5_amd64-gcc4.3.tar.gz) |  55M |
-| root_v5.26.00c.macosx104 powerpc gcc 4.0 | [root_v5.26.00c.macosx104-powerpc-gcc-4.0.tar.gz](https://root.cern.ch/download/root_v5.26.00c.macosx104-powerpc-gcc-4.0.tar.gz) |  42M |
-| root_v5.26.00c.macosx105 i386 gcc 4.0 | [root_v5.26.00c.macosx105-i386-gcc-4.0.tar.gz](https://root.cern.ch/download/root_v5.26.00c.macosx105-i386-gcc-4.0.tar.gz) |  40M |
-| root_v5.26.00c.macosx106 i386 gcc 4.2 | [root_v5.26.00c.macosx106-i386-gcc-4.2.tar.gz](https://root.cern.ch/download/root_v5.26.00c.macosx106-i386-gcc-4.2.tar.gz) |  43M |
-| root_v5.26.00c.macosx106 gcc 4.2 | [root_v5.26.00c.macosx106-x86_64-gcc-4.2.tar.gz](https://root.cern.ch/download/root_v5.26.00c.macosx106-x86_64-gcc-4.2.tar.gz) |  43M |
-| root_v5.26.00c.win32 (dbg) | [root_v5.26.00c.win32.debug.tar.gz](https://root.cern.ch/download/root_v5.26.00c.win32.debug.tar.gz) |  97M |
-| root_v5.26.00c.win32 | [root_v5.26.00c.win32.tar.gz](https://root.cern.ch/download/root_v5.26.00c.win32.tar.gz) |  51M |
-| root_v5.26.00c.Windows Visual Studio 90 (dbg) | [root_v5.26.00c.win32.vc90.debug.tar.gz](https://root.cern.ch/download/root_v5.26.00c.win32.vc90.debug.tar.gz) | 127M |
-| root_v5.26.00c.Windows Visual Studio 90 | [root_v5.26.00c.win32.vc90.tar.gz](https://root.cern.ch/download/root_v5.26.00c.win32.vc90.tar.gz) |  53M |
+| root_v5.26.00 proof 02.Linux slc5_amd64 gcc4.3 | [root_v5.26.00-proof-02.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern/download/root_v5.26.00-proof-02.Linux-slc5_amd64-gcc4.3.tar.gz) |  53M |
+| root_v5.26.00 proof 04.Linux slc5_amd64 gcc4.3 | [root_v5.26.00-proof-04.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern/download/root_v5.26.00-proof-04.Linux-slc5_amd64-gcc4.3.tar.gz) |  52M |
+| Linux slc4 gcc3.4 | [root_v5.26.00.Linux-slc4-gcc3.4.tar.gz](https://root.cern/download/root_v5.26.00.Linux-slc4-gcc3.4.tar.gz) |  54M |
+| Linux slc4 gcc4.3 | [root_v5.26.00.Linux-slc4-gcc4.3.tar.gz](https://root.cern/download/root_v5.26.00.Linux-slc4-gcc4.3.tar.gz) |  54M |
+| Linux slc4_amd64 gcc3.4 | [root_v5.26.00.Linux-slc4_amd64-gcc3.4.tar.gz](https://root.cern/download/root_v5.26.00.Linux-slc4_amd64-gcc3.4.tar.gz) |  55M |
+| Linux slc4_amd64 gcc4.3 | [root_v5.26.00.Linux-slc4_amd64-gcc4.3.tar.gz](https://root.cern/download/root_v5.26.00.Linux-slc4_amd64-gcc4.3.tar.gz) |  55M |
+| Linux slc5 gcc3.4 | [root_v5.26.00.Linux-slc5-gcc3.4.tar.gz](https://root.cern/download/root_v5.26.00.Linux-slc5-gcc3.4.tar.gz) |  54M |
+| Linux slc5 gcc4.3 | [root_v5.26.00.Linux-slc5-gcc4.3.tar.gz](https://root.cern/download/root_v5.26.00.Linux-slc5-gcc4.3.tar.gz) |  54M |
+| Linux slc5_amd64 gcc3.4 | [root_v5.26.00.Linux-slc5_amd64-gcc3.4.tar.gz](https://root.cern/download/root_v5.26.00.Linux-slc5_amd64-gcc3.4.tar.gz) |  56M |
+| Linux slc5_amd64 gcc4.3 | [root_v5.26.00.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern/download/root_v5.26.00.Linux-slc5_amd64-gcc4.3.tar.gz) |  55M |
+| macosx powerpc gcc 4.0 | [root_v5.26.00.macosx-powerpc-gcc-4.0.tar.gz](https://root.cern/download/root_v5.26.00.macosx-powerpc-gcc-4.0.tar.gz) |  51M |
+| macosx105 i386 gcc 4.0 | [root_v5.26.00.macosx105-i386-gcc-4.0.tar.gz](https://root.cern/download/root_v5.26.00.macosx105-i386-gcc-4.0.tar.gz) |  40M |
+| solarisCC5 5.11 i386 | [root_v5.26.00.solarisCC5-5.11-i386.tar.gz](https://root.cern/download/root_v5.26.00.solarisCC5-5.11-i386.tar.gz) |  72M |
+| win32 (dbg) | [root_v5.26.00.win32.debug.tar.gz](https://root.cern/download/root_v5.26.00.win32.debug.tar.gz) |  97M |
+| win32 | [root_v5.26.00.win32.tar.gz](https://root.cern/download/root_v5.26.00.win32.tar.gz) |  51M |
+| Windows Visual Studio 90 (dbg) | [root_v5.26.00.win32.vc90.debug.tar.gz](https://root.cern/download/root_v5.26.00.win32.vc90.debug.tar.gz) | 127M |
+| Windows Visual Studio 90 | [root_v5.26.00.win32.vc90.tar.gz](https://root.cern/download/root_v5.26.00.win32.vc90.tar.gz) |  52M |
+| win32gcc gcc 3.4 | [root_v5.26.00.win32gcc-gcc-3.4.tar.gz](https://root.cern/download/root_v5.26.00.win32gcc-gcc-3.4.tar.gz) |  53M |
+| root_v5.26.00b.Linux slc4 gcc3.4 | [root_v5.26.00b.Linux-slc4-gcc3.4.tar.gz](https://root.cern/download/root_v5.26.00b.Linux-slc4-gcc3.4.tar.gz) |  54M |
+| root_v5.26.00b.Linux slc4 gcc4.3 | [root_v5.26.00b.Linux-slc4-gcc4.3.tar.gz](https://root.cern/download/root_v5.26.00b.Linux-slc4-gcc4.3.tar.gz) |  54M |
+| root_v5.26.00b.Linux slc4_amd64 gcc3.4 | [root_v5.26.00b.Linux-slc4_amd64-gcc3.4.tar.gz](https://root.cern/download/root_v5.26.00b.Linux-slc4_amd64-gcc3.4.tar.gz) |  56M |
+| root_v5.26.00b.Linux slc4_amd64 gcc4.3 | [root_v5.26.00b.Linux-slc4_amd64-gcc4.3.tar.gz](https://root.cern/download/root_v5.26.00b.Linux-slc4_amd64-gcc4.3.tar.gz) |  55M |
+| root_v5.26.00b.Linux slc5 gcc3.4 | [root_v5.26.00b.Linux-slc5-gcc3.4.tar.gz](https://root.cern/download/root_v5.26.00b.Linux-slc5-gcc3.4.tar.gz) |  55M |
+| root_v5.26.00b.Linux slc5 gcc4.3 | [root_v5.26.00b.Linux-slc5-gcc4.3.tar.gz](https://root.cern/download/root_v5.26.00b.Linux-slc5-gcc4.3.tar.gz) |  54M |
+| root_v5.26.00b.Linux slc5_amd64 gcc3.4 | [root_v5.26.00b.Linux-slc5_amd64-gcc3.4.tar.gz](https://root.cern/download/root_v5.26.00b.Linux-slc5_amd64-gcc3.4.tar.gz) |  56M |
+| root_v5.26.00b.Linux slc5_amd64 gcc4.3 | [root_v5.26.00b.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern/download/root_v5.26.00b.Linux-slc5_amd64-gcc4.3.tar.gz) |  55M |
+| root_v5.26.00b.macosx powerpc gcc 4.0 | [root_v5.26.00b.macosx-powerpc-gcc-4.0.tar.gz](https://root.cern/download/root_v5.26.00b.macosx-powerpc-gcc-4.0.tar.gz) |  51M |
+| root_v5.26.00b.macosx105 i386 gcc 4.0 | [root_v5.26.00b.macosx105-i386-gcc-4.0.tar.gz](https://root.cern/download/root_v5.26.00b.macosx105-i386-gcc-4.0.tar.gz) |  40M |
+| root_v5.26.00b.win32 (dbg) | [root_v5.26.00b.win32.debug.tar.gz](https://root.cern/download/root_v5.26.00b.win32.debug.tar.gz) |  97M |
+| root_v5.26.00b.win32 | [root_v5.26.00b.win32.tar.gz](https://root.cern/download/root_v5.26.00b.win32.tar.gz) |  51M |
+| root_v5.26.00b.Windows Visual Studio 90 (dbg) | [root_v5.26.00b.win32.vc90.debug.tar.gz](https://root.cern/download/root_v5.26.00b.win32.vc90.debug.tar.gz) | 127M |
+| root_v5.26.00b.Windows Visual Studio 90 | [root_v5.26.00b.win32.vc90.tar.gz](https://root.cern/download/root_v5.26.00b.win32.vc90.tar.gz) |  52M |
+| root_v5.26.00c.Linux slc4 gcc3.4 | [root_v5.26.00c.Linux-slc4-gcc3.4.tar.gz](https://root.cern/download/root_v5.26.00c.Linux-slc4-gcc3.4.tar.gz) |  54M |
+| root_v5.26.00c.Linux slc4_amd64 gcc3.4 | [root_v5.26.00c.Linux-slc4_amd64-gcc3.4.tar.gz](https://root.cern/download/root_v5.26.00c.Linux-slc4_amd64-gcc3.4.tar.gz) |  56M |
+| root_v5.26.00c.Linux slc5 gcc4.3 | [root_v5.26.00c.Linux-slc5-gcc4.3.tar.gz](https://root.cern/download/root_v5.26.00c.Linux-slc5-gcc4.3.tar.gz) |  54M |
+| root_v5.26.00c.Linux slc5_amd64 gcc4.3 | [root_v5.26.00c.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern/download/root_v5.26.00c.Linux-slc5_amd64-gcc4.3.tar.gz) |  55M |
+| root_v5.26.00c.macosx104 powerpc gcc 4.0 | [root_v5.26.00c.macosx104-powerpc-gcc-4.0.tar.gz](https://root.cern/download/root_v5.26.00c.macosx104-powerpc-gcc-4.0.tar.gz) |  42M |
+| root_v5.26.00c.macosx105 i386 gcc 4.0 | [root_v5.26.00c.macosx105-i386-gcc-4.0.tar.gz](https://root.cern/download/root_v5.26.00c.macosx105-i386-gcc-4.0.tar.gz) |  40M |
+| root_v5.26.00c.macosx106 i386 gcc 4.2 | [root_v5.26.00c.macosx106-i386-gcc-4.2.tar.gz](https://root.cern/download/root_v5.26.00c.macosx106-i386-gcc-4.2.tar.gz) |  43M |
+| root_v5.26.00c.macosx106 gcc 4.2 | [root_v5.26.00c.macosx106-x86_64-gcc-4.2.tar.gz](https://root.cern/download/root_v5.26.00c.macosx106-x86_64-gcc-4.2.tar.gz) |  43M |
+| root_v5.26.00c.win32 (dbg) | [root_v5.26.00c.win32.debug.tar.gz](https://root.cern/download/root_v5.26.00c.win32.debug.tar.gz) |  97M |
+| root_v5.26.00c.win32 | [root_v5.26.00c.win32.tar.gz](https://root.cern/download/root_v5.26.00c.win32.tar.gz) |  51M |
+| root_v5.26.00c.Windows Visual Studio 90 (dbg) | [root_v5.26.00c.win32.vc90.debug.tar.gz](https://root.cern/download/root_v5.26.00c.win32.vc90.debug.tar.gz) | 127M |
+| root_v5.26.00c.Windows Visual Studio 90 | [root_v5.26.00c.win32.vc90.tar.gz](https://root.cern/download/root_v5.26.00c.win32.vc90.tar.gz) |  53M |
 
 
 
@@ -118,7 +118,7 @@ To use ROOT directly from AFS:
 The entire ROOT source can be obtained from our public Git repository:
 
 ~~~
-git clone http://root.cern.ch/git/root.git
+git clone http://root.cern/git/root.git
 ~~~
 The release specific tag can be obtained using:
 ~~~

--- a/_releases/release-52600a.md
+++ b/_releases/release-52600a.md
@@ -15,7 +15,7 @@ sidebar:
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v5.26.00a.source.tar.gz](https://root.cern.ch/download/root_v5.26.00a.source.tar.gz) |  27M |
+| source | [root_v5.26.00a.source.tar.gz](https://root.cern/download/root_v5.26.00a.source.tar.gz) |  27M |
 
 
 
@@ -61,7 +61,7 @@ To use ROOT directly from AFS:
 The entire ROOT source can be obtained from our public Git repository:
 
 ~~~
-git clone http://root.cern.ch/git/root.git
+git clone http://root.cern/git/root.git
 ~~~
 The release specific tag can be obtained using:
 ~~~

--- a/_releases/release-52600b.md
+++ b/_releases/release-52600b.md
@@ -15,28 +15,28 @@ sidebar:
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| old_source | [old_root_v5.26.00b.source.tar.gz](https://root.cern.ch/download/old_root_v5.26.00b.source.tar.gz) |  28M |
-| source | [root_v5.26.00b.source.tar.gz](https://root.cern.ch/download/root_v5.26.00b.source.tar.gz) |  28M |
+| old_source | [old_root_v5.26.00b.source.tar.gz](https://root.cern/download/old_root_v5.26.00b.source.tar.gz) |  28M |
+| source | [root_v5.26.00b.source.tar.gz](https://root.cern/download/root_v5.26.00b.source.tar.gz) |  28M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| Linux slc4 gcc3.4 | [root_v5.26.00b.Linux-slc4-gcc3.4.tar.gz](https://root.cern.ch/download/root_v5.26.00b.Linux-slc4-gcc3.4.tar.gz) |  54M |
-| Linux slc4 gcc4.3 | [root_v5.26.00b.Linux-slc4-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.26.00b.Linux-slc4-gcc4.3.tar.gz) |  54M |
-| Linux slc4_amd64 gcc3.4 | [root_v5.26.00b.Linux-slc4_amd64-gcc3.4.tar.gz](https://root.cern.ch/download/root_v5.26.00b.Linux-slc4_amd64-gcc3.4.tar.gz) |  56M |
-| Linux slc4_amd64 gcc4.3 | [root_v5.26.00b.Linux-slc4_amd64-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.26.00b.Linux-slc4_amd64-gcc4.3.tar.gz) |  55M |
-| Linux slc5 gcc3.4 | [root_v5.26.00b.Linux-slc5-gcc3.4.tar.gz](https://root.cern.ch/download/root_v5.26.00b.Linux-slc5-gcc3.4.tar.gz) |  55M |
-| Linux slc5 gcc4.3 | [root_v5.26.00b.Linux-slc5-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.26.00b.Linux-slc5-gcc4.3.tar.gz) |  54M |
-| Linux slc5_amd64 gcc3.4 | [root_v5.26.00b.Linux-slc5_amd64-gcc3.4.tar.gz](https://root.cern.ch/download/root_v5.26.00b.Linux-slc5_amd64-gcc3.4.tar.gz) |  56M |
-| Linux slc5_amd64 gcc4.3 | [root_v5.26.00b.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.26.00b.Linux-slc5_amd64-gcc4.3.tar.gz) |  55M |
-| macosx powerpc gcc 4.0 | [root_v5.26.00b.macosx-powerpc-gcc-4.0.tar.gz](https://root.cern.ch/download/root_v5.26.00b.macosx-powerpc-gcc-4.0.tar.gz) |  51M |
-| macosx105 i386 gcc 4.0 | [root_v5.26.00b.macosx105-i386-gcc-4.0.tar.gz](https://root.cern.ch/download/root_v5.26.00b.macosx105-i386-gcc-4.0.tar.gz) |  40M |
-| win32 (dbg) | [root_v5.26.00b.win32.debug.tar.gz](https://root.cern.ch/download/root_v5.26.00b.win32.debug.tar.gz) |  97M |
-| win32 | [root_v5.26.00b.win32.tar.gz](https://root.cern.ch/download/root_v5.26.00b.win32.tar.gz) |  51M |
-| Windows Visual Studio 90 (dbg) | [root_v5.26.00b.win32.vc90.debug.tar.gz](https://root.cern.ch/download/root_v5.26.00b.win32.vc90.debug.tar.gz) | 127M |
-| Windows Visual Studio 90 | [root_v5.26.00b.win32.vc90.tar.gz](https://root.cern.ch/download/root_v5.26.00b.win32.vc90.tar.gz) |  52M |
+| Linux slc4 gcc3.4 | [root_v5.26.00b.Linux-slc4-gcc3.4.tar.gz](https://root.cern/download/root_v5.26.00b.Linux-slc4-gcc3.4.tar.gz) |  54M |
+| Linux slc4 gcc4.3 | [root_v5.26.00b.Linux-slc4-gcc4.3.tar.gz](https://root.cern/download/root_v5.26.00b.Linux-slc4-gcc4.3.tar.gz) |  54M |
+| Linux slc4_amd64 gcc3.4 | [root_v5.26.00b.Linux-slc4_amd64-gcc3.4.tar.gz](https://root.cern/download/root_v5.26.00b.Linux-slc4_amd64-gcc3.4.tar.gz) |  56M |
+| Linux slc4_amd64 gcc4.3 | [root_v5.26.00b.Linux-slc4_amd64-gcc4.3.tar.gz](https://root.cern/download/root_v5.26.00b.Linux-slc4_amd64-gcc4.3.tar.gz) |  55M |
+| Linux slc5 gcc3.4 | [root_v5.26.00b.Linux-slc5-gcc3.4.tar.gz](https://root.cern/download/root_v5.26.00b.Linux-slc5-gcc3.4.tar.gz) |  55M |
+| Linux slc5 gcc4.3 | [root_v5.26.00b.Linux-slc5-gcc4.3.tar.gz](https://root.cern/download/root_v5.26.00b.Linux-slc5-gcc4.3.tar.gz) |  54M |
+| Linux slc5_amd64 gcc3.4 | [root_v5.26.00b.Linux-slc5_amd64-gcc3.4.tar.gz](https://root.cern/download/root_v5.26.00b.Linux-slc5_amd64-gcc3.4.tar.gz) |  56M |
+| Linux slc5_amd64 gcc4.3 | [root_v5.26.00b.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern/download/root_v5.26.00b.Linux-slc5_amd64-gcc4.3.tar.gz) |  55M |
+| macosx powerpc gcc 4.0 | [root_v5.26.00b.macosx-powerpc-gcc-4.0.tar.gz](https://root.cern/download/root_v5.26.00b.macosx-powerpc-gcc-4.0.tar.gz) |  51M |
+| macosx105 i386 gcc 4.0 | [root_v5.26.00b.macosx105-i386-gcc-4.0.tar.gz](https://root.cern/download/root_v5.26.00b.macosx105-i386-gcc-4.0.tar.gz) |  40M |
+| win32 (dbg) | [root_v5.26.00b.win32.debug.tar.gz](https://root.cern/download/root_v5.26.00b.win32.debug.tar.gz) |  97M |
+| win32 | [root_v5.26.00b.win32.tar.gz](https://root.cern/download/root_v5.26.00b.win32.tar.gz) |  51M |
+| Windows Visual Studio 90 (dbg) | [root_v5.26.00b.win32.vc90.debug.tar.gz](https://root.cern/download/root_v5.26.00b.win32.vc90.debug.tar.gz) | 127M |
+| Windows Visual Studio 90 | [root_v5.26.00b.win32.vc90.tar.gz](https://root.cern/download/root_v5.26.00b.win32.vc90.tar.gz) |  52M |
 
 
 
@@ -78,7 +78,7 @@ To use ROOT directly from AFS:
 The entire ROOT source can be obtained from our public Git repository:
 
 ~~~
-git clone http://root.cern.ch/git/root.git
+git clone http://root.cern/git/root.git
 ~~~
 The release specific tag can be obtained using:
 ~~~

--- a/_releases/release-52600c.md
+++ b/_releases/release-52600c.md
@@ -15,25 +15,25 @@ sidebar:
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v5.26.00c.source.tar.gz](https://root.cern.ch/download/root_v5.26.00c.source.tar.gz) |  28M |
+| source | [root_v5.26.00c.source.tar.gz](https://root.cern/download/root_v5.26.00c.source.tar.gz) |  28M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| Linux slc4 gcc3.4 | [root_v5.26.00c.Linux-slc4-gcc3.4.tar.gz](https://root.cern.ch/download/root_v5.26.00c.Linux-slc4-gcc3.4.tar.gz) |  54M |
-| Linux slc4_amd64 gcc3.4 | [root_v5.26.00c.Linux-slc4_amd64-gcc3.4.tar.gz](https://root.cern.ch/download/root_v5.26.00c.Linux-slc4_amd64-gcc3.4.tar.gz) |  56M |
-| Linux slc5 gcc4.3 | [root_v5.26.00c.Linux-slc5-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.26.00c.Linux-slc5-gcc4.3.tar.gz) |  54M |
-| Linux slc5_amd64 gcc4.3 | [root_v5.26.00c.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.26.00c.Linux-slc5_amd64-gcc4.3.tar.gz) |  55M |
-| macosx104 powerpc gcc 4.0 | [root_v5.26.00c.macosx104-powerpc-gcc-4.0.tar.gz](https://root.cern.ch/download/root_v5.26.00c.macosx104-powerpc-gcc-4.0.tar.gz) |  42M |
-| macosx105 i386 gcc 4.0 | [root_v5.26.00c.macosx105-i386-gcc-4.0.tar.gz](https://root.cern.ch/download/root_v5.26.00c.macosx105-i386-gcc-4.0.tar.gz) |  40M |
-| macosx106 i386 gcc 4.2 | [root_v5.26.00c.macosx106-i386-gcc-4.2.tar.gz](https://root.cern.ch/download/root_v5.26.00c.macosx106-i386-gcc-4.2.tar.gz) |  43M |
-| macosx106 gcc 4.2 | [root_v5.26.00c.macosx106-x86_64-gcc-4.2.tar.gz](https://root.cern.ch/download/root_v5.26.00c.macosx106-x86_64-gcc-4.2.tar.gz) |  43M |
-| win32 (dbg) | [root_v5.26.00c.win32.debug.tar.gz](https://root.cern.ch/download/root_v5.26.00c.win32.debug.tar.gz) |  97M |
-| win32 | [root_v5.26.00c.win32.tar.gz](https://root.cern.ch/download/root_v5.26.00c.win32.tar.gz) |  51M |
-| Windows Visual Studio 90 (dbg) | [root_v5.26.00c.win32.vc90.debug.tar.gz](https://root.cern.ch/download/root_v5.26.00c.win32.vc90.debug.tar.gz) | 127M |
-| Windows Visual Studio 90 | [root_v5.26.00c.win32.vc90.tar.gz](https://root.cern.ch/download/root_v5.26.00c.win32.vc90.tar.gz) |  53M |
+| Linux slc4 gcc3.4 | [root_v5.26.00c.Linux-slc4-gcc3.4.tar.gz](https://root.cern/download/root_v5.26.00c.Linux-slc4-gcc3.4.tar.gz) |  54M |
+| Linux slc4_amd64 gcc3.4 | [root_v5.26.00c.Linux-slc4_amd64-gcc3.4.tar.gz](https://root.cern/download/root_v5.26.00c.Linux-slc4_amd64-gcc3.4.tar.gz) |  56M |
+| Linux slc5 gcc4.3 | [root_v5.26.00c.Linux-slc5-gcc4.3.tar.gz](https://root.cern/download/root_v5.26.00c.Linux-slc5-gcc4.3.tar.gz) |  54M |
+| Linux slc5_amd64 gcc4.3 | [root_v5.26.00c.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern/download/root_v5.26.00c.Linux-slc5_amd64-gcc4.3.tar.gz) |  55M |
+| macosx104 powerpc gcc 4.0 | [root_v5.26.00c.macosx104-powerpc-gcc-4.0.tar.gz](https://root.cern/download/root_v5.26.00c.macosx104-powerpc-gcc-4.0.tar.gz) |  42M |
+| macosx105 i386 gcc 4.0 | [root_v5.26.00c.macosx105-i386-gcc-4.0.tar.gz](https://root.cern/download/root_v5.26.00c.macosx105-i386-gcc-4.0.tar.gz) |  40M |
+| macosx106 i386 gcc 4.2 | [root_v5.26.00c.macosx106-i386-gcc-4.2.tar.gz](https://root.cern/download/root_v5.26.00c.macosx106-i386-gcc-4.2.tar.gz) |  43M |
+| macosx106 gcc 4.2 | [root_v5.26.00c.macosx106-x86_64-gcc-4.2.tar.gz](https://root.cern/download/root_v5.26.00c.macosx106-x86_64-gcc-4.2.tar.gz) |  43M |
+| win32 (dbg) | [root_v5.26.00c.win32.debug.tar.gz](https://root.cern/download/root_v5.26.00c.win32.debug.tar.gz) |  97M |
+| win32 | [root_v5.26.00c.win32.tar.gz](https://root.cern/download/root_v5.26.00c.win32.tar.gz) |  51M |
+| Windows Visual Studio 90 (dbg) | [root_v5.26.00c.win32.vc90.debug.tar.gz](https://root.cern/download/root_v5.26.00c.win32.vc90.debug.tar.gz) | 127M |
+| Windows Visual Studio 90 | [root_v5.26.00c.win32.vc90.tar.gz](https://root.cern/download/root_v5.26.00c.win32.vc90.tar.gz) |  53M |
 
 
 ## Git

--- a/_releases/release-52702.md
+++ b/_releases/release-52702.md
@@ -15,31 +15,31 @@ sidebar:
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v5.27.02.source.tar.gz](https://root.cern.ch/download/root_v5.27.02.source.tar.gz) |  27M |
+| source | [root_v5.27.02.source.tar.gz](https://root.cern/download/root_v5.27.02.source.tar.gz) |  27M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| Linux slc4 gcc3.4 | [root_v5.27.02.Linux-slc4-gcc3.4.tar.gz](https://root.cern.ch/download/root_v5.27.02.Linux-slc4-gcc3.4.tar.gz) |  54M |
-| Linux slc4 gcc4.3 | [root_v5.27.02.Linux-slc4-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.27.02.Linux-slc4-gcc4.3.tar.gz) |  54M |
-| Linux slc4_amd64 gcc3.4 | [root_v5.27.02.Linux-slc4_amd64-gcc3.4.tar.gz](https://root.cern.ch/download/root_v5.27.02.Linux-slc4_amd64-gcc3.4.tar.gz) |  56M |
-| Linux slc4_amd64 gcc4.3 | [root_v5.27.02.Linux-slc4_amd64-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.27.02.Linux-slc4_amd64-gcc4.3.tar.gz) |  55M |
-| Linux slc5 gcc3.4 | [root_v5.27.02.Linux-slc5-gcc3.4.tar.gz](https://root.cern.ch/download/root_v5.27.02.Linux-slc5-gcc3.4.tar.gz) |  55M |
-| Linux slc5 gcc4.3 | [root_v5.27.02.Linux-slc5-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.27.02.Linux-slc5-gcc4.3.tar.gz) |  54M |
-| Linux slc5_amd64 gcc3.4 | [root_v5.27.02.Linux-slc5_amd64-gcc3.4.tar.gz](https://root.cern.ch/download/root_v5.27.02.Linux-slc5_amd64-gcc3.4.tar.gz) |  56M |
-| Linux slc5_amd64 gcc4.3 | [root_v5.27.02.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.27.02.Linux-slc5_amd64-gcc4.3.tar.gz) |  55M |
-| macosx powerpc gcc 4.0 | [root_v5.27.02.macosx-powerpc-gcc-4.0.tar.gz](https://root.cern.ch/download/root_v5.27.02.macosx-powerpc-gcc-4.0.tar.gz) |  43M |
-| macosx105 i386 gcc 4.0 | [root_v5.27.02.macosx105-i386-gcc-4.0.tar.gz](https://root.cern.ch/download/root_v5.27.02.macosx105-i386-gcc-4.0.tar.gz) |  41M |
-| macosx106 i386 gcc 4.2 | [root_v5.27.02.macosx106-i386-gcc-4.2.tar.gz](https://root.cern.ch/download/root_v5.27.02.macosx106-i386-gcc-4.2.tar.gz) |  43M |
-| macosx106 gcc 4.2 | [root_v5.27.02.macosx106-x86_64-gcc-4.2.tar.gz](https://root.cern.ch/download/root_v5.27.02.macosx106-x86_64-gcc-4.2.tar.gz) |  43M |
-| solarisCC5 5.11 i386 | [root_v5.27.02.solarisCC5-5.11-i386.tar.gz](https://root.cern.ch/download/root_v5.27.02.solarisCC5-5.11-i386.tar.gz) |  53M |
-| win32 (dbg) | [root_v5.27.02.win32.debug.tar.gz](https://root.cern.ch/download/root_v5.27.02.win32.debug.tar.gz) |  97M |
-| win32 | [root_v5.27.02.win32.tar.gz](https://root.cern.ch/download/root_v5.27.02.win32.tar.gz) |  51M |
-| Windows Visual Studio 90 (dbg) | [root_v5.27.02.win32.vc90.debug.tar.gz](https://root.cern.ch/download/root_v5.27.02.win32.vc90.debug.tar.gz) | 128M |
-| Windows Visual Studio 90 | [root_v5.27.02.win32.vc90.tar.gz](https://root.cern.ch/download/root_v5.27.02.win32.vc90.tar.gz) |  52M |
-| win32gcc gcc 3.4 | [root_v5.27.02.win32gcc-gcc-3.4.tar.gz](https://root.cern.ch/download/root_v5.27.02.win32gcc-gcc-3.4.tar.gz) |  53M |
+| Linux slc4 gcc3.4 | [root_v5.27.02.Linux-slc4-gcc3.4.tar.gz](https://root.cern/download/root_v5.27.02.Linux-slc4-gcc3.4.tar.gz) |  54M |
+| Linux slc4 gcc4.3 | [root_v5.27.02.Linux-slc4-gcc4.3.tar.gz](https://root.cern/download/root_v5.27.02.Linux-slc4-gcc4.3.tar.gz) |  54M |
+| Linux slc4_amd64 gcc3.4 | [root_v5.27.02.Linux-slc4_amd64-gcc3.4.tar.gz](https://root.cern/download/root_v5.27.02.Linux-slc4_amd64-gcc3.4.tar.gz) |  56M |
+| Linux slc4_amd64 gcc4.3 | [root_v5.27.02.Linux-slc4_amd64-gcc4.3.tar.gz](https://root.cern/download/root_v5.27.02.Linux-slc4_amd64-gcc4.3.tar.gz) |  55M |
+| Linux slc5 gcc3.4 | [root_v5.27.02.Linux-slc5-gcc3.4.tar.gz](https://root.cern/download/root_v5.27.02.Linux-slc5-gcc3.4.tar.gz) |  55M |
+| Linux slc5 gcc4.3 | [root_v5.27.02.Linux-slc5-gcc4.3.tar.gz](https://root.cern/download/root_v5.27.02.Linux-slc5-gcc4.3.tar.gz) |  54M |
+| Linux slc5_amd64 gcc3.4 | [root_v5.27.02.Linux-slc5_amd64-gcc3.4.tar.gz](https://root.cern/download/root_v5.27.02.Linux-slc5_amd64-gcc3.4.tar.gz) |  56M |
+| Linux slc5_amd64 gcc4.3 | [root_v5.27.02.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern/download/root_v5.27.02.Linux-slc5_amd64-gcc4.3.tar.gz) |  55M |
+| macosx powerpc gcc 4.0 | [root_v5.27.02.macosx-powerpc-gcc-4.0.tar.gz](https://root.cern/download/root_v5.27.02.macosx-powerpc-gcc-4.0.tar.gz) |  43M |
+| macosx105 i386 gcc 4.0 | [root_v5.27.02.macosx105-i386-gcc-4.0.tar.gz](https://root.cern/download/root_v5.27.02.macosx105-i386-gcc-4.0.tar.gz) |  41M |
+| macosx106 i386 gcc 4.2 | [root_v5.27.02.macosx106-i386-gcc-4.2.tar.gz](https://root.cern/download/root_v5.27.02.macosx106-i386-gcc-4.2.tar.gz) |  43M |
+| macosx106 gcc 4.2 | [root_v5.27.02.macosx106-x86_64-gcc-4.2.tar.gz](https://root.cern/download/root_v5.27.02.macosx106-x86_64-gcc-4.2.tar.gz) |  43M |
+| solarisCC5 5.11 i386 | [root_v5.27.02.solarisCC5-5.11-i386.tar.gz](https://root.cern/download/root_v5.27.02.solarisCC5-5.11-i386.tar.gz) |  53M |
+| win32 (dbg) | [root_v5.27.02.win32.debug.tar.gz](https://root.cern/download/root_v5.27.02.win32.debug.tar.gz) |  97M |
+| win32 | [root_v5.27.02.win32.tar.gz](https://root.cern/download/root_v5.27.02.win32.tar.gz) |  51M |
+| Windows Visual Studio 90 (dbg) | [root_v5.27.02.win32.vc90.debug.tar.gz](https://root.cern/download/root_v5.27.02.win32.vc90.debug.tar.gz) | 128M |
+| Windows Visual Studio 90 | [root_v5.27.02.win32.vc90.tar.gz](https://root.cern/download/root_v5.27.02.win32.vc90.tar.gz) |  52M |
+| win32gcc gcc 3.4 | [root_v5.27.02.win32gcc-gcc-3.4.tar.gz](https://root.cern/download/root_v5.27.02.win32gcc-gcc-3.4.tar.gz) |  53M |
 
 
 
@@ -78,7 +78,7 @@ To use ROOT directly from AFS:
 The entire ROOT source can be obtained from our public Git repository:
 
 ~~~
-git clone http://root.cern.ch/git/root.git
+git clone http://root.cern/git/root.git
 ~~~
 The release specific tag can be obtained using:
 ~~~

--- a/_releases/release-52704.md
+++ b/_releases/release-52704.md
@@ -15,30 +15,30 @@ sidebar:
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v5.27.04.source.tar.gz](https://root.cern.ch/download/root_v5.27.04.source.tar.gz) |  27M |
+| source | [root_v5.27.04.source.tar.gz](https://root.cern/download/root_v5.27.04.source.tar.gz) |  27M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| Linux slc4 gcc3.4 | [root_v5.27.04.Linux-slc4-gcc3.4.tar.gz](https://root.cern.ch/download/root_v5.27.04.Linux-slc4-gcc3.4.tar.gz) |  54M |
-| Linux slc4 gcc4.3 | [root_v5.27.04.Linux-slc4-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.27.04.Linux-slc4-gcc4.3.tar.gz) |  54M |
-| Linux slc4_amd64 gcc3.4 | [root_v5.27.04.Linux-slc4_amd64-gcc3.4.tar.gz](https://root.cern.ch/download/root_v5.27.04.Linux-slc4_amd64-gcc3.4.tar.gz) |  55M |
-| Linux slc4_amd64 gcc4.3 | [root_v5.27.04.Linux-slc4_amd64-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.27.04.Linux-slc4_amd64-gcc4.3.tar.gz) |  54M |
-| Linux slc5 gcc3.4 | [root_v5.27.04.Linux-slc5-gcc3.4.tar.gz](https://root.cern.ch/download/root_v5.27.04.Linux-slc5-gcc3.4.tar.gz) |  54M |
-| Linux slc5 gcc4.3 | [root_v5.27.04.Linux-slc5-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.27.04.Linux-slc5-gcc4.3.tar.gz) |  53M |
-| Linux slc5_amd64 gcc3.4 | [root_v5.27.04.Linux-slc5_amd64-gcc3.4.tar.gz](https://root.cern.ch/download/root_v5.27.04.Linux-slc5_amd64-gcc3.4.tar.gz) |  56M |
-| Linux slc5_amd64 gcc4.3 | [root_v5.27.04.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.27.04.Linux-slc5_amd64-gcc4.3.tar.gz) |  55M |
-| macosx powerpc gcc 4.0 | [root_v5.27.04.macosx-powerpc-gcc-4.0.tar.gz](https://root.cern.ch/download/root_v5.27.04.macosx-powerpc-gcc-4.0.tar.gz) |  43M |
-| macosx105 i386 gcc 4.0 | [root_v5.27.04.macosx105-i386-gcc-4.0.tar.gz](https://root.cern.ch/download/root_v5.27.04.macosx105-i386-gcc-4.0.tar.gz) |  41M |
-| macosx106 i386 gcc 4.2 | [root_v5.27.04.macosx106-i386-gcc-4.2.tar.gz](https://root.cern.ch/download/root_v5.27.04.macosx106-i386-gcc-4.2.tar.gz) |  43M |
-| macosx106 gcc 4.2 | [root_v5.27.04.macosx106-x86_64-gcc-4.2.tar.gz](https://root.cern.ch/download/root_v5.27.04.macosx106-x86_64-gcc-4.2.tar.gz) |  43M |
-| win32 (dbg) | [root_v5.27.04.win32.debug.tar.gz](https://root.cern.ch/download/root_v5.27.04.win32.debug.tar.gz) |  97M |
-| win32 | [root_v5.27.04.win32.tar.gz](https://root.cern.ch/download/root_v5.27.04.win32.tar.gz) |  51M |
-| Windows Visual Studio 90 (dbg) | [root_v5.27.04.win32.vc90.debug.tar.gz](https://root.cern.ch/download/root_v5.27.04.win32.vc90.debug.tar.gz) | 128M |
-| Windows Visual Studio 90 | [root_v5.27.04.win32.vc90.tar.gz](https://root.cern.ch/download/root_v5.27.04.win32.vc90.tar.gz) |  52M |
-| win32gcc gcc 4.3 | [root_v5.27.04.win32gcc-gcc-4.3.tar.gz](https://root.cern.ch/download/root_v5.27.04.win32gcc-gcc-4.3.tar.gz) |  41M |
+| Linux slc4 gcc3.4 | [root_v5.27.04.Linux-slc4-gcc3.4.tar.gz](https://root.cern/download/root_v5.27.04.Linux-slc4-gcc3.4.tar.gz) |  54M |
+| Linux slc4 gcc4.3 | [root_v5.27.04.Linux-slc4-gcc4.3.tar.gz](https://root.cern/download/root_v5.27.04.Linux-slc4-gcc4.3.tar.gz) |  54M |
+| Linux slc4_amd64 gcc3.4 | [root_v5.27.04.Linux-slc4_amd64-gcc3.4.tar.gz](https://root.cern/download/root_v5.27.04.Linux-slc4_amd64-gcc3.4.tar.gz) |  55M |
+| Linux slc4_amd64 gcc4.3 | [root_v5.27.04.Linux-slc4_amd64-gcc4.3.tar.gz](https://root.cern/download/root_v5.27.04.Linux-slc4_amd64-gcc4.3.tar.gz) |  54M |
+| Linux slc5 gcc3.4 | [root_v5.27.04.Linux-slc5-gcc3.4.tar.gz](https://root.cern/download/root_v5.27.04.Linux-slc5-gcc3.4.tar.gz) |  54M |
+| Linux slc5 gcc4.3 | [root_v5.27.04.Linux-slc5-gcc4.3.tar.gz](https://root.cern/download/root_v5.27.04.Linux-slc5-gcc4.3.tar.gz) |  53M |
+| Linux slc5_amd64 gcc3.4 | [root_v5.27.04.Linux-slc5_amd64-gcc3.4.tar.gz](https://root.cern/download/root_v5.27.04.Linux-slc5_amd64-gcc3.4.tar.gz) |  56M |
+| Linux slc5_amd64 gcc4.3 | [root_v5.27.04.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern/download/root_v5.27.04.Linux-slc5_amd64-gcc4.3.tar.gz) |  55M |
+| macosx powerpc gcc 4.0 | [root_v5.27.04.macosx-powerpc-gcc-4.0.tar.gz](https://root.cern/download/root_v5.27.04.macosx-powerpc-gcc-4.0.tar.gz) |  43M |
+| macosx105 i386 gcc 4.0 | [root_v5.27.04.macosx105-i386-gcc-4.0.tar.gz](https://root.cern/download/root_v5.27.04.macosx105-i386-gcc-4.0.tar.gz) |  41M |
+| macosx106 i386 gcc 4.2 | [root_v5.27.04.macosx106-i386-gcc-4.2.tar.gz](https://root.cern/download/root_v5.27.04.macosx106-i386-gcc-4.2.tar.gz) |  43M |
+| macosx106 gcc 4.2 | [root_v5.27.04.macosx106-x86_64-gcc-4.2.tar.gz](https://root.cern/download/root_v5.27.04.macosx106-x86_64-gcc-4.2.tar.gz) |  43M |
+| win32 (dbg) | [root_v5.27.04.win32.debug.tar.gz](https://root.cern/download/root_v5.27.04.win32.debug.tar.gz) |  97M |
+| win32 | [root_v5.27.04.win32.tar.gz](https://root.cern/download/root_v5.27.04.win32.tar.gz) |  51M |
+| Windows Visual Studio 90 (dbg) | [root_v5.27.04.win32.vc90.debug.tar.gz](https://root.cern/download/root_v5.27.04.win32.vc90.debug.tar.gz) | 128M |
+| Windows Visual Studio 90 | [root_v5.27.04.win32.vc90.tar.gz](https://root.cern/download/root_v5.27.04.win32.vc90.tar.gz) |  52M |
+| win32gcc gcc 4.3 | [root_v5.27.04.win32gcc-gcc-4.3.tar.gz](https://root.cern/download/root_v5.27.04.win32gcc-gcc-4.3.tar.gz) |  41M |
 
 
 
@@ -77,7 +77,7 @@ To use ROOT directly from AFS:
 The entire ROOT source can be obtained from our public Git repository:
 
 ~~~
-git clone http://root.cern.ch/git/root.git
+git clone http://root.cern/git/root.git
 ~~~
 The release specific tag can be obtained using:
 ~~~

--- a/_releases/release-52706.md
+++ b/_releases/release-52706.md
@@ -15,30 +15,30 @@ sidebar:
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v5.27.06.source.tar.gz](https://root.cern.ch/download/root_v5.27.06.source.tar.gz) |  28M |
-| root_v5.27.06a.source | [root_v5.27.06a.source.tar.gz](https://root.cern.ch/download/root_v5.27.06a.source.tar.gz) |  28M |
-| root_v5.27.06b.source | [root_v5.27.06b.source.tar.gz](https://root.cern.ch/download/root_v5.27.06b.source.tar.gz) |  28M |
-| root_v5.27.06c.source | [root_v5.27.06c.source.tar.gz](https://root.cern.ch/download/root_v5.27.06c.source.tar.gz) |  28M |
-| root_v5.27.06d.source | [root_v5.27.06d.source.tar.gz](https://root.cern.ch/download/root_v5.27.06d.source.tar.gz) |  28M |
+| source | [root_v5.27.06.source.tar.gz](https://root.cern/download/root_v5.27.06.source.tar.gz) |  28M |
+| root_v5.27.06a.source | [root_v5.27.06a.source.tar.gz](https://root.cern/download/root_v5.27.06a.source.tar.gz) |  28M |
+| root_v5.27.06b.source | [root_v5.27.06b.source.tar.gz](https://root.cern/download/root_v5.27.06b.source.tar.gz) |  28M |
+| root_v5.27.06c.source | [root_v5.27.06c.source.tar.gz](https://root.cern/download/root_v5.27.06c.source.tar.gz) |  28M |
+| root_v5.27.06d.source | [root_v5.27.06d.source.tar.gz](https://root.cern/download/root_v5.27.06d.source.tar.gz) |  28M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| Linux slc4 gcc3.4 | [root_v5.27.06.Linux-slc4-gcc3.4.tar.gz](https://root.cern.ch/download/root_v5.27.06.Linux-slc4-gcc3.4.tar.gz) |  53M |
-| Linux slc4_amd64 gcc3.4 | [root_v5.27.06.Linux-slc4_amd64-gcc3.4.tar.gz](https://root.cern.ch/download/root_v5.27.06.Linux-slc4_amd64-gcc3.4.tar.gz) |  55M |
-| Linux slc5 gcc4.3 | [root_v5.27.06.Linux-slc5-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.27.06.Linux-slc5-gcc4.3.tar.gz) |  53M |
-| Linux slc5_amd64 gcc4.3 | [root_v5.27.06.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.27.06.Linux-slc5_amd64-gcc4.3.tar.gz) |  54M |
-| macosx powerpc gcc 4.0 | [root_v5.27.06.macosx-powerpc-gcc-4.0.tar.gz](https://root.cern.ch/download/root_v5.27.06.macosx-powerpc-gcc-4.0.tar.gz) |  42M |
-| macosx106 i386 gcc 4.2 | [root_v5.27.06.macosx106-i386-gcc-4.2.tar.gz](https://root.cern.ch/download/root_v5.27.06.macosx106-i386-gcc-4.2.tar.gz) |  42M |
-| macosx106 gcc 4.2 | [root_v5.27.06.macosx106-x86_64-gcc-4.2.tar.gz](https://root.cern.ch/download/root_v5.27.06.macosx106-x86_64-gcc-4.2.tar.gz) |  42M |
-| solarisCC5 5.11 i386 | [root_v5.27.06.solarisCC5-5.11-i386.tar.gz](https://root.cern.ch/download/root_v5.27.06.solarisCC5-5.11-i386.tar.gz) |  51M |
-| win32 (dbg) | [root_v5.27.06.win32.debug.tar.gz](https://root.cern.ch/download/root_v5.27.06.win32.debug.tar.gz) | 104M |
-| win32 | [root_v5.27.06.win32.tar.gz](https://root.cern.ch/download/root_v5.27.06.win32.tar.gz) |  51M |
-| Windows Visual Studio 90 (dbg) | [root_v5.27.06.win32.vc90.debug.tar.gz](https://root.cern.ch/download/root_v5.27.06.win32.vc90.debug.tar.gz) | 135M |
-| Windows Visual Studio 90 | [root_v5.27.06.win32.vc90.tar.gz](https://root.cern.ch/download/root_v5.27.06.win32.vc90.tar.gz) |  53M |
-| win32gcc gcc 4.3 | [root_v5.27.06.win32gcc-gcc-4.3.tar.gz](https://root.cern.ch/download/root_v5.27.06.win32gcc-gcc-4.3.tar.gz) |  42M |
+| Linux slc4 gcc3.4 | [root_v5.27.06.Linux-slc4-gcc3.4.tar.gz](https://root.cern/download/root_v5.27.06.Linux-slc4-gcc3.4.tar.gz) |  53M |
+| Linux slc4_amd64 gcc3.4 | [root_v5.27.06.Linux-slc4_amd64-gcc3.4.tar.gz](https://root.cern/download/root_v5.27.06.Linux-slc4_amd64-gcc3.4.tar.gz) |  55M |
+| Linux slc5 gcc4.3 | [root_v5.27.06.Linux-slc5-gcc4.3.tar.gz](https://root.cern/download/root_v5.27.06.Linux-slc5-gcc4.3.tar.gz) |  53M |
+| Linux slc5_amd64 gcc4.3 | [root_v5.27.06.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern/download/root_v5.27.06.Linux-slc5_amd64-gcc4.3.tar.gz) |  54M |
+| macosx powerpc gcc 4.0 | [root_v5.27.06.macosx-powerpc-gcc-4.0.tar.gz](https://root.cern/download/root_v5.27.06.macosx-powerpc-gcc-4.0.tar.gz) |  42M |
+| macosx106 i386 gcc 4.2 | [root_v5.27.06.macosx106-i386-gcc-4.2.tar.gz](https://root.cern/download/root_v5.27.06.macosx106-i386-gcc-4.2.tar.gz) |  42M |
+| macosx106 gcc 4.2 | [root_v5.27.06.macosx106-x86_64-gcc-4.2.tar.gz](https://root.cern/download/root_v5.27.06.macosx106-x86_64-gcc-4.2.tar.gz) |  42M |
+| solarisCC5 5.11 i386 | [root_v5.27.06.solarisCC5-5.11-i386.tar.gz](https://root.cern/download/root_v5.27.06.solarisCC5-5.11-i386.tar.gz) |  51M |
+| win32 (dbg) | [root_v5.27.06.win32.debug.tar.gz](https://root.cern/download/root_v5.27.06.win32.debug.tar.gz) | 104M |
+| win32 | [root_v5.27.06.win32.tar.gz](https://root.cern/download/root_v5.27.06.win32.tar.gz) |  51M |
+| Windows Visual Studio 90 (dbg) | [root_v5.27.06.win32.vc90.debug.tar.gz](https://root.cern/download/root_v5.27.06.win32.vc90.debug.tar.gz) | 135M |
+| Windows Visual Studio 90 | [root_v5.27.06.win32.vc90.tar.gz](https://root.cern/download/root_v5.27.06.win32.vc90.tar.gz) |  53M |
+| win32gcc gcc 4.3 | [root_v5.27.06.win32gcc-gcc-4.3.tar.gz](https://root.cern/download/root_v5.27.06.win32gcc-gcc-4.3.tar.gz) |  42M |
 
 
 
@@ -75,7 +75,7 @@ To use ROOT directly from AFS:
 The entire ROOT source can be obtained from our public Git repository:
 
 ~~~
-git clone http://root.cern.ch/git/root.git
+git clone http://root.cern/git/root.git
 ~~~
 The release specific tag can be obtained using:
 ~~~

--- a/_releases/release-52800.md
+++ b/_releases/release-52800.md
@@ -15,123 +15,123 @@ sidebar:
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v5.28.00.source.tar.gz](https://root.cern.ch/download/root_v5.28.00.source.tar.gz) |  29M |
-| root_v5.28.00a.source | [root_v5.28.00a.source.tar.gz](https://root.cern.ch/download/root_v5.28.00a.source.tar.gz) |  28M |
-| root_v5.28.00b.source | [root_v5.28.00b.source.tar.gz](https://root.cern.ch/download/root_v5.28.00b.source.tar.gz) |  28M |
-| root_v5.28.00c.source | [root_v5.28.00c.source.tar.gz](https://root.cern.ch/download/root_v5.28.00c.source.tar.gz) |  28M |
-| root_v5.28.00d.source | [root_v5.28.00d.source.tar.gz](https://root.cern.ch/download/root_v5.28.00d.source.tar.gz) |  30M |
-| root_v5.28.00e.source | [root_v5.28.00e.source.tar.gz](https://root.cern.ch/download/root_v5.28.00e.source.tar.gz) |  30M |
-| root_v5.28.00f.source | [root_v5.28.00f.source.tar.gz](https://root.cern.ch/download/root_v5.28.00f.source.tar.gz) |  30M |
-| root_v5.28.00g.source | [root_v5.28.00g.source.tar.gz](https://root.cern.ch/download/root_v5.28.00g.source.tar.gz) |  30M |
-| root_v5.28.00h.source | [root_v5.28.00h.source.tar.gz](https://root.cern.ch/download/root_v5.28.00h.source.tar.gz) |  30M |
+| source | [root_v5.28.00.source.tar.gz](https://root.cern/download/root_v5.28.00.source.tar.gz) |  29M |
+| root_v5.28.00a.source | [root_v5.28.00a.source.tar.gz](https://root.cern/download/root_v5.28.00a.source.tar.gz) |  28M |
+| root_v5.28.00b.source | [root_v5.28.00b.source.tar.gz](https://root.cern/download/root_v5.28.00b.source.tar.gz) |  28M |
+| root_v5.28.00c.source | [root_v5.28.00c.source.tar.gz](https://root.cern/download/root_v5.28.00c.source.tar.gz) |  28M |
+| root_v5.28.00d.source | [root_v5.28.00d.source.tar.gz](https://root.cern/download/root_v5.28.00d.source.tar.gz) |  30M |
+| root_v5.28.00e.source | [root_v5.28.00e.source.tar.gz](https://root.cern/download/root_v5.28.00e.source.tar.gz) |  30M |
+| root_v5.28.00f.source | [root_v5.28.00f.source.tar.gz](https://root.cern/download/root_v5.28.00f.source.tar.gz) |  30M |
+| root_v5.28.00g.source | [root_v5.28.00g.source.tar.gz](https://root.cern/download/root_v5.28.00g.source.tar.gz) |  30M |
+| root_v5.28.00h.source | [root_v5.28.00h.source.tar.gz](https://root.cern/download/root_v5.28.00h.source.tar.gz) |  30M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| Linux slc4 gcc3.4 | [root_v5.28.00.Linux-slc4-gcc3.4.tar.gz](https://root.cern.ch/download/root_v5.28.00.Linux-slc4-gcc3.4.tar.gz) |  54M |
-| Linux slc4_amd64 gcc3.4 | [root_v5.28.00.Linux-slc4_amd64-gcc3.4.tar.gz](https://root.cern.ch/download/root_v5.28.00.Linux-slc4_amd64-gcc3.4.tar.gz) |  56M |
-| Linux slc5 gcc3.4 | [root_v5.28.00.Linux-slc5-gcc3.4.tar.gz](https://root.cern.ch/download/root_v5.28.00.Linux-slc5-gcc3.4.tar.gz) |  54M |
-| Linux slc5 gcc4.3 | [root_v5.28.00.Linux-slc5-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.28.00.Linux-slc5-gcc4.3.tar.gz) |  53M |
-| Linux slc5_amd64 gcc3.4 | [root_v5.28.00.Linux-slc5_amd64-gcc3.4.tar.gz](https://root.cern.ch/download/root_v5.28.00.Linux-slc5_amd64-gcc3.4.tar.gz) |  56M |
-| Linux slc5_amd64 gcc4.3 | [root_v5.28.00.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.28.00.Linux-slc5_amd64-gcc4.3.tar.gz) |  55M |
-| macosx powerpc gcc 4.0 | [root_v5.28.00.macosx-powerpc-gcc-4.0.tar.gz](https://root.cern.ch/download/root_v5.28.00.macosx-powerpc-gcc-4.0.tar.gz) |  43M |
-| macosx106 i386 gcc 4.2 | [root_v5.28.00.macosx106-i386-gcc-4.2.tar.gz](https://root.cern.ch/download/root_v5.28.00.macosx106-i386-gcc-4.2.tar.gz) |  44M |
-| macosx106 gcc 4.2 | [root_v5.28.00.macosx106-x86_64-gcc-4.2.tar.gz](https://root.cern.ch/download/root_v5.28.00.macosx106-x86_64-gcc-4.2.tar.gz) |  44M |
-| solarisCC5 5.11 i386 | [root_v5.28.00.solarisCC5-5.11-i386.tar.gz](https://root.cern.ch/download/root_v5.28.00.solarisCC5-5.11-i386.tar.gz) |  59M |
-| win32 (dbg) | [root_v5.28.00.win32.debug.tar.gz](https://root.cern.ch/download/root_v5.28.00.win32.debug.tar.gz) | 108M |
-| win32 | [root_v5.28.00.win32.tar.gz](https://root.cern.ch/download/root_v5.28.00.win32.tar.gz) |  52M |
-| Windows Visual Studio 10 (dbg) | [root_v5.28.00.win32.vc10.debug.tar.gz](https://root.cern.ch/download/root_v5.28.00.win32.vc10.debug.tar.gz) | 145M |
-| Windows Visual Studio 10 | [root_v5.28.00.win32.vc10.tar.gz](https://root.cern.ch/download/root_v5.28.00.win32.vc10.tar.gz) |  56M |
-| Windows Visual Studio 90 (dbg) | [root_v5.28.00.win32.vc90.debug.tar.gz](https://root.cern.ch/download/root_v5.28.00.win32.vc90.debug.tar.gz) | 140M |
-| Windows Visual Studio 90 | [root_v5.28.00.win32.vc90.tar.gz](https://root.cern.ch/download/root_v5.28.00.win32.vc90.tar.gz) |  54M |
-| win32gcc gcc 4.3 | [root_v5.28.00.win32gcc-gcc-4.3.tar.gz](https://root.cern.ch/download/root_v5.28.00.win32gcc-gcc-4.3.tar.gz) |  42M |
-| root_v5.28.00a.Linux slc4 gcc3.4 | [root_v5.28.00a.Linux-slc4-gcc3.4.tar.gz](https://root.cern.ch/download/root_v5.28.00a.Linux-slc4-gcc3.4.tar.gz) |  54M |
-| root_v5.28.00a.Linux slc4_amd64 gcc3.4 | [root_v5.28.00a.Linux-slc4_amd64-gcc3.4.tar.gz](https://root.cern.ch/download/root_v5.28.00a.Linux-slc4_amd64-gcc3.4.tar.gz) |  56M |
-| root_v5.28.00a.Linux slc5 gcc4.3 | [root_v5.28.00a.Linux-slc5-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.28.00a.Linux-slc5-gcc4.3.tar.gz) |  54M |
-| root_v5.28.00a.Linux slc5_amd64 gcc4.3 | [root_v5.28.00a.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.28.00a.Linux-slc5_amd64-gcc4.3.tar.gz) |  55M |
-| root_v5.28.00a.macosx powerpc gcc 4.0 | [root_v5.28.00a.macosx-powerpc-gcc-4.0.tar.gz](https://root.cern.ch/download/root_v5.28.00a.macosx-powerpc-gcc-4.0.tar.gz) |  43M |
-| root_v5.28.00a.macosx106 i386 gcc 4.2 | [root_v5.28.00a.macosx106-i386-gcc-4.2.tar.gz](https://root.cern.ch/download/root_v5.28.00a.macosx106-i386-gcc-4.2.tar.gz) |  44M |
-| root_v5.28.00a.macosx106 gcc 4.2 | [root_v5.28.00a.macosx106-x86_64-gcc-4.2.tar.gz](https://root.cern.ch/download/root_v5.28.00a.macosx106-x86_64-gcc-4.2.tar.gz) |  44M |
-| root_v5.28.00a.win32 (dbg) | [root_v5.28.00a.win32.debug.tar.gz](https://root.cern.ch/download/root_v5.28.00a.win32.debug.tar.gz) | 108M |
-| root_v5.28.00a.win32 | [root_v5.28.00a.win32.tar.gz](https://root.cern.ch/download/root_v5.28.00a.win32.tar.gz) |  53M |
-| root_v5.28.00a.Windows Visual Studio 10 (dbg) | [root_v5.28.00a.win32.vc10.debug.tar.gz](https://root.cern.ch/download/root_v5.28.00a.win32.vc10.debug.tar.gz) | 144M |
-| root_v5.28.00a.Windows Visual Studio 10 | [root_v5.28.00a.win32.vc10.tar.gz](https://root.cern.ch/download/root_v5.28.00a.win32.vc10.tar.gz) |  56M |
-| root_v5.28.00a.Windows Visual Studio 90 (dbg) | [root_v5.28.00a.win32.vc90.debug.tar.gz](https://root.cern.ch/download/root_v5.28.00a.win32.vc90.debug.tar.gz) | 140M |
-| root_v5.28.00a.Windows Visual Studio 90 | [root_v5.28.00a.win32.vc90.tar.gz](https://root.cern.ch/download/root_v5.28.00a.win32.vc90.tar.gz) |  54M |
-| root_v5.28.00a.win32gcc gcc 4.3 | [root_v5.28.00a.win32gcc-gcc-4.3.tar.gz](https://root.cern.ch/download/root_v5.28.00a.win32gcc-gcc-4.3.tar.gz) |  42M |
-| root_v5.28.00b.Linux slc4 gcc3.4 | [root_v5.28.00b.Linux-slc4-gcc3.4.tar.gz](https://root.cern.ch/download/root_v5.28.00b.Linux-slc4-gcc3.4.tar.gz) |  54M |
-| root_v5.28.00b.Linux slc4_amd64 gcc3.4 | [root_v5.28.00b.Linux-slc4_amd64-gcc3.4.tar.gz](https://root.cern.ch/download/root_v5.28.00b.Linux-slc4_amd64-gcc3.4.tar.gz) |  56M |
-| root_v5.28.00b.Linux slc5 gcc4.3 | [root_v5.28.00b.Linux-slc5-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.28.00b.Linux-slc5-gcc4.3.tar.gz) |  54M |
-| root_v5.28.00b.Linux slc5_amd64 gcc4.3 | [root_v5.28.00b.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.28.00b.Linux-slc5_amd64-gcc4.3.tar.gz) |  55M |
-| root_v5.28.00b.macosx powerpc gcc 4.0 | [root_v5.28.00b.macosx-powerpc-gcc-4.0.tar.gz](https://root.cern.ch/download/root_v5.28.00b.macosx-powerpc-gcc-4.0.tar.gz) |  43M |
-| root_v5.28.00b.macosx106 i386 gcc 4.2 | [root_v5.28.00b.macosx106-i386-gcc-4.2.tar.gz](https://root.cern.ch/download/root_v5.28.00b.macosx106-i386-gcc-4.2.tar.gz) |  44M |
-| root_v5.28.00b.macosx106 gcc 4.2 | [root_v5.28.00b.macosx106-x86_64-gcc-4.2.tar.gz](https://root.cern.ch/download/root_v5.28.00b.macosx106-x86_64-gcc-4.2.tar.gz) |  44M |
-| root_v5.28.00b.win32 (dbg) | [root_v5.28.00b.win32.debug.tar.gz](https://root.cern.ch/download/root_v5.28.00b.win32.debug.tar.gz) | 108M |
-| root_v5.28.00b.win32 | [root_v5.28.00b.win32.tar.gz](https://root.cern.ch/download/root_v5.28.00b.win32.tar.gz) |  53M |
-| root_v5.28.00b.Windows Visual Studio 10 (dbg) | [root_v5.28.00b.win32.vc10.debug.tar.gz](https://root.cern.ch/download/root_v5.28.00b.win32.vc10.debug.tar.gz) | 144M |
-| root_v5.28.00b.Windows Visual Studio 10 | [root_v5.28.00b.win32.vc10.tar.gz](https://root.cern.ch/download/root_v5.28.00b.win32.vc10.tar.gz) |  56M |
-| root_v5.28.00b.Windows Visual Studio 90 (dbg) | [root_v5.28.00b.win32.vc90.debug.tar.gz](https://root.cern.ch/download/root_v5.28.00b.win32.vc90.debug.tar.gz) | 140M |
-| root_v5.28.00b.Windows Visual Studio 90 | [root_v5.28.00b.win32.vc90.tar.gz](https://root.cern.ch/download/root_v5.28.00b.win32.vc90.tar.gz) |  54M |
-| root_v5.28.00b.win32gcc gcc 4.3 | [root_v5.28.00b.win32gcc-gcc-4.3.tar.gz](https://root.cern.ch/download/root_v5.28.00b.win32gcc-gcc-4.3.tar.gz) |  42M |
-| root_v5.28.00c.Linux slc4 gcc3.4 | [root_v5.28.00c.Linux-slc4-gcc3.4.tar.gz](https://root.cern.ch/download/root_v5.28.00c.Linux-slc4-gcc3.4.tar.gz) |  54M |
-| root_v5.28.00c.Linux slc4_amd64 gcc3.4 | [root_v5.28.00c.Linux-slc4_amd64-gcc3.4.tar.gz](https://root.cern.ch/download/root_v5.28.00c.Linux-slc4_amd64-gcc3.4.tar.gz) |  56M |
-| root_v5.28.00c.Linux slc5 gcc4.3 | [root_v5.28.00c.Linux-slc5-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.28.00c.Linux-slc5-gcc4.3.tar.gz) |  54M |
-| root_v5.28.00c.Linux slc5_amd64 gcc4.3 | [root_v5.28.00c.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.28.00c.Linux-slc5_amd64-gcc4.3.tar.gz) |  55M |
-| root_v5.28.00c.macosx powerpc gcc 4.0 | [root_v5.28.00c.macosx-powerpc-gcc-4.0.tar.gz](https://root.cern.ch/download/root_v5.28.00c.macosx-powerpc-gcc-4.0.tar.gz) |  43M |
-| root_v5.28.00c.macosx106 i386 gcc 4.2 | [root_v5.28.00c.macosx106-i386-gcc-4.2.tar.gz](https://root.cern.ch/download/root_v5.28.00c.macosx106-i386-gcc-4.2.tar.gz) |  44M |
-| root_v5.28.00c.macosx106 gcc 4.2 | [root_v5.28.00c.macosx106-x86_64-gcc-4.2.tar.gz](https://root.cern.ch/download/root_v5.28.00c.macosx106-x86_64-gcc-4.2.tar.gz) |  44M |
-| root_v5.28.00c.win32 (dbg) | [root_v5.28.00c.win32.debug.tar.gz](https://root.cern.ch/download/root_v5.28.00c.win32.debug.tar.gz) | 108M |
-| root_v5.28.00c.win32 | [root_v5.28.00c.win32.tar.gz](https://root.cern.ch/download/root_v5.28.00c.win32.tar.gz) |  53M |
-| root_v5.28.00c.Windows Visual Studio 10 (dbg) | [root_v5.28.00c.win32.vc10.debug.tar.gz](https://root.cern.ch/download/root_v5.28.00c.win32.vc10.debug.tar.gz) | 143M |
-| root_v5.28.00c.Windows Visual Studio 10 | [root_v5.28.00c.win32.vc10.tar.gz](https://root.cern.ch/download/root_v5.28.00c.win32.vc10.tar.gz) |  55M |
-| root_v5.28.00c.Windows Visual Studio 90 (dbg) | [root_v5.28.00c.win32.vc90.debug.tar.gz](https://root.cern.ch/download/root_v5.28.00c.win32.vc90.debug.tar.gz) | 140M |
-| root_v5.28.00c.Windows Visual Studio 90 | [root_v5.28.00c.win32.vc90.tar.gz](https://root.cern.ch/download/root_v5.28.00c.win32.vc90.tar.gz) |  54M |
-| root_v5.28.00c.win32gcc gcc 4.3 | [root_v5.28.00c.win32gcc-gcc-4.3.tar.gz](https://root.cern.ch/download/root_v5.28.00c.win32gcc-gcc-4.3.tar.gz) |  42M |
-| root_v5.28.00d.Linux slc4 gcc3.4 | [root_v5.28.00d.Linux-slc4-gcc3.4.tar.gz](https://root.cern.ch/download/root_v5.28.00d.Linux-slc4-gcc3.4.tar.gz) |  54M |
-| root_v5.28.00d.Linux slc4_amd64 gcc3.4 | [root_v5.28.00d.Linux-slc4_amd64-gcc3.4.tar.gz](https://root.cern.ch/download/root_v5.28.00d.Linux-slc4_amd64-gcc3.4.tar.gz) |  56M |
-| root_v5.28.00d.Linux slc5 gcc4.3 | [root_v5.28.00d.Linux-slc5-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.28.00d.Linux-slc5-gcc4.3.tar.gz) |  54M |
-| root_v5.28.00d.Linux slc5_amd64 gcc4.3 | [root_v5.28.00d.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.28.00d.Linux-slc5_amd64-gcc4.3.tar.gz) |  55M |
-| root_v5.28.00d.macosx106 i386 gcc 4.2 | [root_v5.28.00d.macosx106-i386-gcc-4.2.tar.gz](https://root.cern.ch/download/root_v5.28.00d.macosx106-i386-gcc-4.2.tar.gz) |  44M |
-| root_v5.28.00d.macosx106 gcc 4.2 | [root_v5.28.00d.macosx106-x86_64-gcc-4.2.tar.gz](https://root.cern.ch/download/root_v5.28.00d.macosx106-x86_64-gcc-4.2.tar.gz) |  44M |
-| root_v5.28.00d.win32 (dbg) | [root_v5.28.00d.win32.debug.tar.gz](https://root.cern.ch/download/root_v5.28.00d.win32.debug.tar.gz) | 108M |
-| root_v5.28.00d.win32 | [root_v5.28.00d.win32.tar.gz](https://root.cern.ch/download/root_v5.28.00d.win32.tar.gz) |  53M |
-| root_v5.28.00d.Windows Visual Studio 10 (dbg) | [root_v5.28.00d.win32.vc10.debug.tar.gz](https://root.cern.ch/download/root_v5.28.00d.win32.vc10.debug.tar.gz) | 145M |
-| root_v5.28.00d.Windows Visual Studio 10 | [root_v5.28.00d.win32.vc10.tar.gz](https://root.cern.ch/download/root_v5.28.00d.win32.vc10.tar.gz) |  56M |
-| root_v5.28.00d.Windows Visual Studio 90 (dbg) | [root_v5.28.00d.win32.vc90.debug.tar.gz](https://root.cern.ch/download/root_v5.28.00d.win32.vc90.debug.tar.gz) | 140M |
-| root_v5.28.00d.Windows Visual Studio 90 | [root_v5.28.00d.win32.vc90.tar.gz](https://root.cern.ch/download/root_v5.28.00d.win32.vc90.tar.gz) |  54M |
-| root_v5.28.00d.win32gcc gcc 4.3 | [root_v5.28.00d.win32gcc-gcc-4.3.tar.gz](https://root.cern.ch/download/root_v5.28.00d.win32gcc-gcc-4.3.tar.gz) |  42M |
-| root_v5.28.00e.Linux slc5 gcc4.3 | [root_v5.28.00e.Linux-slc5-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.28.00e.Linux-slc5-gcc4.3.tar.gz) |  54M |
-| root_v5.28.00e.Linux slc5_amd64 gcc4.3 | [root_v5.28.00e.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.28.00e.Linux-slc5_amd64-gcc4.3.tar.gz) |  55M |
-| root_v5.28.00e.macosx106 i386 gcc 4.2 | [root_v5.28.00e.macosx106-i386-gcc-4.2.tar.gz](https://root.cern.ch/download/root_v5.28.00e.macosx106-i386-gcc-4.2.tar.gz) |  44M |
-| root_v5.28.00e.macosx106 gcc 4.2 | [root_v5.28.00e.macosx106-x86_64-gcc-4.2.tar.gz](https://root.cern.ch/download/root_v5.28.00e.macosx106-x86_64-gcc-4.2.tar.gz) |  44M |
-| root_v5.28.00e.win32 (dbg) | [root_v5.28.00e.win32.debug.tar.gz](https://root.cern.ch/download/root_v5.28.00e.win32.debug.tar.gz) | 108M |
-| root_v5.28.00e.win32 | [root_v5.28.00e.win32.tar.gz](https://root.cern.ch/download/root_v5.28.00e.win32.tar.gz) |  53M |
-| root_v5.28.00e.Windows Visual Studio 10 (dbg) | [root_v5.28.00e.win32.vc10.debug.tar.gz](https://root.cern.ch/download/root_v5.28.00e.win32.vc10.debug.tar.gz) | 145M |
-| root_v5.28.00e.Windows Visual Studio 10 | [root_v5.28.00e.win32.vc10.tar.gz](https://root.cern.ch/download/root_v5.28.00e.win32.vc10.tar.gz) |  56M |
-| root_v5.28.00e.Windows Visual Studio 90 (dbg) | [root_v5.28.00e.win32.vc90.debug.tar.gz](https://root.cern.ch/download/root_v5.28.00e.win32.vc90.debug.tar.gz) | 140M |
-| root_v5.28.00e.Windows Visual Studio 90 | [root_v5.28.00e.win32.vc90.tar.gz](https://root.cern.ch/download/root_v5.28.00e.win32.vc90.tar.gz) |  54M |
-| root_v5.28.00f.Linux slc5 gcc4.3 | [root_v5.28.00f.Linux-slc5-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.28.00f.Linux-slc5-gcc4.3.tar.gz) |  54M |
-| root_v5.28.00f.Linux slc5_amd64 gcc4.3 | [root_v5.28.00f.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.28.00f.Linux-slc5_amd64-gcc4.3.tar.gz) |  55M |
-| root_v5.28.00f.macosx106 i386 gcc 4.2 | [root_v5.28.00f.macosx106-i386-gcc-4.2.tar.gz](https://root.cern.ch/download/root_v5.28.00f.macosx106-i386-gcc-4.2.tar.gz) |  44M |
-| root_v5.28.00f.macosx106 gcc 4.2 | [root_v5.28.00f.macosx106-x86_64-gcc-4.2.tar.gz](https://root.cern.ch/download/root_v5.28.00f.macosx106-x86_64-gcc-4.2.tar.gz) |  44M |
-| root_v5.28.00f.win32 (dbg) | [root_v5.28.00f.win32.debug.tar.gz](https://root.cern.ch/download/root_v5.28.00f.win32.debug.tar.gz) | 108M |
-| root_v5.28.00f.win32 | [root_v5.28.00f.win32.tar.gz](https://root.cern.ch/download/root_v5.28.00f.win32.tar.gz) |  53M |
-| root_v5.28.00f.Windows Visual Studio 10 (dbg) | [root_v5.28.00f.win32.vc10.debug.tar.gz](https://root.cern.ch/download/root_v5.28.00f.win32.vc10.debug.tar.gz) | 145M |
-| root_v5.28.00f.Windows Visual Studio 10 | [root_v5.28.00f.win32.vc10.tar.gz](https://root.cern.ch/download/root_v5.28.00f.win32.vc10.tar.gz) |  56M |
-| root_v5.28.00f.Windows Visual Studio 90 (dbg) | [root_v5.28.00f.win32.vc90.debug.tar.gz](https://root.cern.ch/download/root_v5.28.00f.win32.vc90.debug.tar.gz) | 140M |
-| root_v5.28.00f.Windows Visual Studio 90 | [root_v5.28.00f.win32.vc90.tar.gz](https://root.cern.ch/download/root_v5.28.00f.win32.vc90.tar.gz) |  54M |
-| root_v5.28.00g.Linux slc5 gcc4.3 | [root_v5.28.00g.Linux-slc5-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.28.00g.Linux-slc5-gcc4.3.tar.gz) |  54M |
-| root_v5.28.00g.Linux slc5_amd64 gcc4.3 | [root_v5.28.00g.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.28.00g.Linux-slc5_amd64-gcc4.3.tar.gz) |  55M |
-| root_v5.28.00g.macosx106 i386 gcc 4.2 | [root_v5.28.00g.macosx106-i386-gcc-4.2.tar.gz](https://root.cern.ch/download/root_v5.28.00g.macosx106-i386-gcc-4.2.tar.gz) |  44M |
-| root_v5.28.00g.macosx106 gcc 4.2 | [root_v5.28.00g.macosx106-x86_64-gcc-4.2.tar.gz](https://root.cern.ch/download/root_v5.28.00g.macosx106-x86_64-gcc-4.2.tar.gz) |  44M |
-| root_v5.28.00g.win32 (dbg) | [root_v5.28.00g.win32.debug.tar.gz](https://root.cern.ch/download/root_v5.28.00g.win32.debug.tar.gz) | 108M |
-| root_v5.28.00g.win32 | [root_v5.28.00g.win32.tar.gz](https://root.cern.ch/download/root_v5.28.00g.win32.tar.gz) |  53M |
-| root_v5.28.00g.Windows Visual Studio 10 (dbg) | [root_v5.28.00g.win32.vc10.debug.tar.gz](https://root.cern.ch/download/root_v5.28.00g.win32.vc10.debug.tar.gz) | 145M |
-| root_v5.28.00g.Windows Visual Studio 10 | [root_v5.28.00g.win32.vc10.tar.gz](https://root.cern.ch/download/root_v5.28.00g.win32.vc10.tar.gz) |  56M |
-| root_v5.28.00g.Windows Visual Studio 90 (dbg) | [root_v5.28.00g.win32.vc90.debug.tar.gz](https://root.cern.ch/download/root_v5.28.00g.win32.vc90.debug.tar.gz) | 140M |
-| root_v5.28.00g.Windows Visual Studio 90 | [root_v5.28.00g.win32.vc90.tar.gz](https://root.cern.ch/download/root_v5.28.00g.win32.vc90.tar.gz) |  54M |
+| Linux slc4 gcc3.4 | [root_v5.28.00.Linux-slc4-gcc3.4.tar.gz](https://root.cern/download/root_v5.28.00.Linux-slc4-gcc3.4.tar.gz) |  54M |
+| Linux slc4_amd64 gcc3.4 | [root_v5.28.00.Linux-slc4_amd64-gcc3.4.tar.gz](https://root.cern/download/root_v5.28.00.Linux-slc4_amd64-gcc3.4.tar.gz) |  56M |
+| Linux slc5 gcc3.4 | [root_v5.28.00.Linux-slc5-gcc3.4.tar.gz](https://root.cern/download/root_v5.28.00.Linux-slc5-gcc3.4.tar.gz) |  54M |
+| Linux slc5 gcc4.3 | [root_v5.28.00.Linux-slc5-gcc4.3.tar.gz](https://root.cern/download/root_v5.28.00.Linux-slc5-gcc4.3.tar.gz) |  53M |
+| Linux slc5_amd64 gcc3.4 | [root_v5.28.00.Linux-slc5_amd64-gcc3.4.tar.gz](https://root.cern/download/root_v5.28.00.Linux-slc5_amd64-gcc3.4.tar.gz) |  56M |
+| Linux slc5_amd64 gcc4.3 | [root_v5.28.00.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern/download/root_v5.28.00.Linux-slc5_amd64-gcc4.3.tar.gz) |  55M |
+| macosx powerpc gcc 4.0 | [root_v5.28.00.macosx-powerpc-gcc-4.0.tar.gz](https://root.cern/download/root_v5.28.00.macosx-powerpc-gcc-4.0.tar.gz) |  43M |
+| macosx106 i386 gcc 4.2 | [root_v5.28.00.macosx106-i386-gcc-4.2.tar.gz](https://root.cern/download/root_v5.28.00.macosx106-i386-gcc-4.2.tar.gz) |  44M |
+| macosx106 gcc 4.2 | [root_v5.28.00.macosx106-x86_64-gcc-4.2.tar.gz](https://root.cern/download/root_v5.28.00.macosx106-x86_64-gcc-4.2.tar.gz) |  44M |
+| solarisCC5 5.11 i386 | [root_v5.28.00.solarisCC5-5.11-i386.tar.gz](https://root.cern/download/root_v5.28.00.solarisCC5-5.11-i386.tar.gz) |  59M |
+| win32 (dbg) | [root_v5.28.00.win32.debug.tar.gz](https://root.cern/download/root_v5.28.00.win32.debug.tar.gz) | 108M |
+| win32 | [root_v5.28.00.win32.tar.gz](https://root.cern/download/root_v5.28.00.win32.tar.gz) |  52M |
+| Windows Visual Studio 10 (dbg) | [root_v5.28.00.win32.vc10.debug.tar.gz](https://root.cern/download/root_v5.28.00.win32.vc10.debug.tar.gz) | 145M |
+| Windows Visual Studio 10 | [root_v5.28.00.win32.vc10.tar.gz](https://root.cern/download/root_v5.28.00.win32.vc10.tar.gz) |  56M |
+| Windows Visual Studio 90 (dbg) | [root_v5.28.00.win32.vc90.debug.tar.gz](https://root.cern/download/root_v5.28.00.win32.vc90.debug.tar.gz) | 140M |
+| Windows Visual Studio 90 | [root_v5.28.00.win32.vc90.tar.gz](https://root.cern/download/root_v5.28.00.win32.vc90.tar.gz) |  54M |
+| win32gcc gcc 4.3 | [root_v5.28.00.win32gcc-gcc-4.3.tar.gz](https://root.cern/download/root_v5.28.00.win32gcc-gcc-4.3.tar.gz) |  42M |
+| root_v5.28.00a.Linux slc4 gcc3.4 | [root_v5.28.00a.Linux-slc4-gcc3.4.tar.gz](https://root.cern/download/root_v5.28.00a.Linux-slc4-gcc3.4.tar.gz) |  54M |
+| root_v5.28.00a.Linux slc4_amd64 gcc3.4 | [root_v5.28.00a.Linux-slc4_amd64-gcc3.4.tar.gz](https://root.cern/download/root_v5.28.00a.Linux-slc4_amd64-gcc3.4.tar.gz) |  56M |
+| root_v5.28.00a.Linux slc5 gcc4.3 | [root_v5.28.00a.Linux-slc5-gcc4.3.tar.gz](https://root.cern/download/root_v5.28.00a.Linux-slc5-gcc4.3.tar.gz) |  54M |
+| root_v5.28.00a.Linux slc5_amd64 gcc4.3 | [root_v5.28.00a.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern/download/root_v5.28.00a.Linux-slc5_amd64-gcc4.3.tar.gz) |  55M |
+| root_v5.28.00a.macosx powerpc gcc 4.0 | [root_v5.28.00a.macosx-powerpc-gcc-4.0.tar.gz](https://root.cern/download/root_v5.28.00a.macosx-powerpc-gcc-4.0.tar.gz) |  43M |
+| root_v5.28.00a.macosx106 i386 gcc 4.2 | [root_v5.28.00a.macosx106-i386-gcc-4.2.tar.gz](https://root.cern/download/root_v5.28.00a.macosx106-i386-gcc-4.2.tar.gz) |  44M |
+| root_v5.28.00a.macosx106 gcc 4.2 | [root_v5.28.00a.macosx106-x86_64-gcc-4.2.tar.gz](https://root.cern/download/root_v5.28.00a.macosx106-x86_64-gcc-4.2.tar.gz) |  44M |
+| root_v5.28.00a.win32 (dbg) | [root_v5.28.00a.win32.debug.tar.gz](https://root.cern/download/root_v5.28.00a.win32.debug.tar.gz) | 108M |
+| root_v5.28.00a.win32 | [root_v5.28.00a.win32.tar.gz](https://root.cern/download/root_v5.28.00a.win32.tar.gz) |  53M |
+| root_v5.28.00a.Windows Visual Studio 10 (dbg) | [root_v5.28.00a.win32.vc10.debug.tar.gz](https://root.cern/download/root_v5.28.00a.win32.vc10.debug.tar.gz) | 144M |
+| root_v5.28.00a.Windows Visual Studio 10 | [root_v5.28.00a.win32.vc10.tar.gz](https://root.cern/download/root_v5.28.00a.win32.vc10.tar.gz) |  56M |
+| root_v5.28.00a.Windows Visual Studio 90 (dbg) | [root_v5.28.00a.win32.vc90.debug.tar.gz](https://root.cern/download/root_v5.28.00a.win32.vc90.debug.tar.gz) | 140M |
+| root_v5.28.00a.Windows Visual Studio 90 | [root_v5.28.00a.win32.vc90.tar.gz](https://root.cern/download/root_v5.28.00a.win32.vc90.tar.gz) |  54M |
+| root_v5.28.00a.win32gcc gcc 4.3 | [root_v5.28.00a.win32gcc-gcc-4.3.tar.gz](https://root.cern/download/root_v5.28.00a.win32gcc-gcc-4.3.tar.gz) |  42M |
+| root_v5.28.00b.Linux slc4 gcc3.4 | [root_v5.28.00b.Linux-slc4-gcc3.4.tar.gz](https://root.cern/download/root_v5.28.00b.Linux-slc4-gcc3.4.tar.gz) |  54M |
+| root_v5.28.00b.Linux slc4_amd64 gcc3.4 | [root_v5.28.00b.Linux-slc4_amd64-gcc3.4.tar.gz](https://root.cern/download/root_v5.28.00b.Linux-slc4_amd64-gcc3.4.tar.gz) |  56M |
+| root_v5.28.00b.Linux slc5 gcc4.3 | [root_v5.28.00b.Linux-slc5-gcc4.3.tar.gz](https://root.cern/download/root_v5.28.00b.Linux-slc5-gcc4.3.tar.gz) |  54M |
+| root_v5.28.00b.Linux slc5_amd64 gcc4.3 | [root_v5.28.00b.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern/download/root_v5.28.00b.Linux-slc5_amd64-gcc4.3.tar.gz) |  55M |
+| root_v5.28.00b.macosx powerpc gcc 4.0 | [root_v5.28.00b.macosx-powerpc-gcc-4.0.tar.gz](https://root.cern/download/root_v5.28.00b.macosx-powerpc-gcc-4.0.tar.gz) |  43M |
+| root_v5.28.00b.macosx106 i386 gcc 4.2 | [root_v5.28.00b.macosx106-i386-gcc-4.2.tar.gz](https://root.cern/download/root_v5.28.00b.macosx106-i386-gcc-4.2.tar.gz) |  44M |
+| root_v5.28.00b.macosx106 gcc 4.2 | [root_v5.28.00b.macosx106-x86_64-gcc-4.2.tar.gz](https://root.cern/download/root_v5.28.00b.macosx106-x86_64-gcc-4.2.tar.gz) |  44M |
+| root_v5.28.00b.win32 (dbg) | [root_v5.28.00b.win32.debug.tar.gz](https://root.cern/download/root_v5.28.00b.win32.debug.tar.gz) | 108M |
+| root_v5.28.00b.win32 | [root_v5.28.00b.win32.tar.gz](https://root.cern/download/root_v5.28.00b.win32.tar.gz) |  53M |
+| root_v5.28.00b.Windows Visual Studio 10 (dbg) | [root_v5.28.00b.win32.vc10.debug.tar.gz](https://root.cern/download/root_v5.28.00b.win32.vc10.debug.tar.gz) | 144M |
+| root_v5.28.00b.Windows Visual Studio 10 | [root_v5.28.00b.win32.vc10.tar.gz](https://root.cern/download/root_v5.28.00b.win32.vc10.tar.gz) |  56M |
+| root_v5.28.00b.Windows Visual Studio 90 (dbg) | [root_v5.28.00b.win32.vc90.debug.tar.gz](https://root.cern/download/root_v5.28.00b.win32.vc90.debug.tar.gz) | 140M |
+| root_v5.28.00b.Windows Visual Studio 90 | [root_v5.28.00b.win32.vc90.tar.gz](https://root.cern/download/root_v5.28.00b.win32.vc90.tar.gz) |  54M |
+| root_v5.28.00b.win32gcc gcc 4.3 | [root_v5.28.00b.win32gcc-gcc-4.3.tar.gz](https://root.cern/download/root_v5.28.00b.win32gcc-gcc-4.3.tar.gz) |  42M |
+| root_v5.28.00c.Linux slc4 gcc3.4 | [root_v5.28.00c.Linux-slc4-gcc3.4.tar.gz](https://root.cern/download/root_v5.28.00c.Linux-slc4-gcc3.4.tar.gz) |  54M |
+| root_v5.28.00c.Linux slc4_amd64 gcc3.4 | [root_v5.28.00c.Linux-slc4_amd64-gcc3.4.tar.gz](https://root.cern/download/root_v5.28.00c.Linux-slc4_amd64-gcc3.4.tar.gz) |  56M |
+| root_v5.28.00c.Linux slc5 gcc4.3 | [root_v5.28.00c.Linux-slc5-gcc4.3.tar.gz](https://root.cern/download/root_v5.28.00c.Linux-slc5-gcc4.3.tar.gz) |  54M |
+| root_v5.28.00c.Linux slc5_amd64 gcc4.3 | [root_v5.28.00c.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern/download/root_v5.28.00c.Linux-slc5_amd64-gcc4.3.tar.gz) |  55M |
+| root_v5.28.00c.macosx powerpc gcc 4.0 | [root_v5.28.00c.macosx-powerpc-gcc-4.0.tar.gz](https://root.cern/download/root_v5.28.00c.macosx-powerpc-gcc-4.0.tar.gz) |  43M |
+| root_v5.28.00c.macosx106 i386 gcc 4.2 | [root_v5.28.00c.macosx106-i386-gcc-4.2.tar.gz](https://root.cern/download/root_v5.28.00c.macosx106-i386-gcc-4.2.tar.gz) |  44M |
+| root_v5.28.00c.macosx106 gcc 4.2 | [root_v5.28.00c.macosx106-x86_64-gcc-4.2.tar.gz](https://root.cern/download/root_v5.28.00c.macosx106-x86_64-gcc-4.2.tar.gz) |  44M |
+| root_v5.28.00c.win32 (dbg) | [root_v5.28.00c.win32.debug.tar.gz](https://root.cern/download/root_v5.28.00c.win32.debug.tar.gz) | 108M |
+| root_v5.28.00c.win32 | [root_v5.28.00c.win32.tar.gz](https://root.cern/download/root_v5.28.00c.win32.tar.gz) |  53M |
+| root_v5.28.00c.Windows Visual Studio 10 (dbg) | [root_v5.28.00c.win32.vc10.debug.tar.gz](https://root.cern/download/root_v5.28.00c.win32.vc10.debug.tar.gz) | 143M |
+| root_v5.28.00c.Windows Visual Studio 10 | [root_v5.28.00c.win32.vc10.tar.gz](https://root.cern/download/root_v5.28.00c.win32.vc10.tar.gz) |  55M |
+| root_v5.28.00c.Windows Visual Studio 90 (dbg) | [root_v5.28.00c.win32.vc90.debug.tar.gz](https://root.cern/download/root_v5.28.00c.win32.vc90.debug.tar.gz) | 140M |
+| root_v5.28.00c.Windows Visual Studio 90 | [root_v5.28.00c.win32.vc90.tar.gz](https://root.cern/download/root_v5.28.00c.win32.vc90.tar.gz) |  54M |
+| root_v5.28.00c.win32gcc gcc 4.3 | [root_v5.28.00c.win32gcc-gcc-4.3.tar.gz](https://root.cern/download/root_v5.28.00c.win32gcc-gcc-4.3.tar.gz) |  42M |
+| root_v5.28.00d.Linux slc4 gcc3.4 | [root_v5.28.00d.Linux-slc4-gcc3.4.tar.gz](https://root.cern/download/root_v5.28.00d.Linux-slc4-gcc3.4.tar.gz) |  54M |
+| root_v5.28.00d.Linux slc4_amd64 gcc3.4 | [root_v5.28.00d.Linux-slc4_amd64-gcc3.4.tar.gz](https://root.cern/download/root_v5.28.00d.Linux-slc4_amd64-gcc3.4.tar.gz) |  56M |
+| root_v5.28.00d.Linux slc5 gcc4.3 | [root_v5.28.00d.Linux-slc5-gcc4.3.tar.gz](https://root.cern/download/root_v5.28.00d.Linux-slc5-gcc4.3.tar.gz) |  54M |
+| root_v5.28.00d.Linux slc5_amd64 gcc4.3 | [root_v5.28.00d.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern/download/root_v5.28.00d.Linux-slc5_amd64-gcc4.3.tar.gz) |  55M |
+| root_v5.28.00d.macosx106 i386 gcc 4.2 | [root_v5.28.00d.macosx106-i386-gcc-4.2.tar.gz](https://root.cern/download/root_v5.28.00d.macosx106-i386-gcc-4.2.tar.gz) |  44M |
+| root_v5.28.00d.macosx106 gcc 4.2 | [root_v5.28.00d.macosx106-x86_64-gcc-4.2.tar.gz](https://root.cern/download/root_v5.28.00d.macosx106-x86_64-gcc-4.2.tar.gz) |  44M |
+| root_v5.28.00d.win32 (dbg) | [root_v5.28.00d.win32.debug.tar.gz](https://root.cern/download/root_v5.28.00d.win32.debug.tar.gz) | 108M |
+| root_v5.28.00d.win32 | [root_v5.28.00d.win32.tar.gz](https://root.cern/download/root_v5.28.00d.win32.tar.gz) |  53M |
+| root_v5.28.00d.Windows Visual Studio 10 (dbg) | [root_v5.28.00d.win32.vc10.debug.tar.gz](https://root.cern/download/root_v5.28.00d.win32.vc10.debug.tar.gz) | 145M |
+| root_v5.28.00d.Windows Visual Studio 10 | [root_v5.28.00d.win32.vc10.tar.gz](https://root.cern/download/root_v5.28.00d.win32.vc10.tar.gz) |  56M |
+| root_v5.28.00d.Windows Visual Studio 90 (dbg) | [root_v5.28.00d.win32.vc90.debug.tar.gz](https://root.cern/download/root_v5.28.00d.win32.vc90.debug.tar.gz) | 140M |
+| root_v5.28.00d.Windows Visual Studio 90 | [root_v5.28.00d.win32.vc90.tar.gz](https://root.cern/download/root_v5.28.00d.win32.vc90.tar.gz) |  54M |
+| root_v5.28.00d.win32gcc gcc 4.3 | [root_v5.28.00d.win32gcc-gcc-4.3.tar.gz](https://root.cern/download/root_v5.28.00d.win32gcc-gcc-4.3.tar.gz) |  42M |
+| root_v5.28.00e.Linux slc5 gcc4.3 | [root_v5.28.00e.Linux-slc5-gcc4.3.tar.gz](https://root.cern/download/root_v5.28.00e.Linux-slc5-gcc4.3.tar.gz) |  54M |
+| root_v5.28.00e.Linux slc5_amd64 gcc4.3 | [root_v5.28.00e.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern/download/root_v5.28.00e.Linux-slc5_amd64-gcc4.3.tar.gz) |  55M |
+| root_v5.28.00e.macosx106 i386 gcc 4.2 | [root_v5.28.00e.macosx106-i386-gcc-4.2.tar.gz](https://root.cern/download/root_v5.28.00e.macosx106-i386-gcc-4.2.tar.gz) |  44M |
+| root_v5.28.00e.macosx106 gcc 4.2 | [root_v5.28.00e.macosx106-x86_64-gcc-4.2.tar.gz](https://root.cern/download/root_v5.28.00e.macosx106-x86_64-gcc-4.2.tar.gz) |  44M |
+| root_v5.28.00e.win32 (dbg) | [root_v5.28.00e.win32.debug.tar.gz](https://root.cern/download/root_v5.28.00e.win32.debug.tar.gz) | 108M |
+| root_v5.28.00e.win32 | [root_v5.28.00e.win32.tar.gz](https://root.cern/download/root_v5.28.00e.win32.tar.gz) |  53M |
+| root_v5.28.00e.Windows Visual Studio 10 (dbg) | [root_v5.28.00e.win32.vc10.debug.tar.gz](https://root.cern/download/root_v5.28.00e.win32.vc10.debug.tar.gz) | 145M |
+| root_v5.28.00e.Windows Visual Studio 10 | [root_v5.28.00e.win32.vc10.tar.gz](https://root.cern/download/root_v5.28.00e.win32.vc10.tar.gz) |  56M |
+| root_v5.28.00e.Windows Visual Studio 90 (dbg) | [root_v5.28.00e.win32.vc90.debug.tar.gz](https://root.cern/download/root_v5.28.00e.win32.vc90.debug.tar.gz) | 140M |
+| root_v5.28.00e.Windows Visual Studio 90 | [root_v5.28.00e.win32.vc90.tar.gz](https://root.cern/download/root_v5.28.00e.win32.vc90.tar.gz) |  54M |
+| root_v5.28.00f.Linux slc5 gcc4.3 | [root_v5.28.00f.Linux-slc5-gcc4.3.tar.gz](https://root.cern/download/root_v5.28.00f.Linux-slc5-gcc4.3.tar.gz) |  54M |
+| root_v5.28.00f.Linux slc5_amd64 gcc4.3 | [root_v5.28.00f.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern/download/root_v5.28.00f.Linux-slc5_amd64-gcc4.3.tar.gz) |  55M |
+| root_v5.28.00f.macosx106 i386 gcc 4.2 | [root_v5.28.00f.macosx106-i386-gcc-4.2.tar.gz](https://root.cern/download/root_v5.28.00f.macosx106-i386-gcc-4.2.tar.gz) |  44M |
+| root_v5.28.00f.macosx106 gcc 4.2 | [root_v5.28.00f.macosx106-x86_64-gcc-4.2.tar.gz](https://root.cern/download/root_v5.28.00f.macosx106-x86_64-gcc-4.2.tar.gz) |  44M |
+| root_v5.28.00f.win32 (dbg) | [root_v5.28.00f.win32.debug.tar.gz](https://root.cern/download/root_v5.28.00f.win32.debug.tar.gz) | 108M |
+| root_v5.28.00f.win32 | [root_v5.28.00f.win32.tar.gz](https://root.cern/download/root_v5.28.00f.win32.tar.gz) |  53M |
+| root_v5.28.00f.Windows Visual Studio 10 (dbg) | [root_v5.28.00f.win32.vc10.debug.tar.gz](https://root.cern/download/root_v5.28.00f.win32.vc10.debug.tar.gz) | 145M |
+| root_v5.28.00f.Windows Visual Studio 10 | [root_v5.28.00f.win32.vc10.tar.gz](https://root.cern/download/root_v5.28.00f.win32.vc10.tar.gz) |  56M |
+| root_v5.28.00f.Windows Visual Studio 90 (dbg) | [root_v5.28.00f.win32.vc90.debug.tar.gz](https://root.cern/download/root_v5.28.00f.win32.vc90.debug.tar.gz) | 140M |
+| root_v5.28.00f.Windows Visual Studio 90 | [root_v5.28.00f.win32.vc90.tar.gz](https://root.cern/download/root_v5.28.00f.win32.vc90.tar.gz) |  54M |
+| root_v5.28.00g.Linux slc5 gcc4.3 | [root_v5.28.00g.Linux-slc5-gcc4.3.tar.gz](https://root.cern/download/root_v5.28.00g.Linux-slc5-gcc4.3.tar.gz) |  54M |
+| root_v5.28.00g.Linux slc5_amd64 gcc4.3 | [root_v5.28.00g.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern/download/root_v5.28.00g.Linux-slc5_amd64-gcc4.3.tar.gz) |  55M |
+| root_v5.28.00g.macosx106 i386 gcc 4.2 | [root_v5.28.00g.macosx106-i386-gcc-4.2.tar.gz](https://root.cern/download/root_v5.28.00g.macosx106-i386-gcc-4.2.tar.gz) |  44M |
+| root_v5.28.00g.macosx106 gcc 4.2 | [root_v5.28.00g.macosx106-x86_64-gcc-4.2.tar.gz](https://root.cern/download/root_v5.28.00g.macosx106-x86_64-gcc-4.2.tar.gz) |  44M |
+| root_v5.28.00g.win32 (dbg) | [root_v5.28.00g.win32.debug.tar.gz](https://root.cern/download/root_v5.28.00g.win32.debug.tar.gz) | 108M |
+| root_v5.28.00g.win32 | [root_v5.28.00g.win32.tar.gz](https://root.cern/download/root_v5.28.00g.win32.tar.gz) |  53M |
+| root_v5.28.00g.Windows Visual Studio 10 (dbg) | [root_v5.28.00g.win32.vc10.debug.tar.gz](https://root.cern/download/root_v5.28.00g.win32.vc10.debug.tar.gz) | 145M |
+| root_v5.28.00g.Windows Visual Studio 10 | [root_v5.28.00g.win32.vc10.tar.gz](https://root.cern/download/root_v5.28.00g.win32.vc10.tar.gz) |  56M |
+| root_v5.28.00g.Windows Visual Studio 90 (dbg) | [root_v5.28.00g.win32.vc90.debug.tar.gz](https://root.cern/download/root_v5.28.00g.win32.vc90.debug.tar.gz) | 140M |
+| root_v5.28.00g.Windows Visual Studio 90 | [root_v5.28.00g.win32.vc90.tar.gz](https://root.cern/download/root_v5.28.00g.win32.vc90.tar.gz) |  54M |
 
 
 
@@ -172,7 +172,7 @@ To use ROOT directly from AFS:
 The entire ROOT source can be obtained from our public Git repository:
 
 ~~~
-git clone http://root.cern.ch/git/root.git
+git clone http://root.cern/git/root.git
 ~~~
 The release specific tag can be obtained using:
 ~~~

--- a/_releases/release-52800a.md
+++ b/_releases/release-52800a.md
@@ -15,27 +15,27 @@ sidebar:
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v5.28.00a.source.tar.gz](https://root.cern.ch/download/root_v5.28.00a.source.tar.gz) |  28M |
+| source | [root_v5.28.00a.source.tar.gz](https://root.cern/download/root_v5.28.00a.source.tar.gz) |  28M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| Linux slc4 gcc3.4 | [root_v5.28.00a.Linux-slc4-gcc3.4.tar.gz](https://root.cern.ch/download/root_v5.28.00a.Linux-slc4-gcc3.4.tar.gz) |  54M |
-| Linux slc4_amd64 gcc3.4 | [root_v5.28.00a.Linux-slc4_amd64-gcc3.4.tar.gz](https://root.cern.ch/download/root_v5.28.00a.Linux-slc4_amd64-gcc3.4.tar.gz) |  56M |
-| Linux slc5 gcc4.3 | [root_v5.28.00a.Linux-slc5-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.28.00a.Linux-slc5-gcc4.3.tar.gz) |  54M |
-| Linux slc5_amd64 gcc4.3 | [root_v5.28.00a.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.28.00a.Linux-slc5_amd64-gcc4.3.tar.gz) |  55M |
-| macosx powerpc gcc 4.0 | [root_v5.28.00a.macosx-powerpc-gcc-4.0.tar.gz](https://root.cern.ch/download/root_v5.28.00a.macosx-powerpc-gcc-4.0.tar.gz) |  43M |
-| macosx106 i386 gcc 4.2 | [root_v5.28.00a.macosx106-i386-gcc-4.2.tar.gz](https://root.cern.ch/download/root_v5.28.00a.macosx106-i386-gcc-4.2.tar.gz) |  44M |
-| macosx106 gcc 4.2 | [root_v5.28.00a.macosx106-x86_64-gcc-4.2.tar.gz](https://root.cern.ch/download/root_v5.28.00a.macosx106-x86_64-gcc-4.2.tar.gz) |  44M |
-| win32 (dbg) | [root_v5.28.00a.win32.debug.tar.gz](https://root.cern.ch/download/root_v5.28.00a.win32.debug.tar.gz) | 108M |
-| win32 | [root_v5.28.00a.win32.tar.gz](https://root.cern.ch/download/root_v5.28.00a.win32.tar.gz) |  53M |
-| Windows Visual Studio 10 (dbg) | [root_v5.28.00a.win32.vc10.debug.tar.gz](https://root.cern.ch/download/root_v5.28.00a.win32.vc10.debug.tar.gz) | 144M |
-| Windows Visual Studio 10 | [root_v5.28.00a.win32.vc10.tar.gz](https://root.cern.ch/download/root_v5.28.00a.win32.vc10.tar.gz) |  56M |
-| Windows Visual Studio 90 (dbg) | [root_v5.28.00a.win32.vc90.debug.tar.gz](https://root.cern.ch/download/root_v5.28.00a.win32.vc90.debug.tar.gz) | 140M |
-| Windows Visual Studio 90 | [root_v5.28.00a.win32.vc90.tar.gz](https://root.cern.ch/download/root_v5.28.00a.win32.vc90.tar.gz) |  54M |
-| win32gcc gcc 4.3 | [root_v5.28.00a.win32gcc-gcc-4.3.tar.gz](https://root.cern.ch/download/root_v5.28.00a.win32gcc-gcc-4.3.tar.gz) |  42M |
+| Linux slc4 gcc3.4 | [root_v5.28.00a.Linux-slc4-gcc3.4.tar.gz](https://root.cern/download/root_v5.28.00a.Linux-slc4-gcc3.4.tar.gz) |  54M |
+| Linux slc4_amd64 gcc3.4 | [root_v5.28.00a.Linux-slc4_amd64-gcc3.4.tar.gz](https://root.cern/download/root_v5.28.00a.Linux-slc4_amd64-gcc3.4.tar.gz) |  56M |
+| Linux slc5 gcc4.3 | [root_v5.28.00a.Linux-slc5-gcc4.3.tar.gz](https://root.cern/download/root_v5.28.00a.Linux-slc5-gcc4.3.tar.gz) |  54M |
+| Linux slc5_amd64 gcc4.3 | [root_v5.28.00a.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern/download/root_v5.28.00a.Linux-slc5_amd64-gcc4.3.tar.gz) |  55M |
+| macosx powerpc gcc 4.0 | [root_v5.28.00a.macosx-powerpc-gcc-4.0.tar.gz](https://root.cern/download/root_v5.28.00a.macosx-powerpc-gcc-4.0.tar.gz) |  43M |
+| macosx106 i386 gcc 4.2 | [root_v5.28.00a.macosx106-i386-gcc-4.2.tar.gz](https://root.cern/download/root_v5.28.00a.macosx106-i386-gcc-4.2.tar.gz) |  44M |
+| macosx106 gcc 4.2 | [root_v5.28.00a.macosx106-x86_64-gcc-4.2.tar.gz](https://root.cern/download/root_v5.28.00a.macosx106-x86_64-gcc-4.2.tar.gz) |  44M |
+| win32 (dbg) | [root_v5.28.00a.win32.debug.tar.gz](https://root.cern/download/root_v5.28.00a.win32.debug.tar.gz) | 108M |
+| win32 | [root_v5.28.00a.win32.tar.gz](https://root.cern/download/root_v5.28.00a.win32.tar.gz) |  53M |
+| Windows Visual Studio 10 (dbg) | [root_v5.28.00a.win32.vc10.debug.tar.gz](https://root.cern/download/root_v5.28.00a.win32.vc10.debug.tar.gz) | 144M |
+| Windows Visual Studio 10 | [root_v5.28.00a.win32.vc10.tar.gz](https://root.cern/download/root_v5.28.00a.win32.vc10.tar.gz) |  56M |
+| Windows Visual Studio 90 (dbg) | [root_v5.28.00a.win32.vc90.debug.tar.gz](https://root.cern/download/root_v5.28.00a.win32.vc90.debug.tar.gz) | 140M |
+| Windows Visual Studio 90 | [root_v5.28.00a.win32.vc90.tar.gz](https://root.cern/download/root_v5.28.00a.win32.vc90.tar.gz) |  54M |
+| win32gcc gcc 4.3 | [root_v5.28.00a.win32gcc-gcc-4.3.tar.gz](https://root.cern/download/root_v5.28.00a.win32gcc-gcc-4.3.tar.gz) |  42M |
 
 
 
@@ -76,7 +76,7 @@ To use ROOT directly from AFS:
 The entire ROOT source can be obtained from our public Git repository:
 
 ~~~
-git clone http://root.cern.ch/git/root.git
+git clone http://root.cern/git/root.git
 ~~~
 The release specific tag can be obtained using:
 ~~~

--- a/_releases/release-52800b.md
+++ b/_releases/release-52800b.md
@@ -15,27 +15,27 @@ sidebar:
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v5.28.00b.source.tar.gz](https://root.cern.ch/download/root_v5.28.00b.source.tar.gz) |  28M |
+| source | [root_v5.28.00b.source.tar.gz](https://root.cern/download/root_v5.28.00b.source.tar.gz) |  28M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| Linux slc4 gcc3.4 | [root_v5.28.00b.Linux-slc4-gcc3.4.tar.gz](https://root.cern.ch/download/root_v5.28.00b.Linux-slc4-gcc3.4.tar.gz) |  54M |
-| Linux slc4_amd64 gcc3.4 | [root_v5.28.00b.Linux-slc4_amd64-gcc3.4.tar.gz](https://root.cern.ch/download/root_v5.28.00b.Linux-slc4_amd64-gcc3.4.tar.gz) |  56M |
-| Linux slc5 gcc4.3 | [root_v5.28.00b.Linux-slc5-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.28.00b.Linux-slc5-gcc4.3.tar.gz) |  54M |
-| Linux slc5_amd64 gcc4.3 | [root_v5.28.00b.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.28.00b.Linux-slc5_amd64-gcc4.3.tar.gz) |  55M |
-| macosx powerpc gcc 4.0 | [root_v5.28.00b.macosx-powerpc-gcc-4.0.tar.gz](https://root.cern.ch/download/root_v5.28.00b.macosx-powerpc-gcc-4.0.tar.gz) |  43M |
-| macosx106 i386 gcc 4.2 | [root_v5.28.00b.macosx106-i386-gcc-4.2.tar.gz](https://root.cern.ch/download/root_v5.28.00b.macosx106-i386-gcc-4.2.tar.gz) |  44M |
-| macosx106 gcc 4.2 | [root_v5.28.00b.macosx106-x86_64-gcc-4.2.tar.gz](https://root.cern.ch/download/root_v5.28.00b.macosx106-x86_64-gcc-4.2.tar.gz) |  44M |
-| win32 (dbg) | [root_v5.28.00b.win32.debug.tar.gz](https://root.cern.ch/download/root_v5.28.00b.win32.debug.tar.gz) | 108M |
-| win32 | [root_v5.28.00b.win32.tar.gz](https://root.cern.ch/download/root_v5.28.00b.win32.tar.gz) |  53M |
-| Windows Visual Studio 10 (dbg) | [root_v5.28.00b.win32.vc10.debug.tar.gz](https://root.cern.ch/download/root_v5.28.00b.win32.vc10.debug.tar.gz) | 144M |
-| Windows Visual Studio 10 | [root_v5.28.00b.win32.vc10.tar.gz](https://root.cern.ch/download/root_v5.28.00b.win32.vc10.tar.gz) |  56M |
-| Windows Visual Studio 90 (dbg) | [root_v5.28.00b.win32.vc90.debug.tar.gz](https://root.cern.ch/download/root_v5.28.00b.win32.vc90.debug.tar.gz) | 140M |
-| Windows Visual Studio 90 | [root_v5.28.00b.win32.vc90.tar.gz](https://root.cern.ch/download/root_v5.28.00b.win32.vc90.tar.gz) |  54M |
-| win32gcc gcc 4.3 | [root_v5.28.00b.win32gcc-gcc-4.3.tar.gz](https://root.cern.ch/download/root_v5.28.00b.win32gcc-gcc-4.3.tar.gz) |  42M |
+| Linux slc4 gcc3.4 | [root_v5.28.00b.Linux-slc4-gcc3.4.tar.gz](https://root.cern/download/root_v5.28.00b.Linux-slc4-gcc3.4.tar.gz) |  54M |
+| Linux slc4_amd64 gcc3.4 | [root_v5.28.00b.Linux-slc4_amd64-gcc3.4.tar.gz](https://root.cern/download/root_v5.28.00b.Linux-slc4_amd64-gcc3.4.tar.gz) |  56M |
+| Linux slc5 gcc4.3 | [root_v5.28.00b.Linux-slc5-gcc4.3.tar.gz](https://root.cern/download/root_v5.28.00b.Linux-slc5-gcc4.3.tar.gz) |  54M |
+| Linux slc5_amd64 gcc4.3 | [root_v5.28.00b.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern/download/root_v5.28.00b.Linux-slc5_amd64-gcc4.3.tar.gz) |  55M |
+| macosx powerpc gcc 4.0 | [root_v5.28.00b.macosx-powerpc-gcc-4.0.tar.gz](https://root.cern/download/root_v5.28.00b.macosx-powerpc-gcc-4.0.tar.gz) |  43M |
+| macosx106 i386 gcc 4.2 | [root_v5.28.00b.macosx106-i386-gcc-4.2.tar.gz](https://root.cern/download/root_v5.28.00b.macosx106-i386-gcc-4.2.tar.gz) |  44M |
+| macosx106 gcc 4.2 | [root_v5.28.00b.macosx106-x86_64-gcc-4.2.tar.gz](https://root.cern/download/root_v5.28.00b.macosx106-x86_64-gcc-4.2.tar.gz) |  44M |
+| win32 (dbg) | [root_v5.28.00b.win32.debug.tar.gz](https://root.cern/download/root_v5.28.00b.win32.debug.tar.gz) | 108M |
+| win32 | [root_v5.28.00b.win32.tar.gz](https://root.cern/download/root_v5.28.00b.win32.tar.gz) |  53M |
+| Windows Visual Studio 10 (dbg) | [root_v5.28.00b.win32.vc10.debug.tar.gz](https://root.cern/download/root_v5.28.00b.win32.vc10.debug.tar.gz) | 144M |
+| Windows Visual Studio 10 | [root_v5.28.00b.win32.vc10.tar.gz](https://root.cern/download/root_v5.28.00b.win32.vc10.tar.gz) |  56M |
+| Windows Visual Studio 90 (dbg) | [root_v5.28.00b.win32.vc90.debug.tar.gz](https://root.cern/download/root_v5.28.00b.win32.vc90.debug.tar.gz) | 140M |
+| Windows Visual Studio 90 | [root_v5.28.00b.win32.vc90.tar.gz](https://root.cern/download/root_v5.28.00b.win32.vc90.tar.gz) |  54M |
+| win32gcc gcc 4.3 | [root_v5.28.00b.win32gcc-gcc-4.3.tar.gz](https://root.cern/download/root_v5.28.00b.win32gcc-gcc-4.3.tar.gz) |  42M |
 
 
 
@@ -72,7 +72,7 @@ To use ROOT directly from AFS:
 The entire ROOT source can be obtained from our public Git repository:
 
 ~~~
-git clone http://root.cern.ch/git/root.git
+git clone http://root.cern/git/root.git
 ~~~
 The release specific tag can be obtained using:
 ~~~

--- a/_releases/release-52800c.md
+++ b/_releases/release-52800c.md
@@ -15,27 +15,27 @@ sidebar:
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v5.28.00c.source.tar.gz](https://root.cern.ch/download/root_v5.28.00c.source.tar.gz) |  28M |
+| source | [root_v5.28.00c.source.tar.gz](https://root.cern/download/root_v5.28.00c.source.tar.gz) |  28M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| Linux slc4 gcc3.4 | [root_v5.28.00c.Linux-slc4-gcc3.4.tar.gz](https://root.cern.ch/download/root_v5.28.00c.Linux-slc4-gcc3.4.tar.gz) |  54M |
-| Linux slc4_amd64 gcc3.4 | [root_v5.28.00c.Linux-slc4_amd64-gcc3.4.tar.gz](https://root.cern.ch/download/root_v5.28.00c.Linux-slc4_amd64-gcc3.4.tar.gz) |  56M |
-| Linux slc5 gcc4.3 | [root_v5.28.00c.Linux-slc5-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.28.00c.Linux-slc5-gcc4.3.tar.gz) |  54M |
-| Linux slc5_amd64 gcc4.3 | [root_v5.28.00c.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.28.00c.Linux-slc5_amd64-gcc4.3.tar.gz) |  55M |
-| macosx powerpc gcc 4.0 | [root_v5.28.00c.macosx-powerpc-gcc-4.0.tar.gz](https://root.cern.ch/download/root_v5.28.00c.macosx-powerpc-gcc-4.0.tar.gz) |  43M |
-| macosx106 i386 gcc 4.2 | [root_v5.28.00c.macosx106-i386-gcc-4.2.tar.gz](https://root.cern.ch/download/root_v5.28.00c.macosx106-i386-gcc-4.2.tar.gz) |  44M |
-| macosx106 gcc 4.2 | [root_v5.28.00c.macosx106-x86_64-gcc-4.2.tar.gz](https://root.cern.ch/download/root_v5.28.00c.macosx106-x86_64-gcc-4.2.tar.gz) |  44M |
-| win32 (dbg) | [root_v5.28.00c.win32.debug.tar.gz](https://root.cern.ch/download/root_v5.28.00c.win32.debug.tar.gz) | 108M |
-| win32 | [root_v5.28.00c.win32.tar.gz](https://root.cern.ch/download/root_v5.28.00c.win32.tar.gz) |  53M |
-| Windows Visual Studio 10 (dbg) | [root_v5.28.00c.win32.vc10.debug.tar.gz](https://root.cern.ch/download/root_v5.28.00c.win32.vc10.debug.tar.gz) | 143M |
-| Windows Visual Studio 10 | [root_v5.28.00c.win32.vc10.tar.gz](https://root.cern.ch/download/root_v5.28.00c.win32.vc10.tar.gz) |  55M |
-| Windows Visual Studio 90 (dbg) | [root_v5.28.00c.win32.vc90.debug.tar.gz](https://root.cern.ch/download/root_v5.28.00c.win32.vc90.debug.tar.gz) | 140M |
-| Windows Visual Studio 90 | [root_v5.28.00c.win32.vc90.tar.gz](https://root.cern.ch/download/root_v5.28.00c.win32.vc90.tar.gz) |  54M |
-| win32gcc gcc 4.3 | [root_v5.28.00c.win32gcc-gcc-4.3.tar.gz](https://root.cern.ch/download/root_v5.28.00c.win32gcc-gcc-4.3.tar.gz) |  42M |
+| Linux slc4 gcc3.4 | [root_v5.28.00c.Linux-slc4-gcc3.4.tar.gz](https://root.cern/download/root_v5.28.00c.Linux-slc4-gcc3.4.tar.gz) |  54M |
+| Linux slc4_amd64 gcc3.4 | [root_v5.28.00c.Linux-slc4_amd64-gcc3.4.tar.gz](https://root.cern/download/root_v5.28.00c.Linux-slc4_amd64-gcc3.4.tar.gz) |  56M |
+| Linux slc5 gcc4.3 | [root_v5.28.00c.Linux-slc5-gcc4.3.tar.gz](https://root.cern/download/root_v5.28.00c.Linux-slc5-gcc4.3.tar.gz) |  54M |
+| Linux slc5_amd64 gcc4.3 | [root_v5.28.00c.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern/download/root_v5.28.00c.Linux-slc5_amd64-gcc4.3.tar.gz) |  55M |
+| macosx powerpc gcc 4.0 | [root_v5.28.00c.macosx-powerpc-gcc-4.0.tar.gz](https://root.cern/download/root_v5.28.00c.macosx-powerpc-gcc-4.0.tar.gz) |  43M |
+| macosx106 i386 gcc 4.2 | [root_v5.28.00c.macosx106-i386-gcc-4.2.tar.gz](https://root.cern/download/root_v5.28.00c.macosx106-i386-gcc-4.2.tar.gz) |  44M |
+| macosx106 gcc 4.2 | [root_v5.28.00c.macosx106-x86_64-gcc-4.2.tar.gz](https://root.cern/download/root_v5.28.00c.macosx106-x86_64-gcc-4.2.tar.gz) |  44M |
+| win32 (dbg) | [root_v5.28.00c.win32.debug.tar.gz](https://root.cern/download/root_v5.28.00c.win32.debug.tar.gz) | 108M |
+| win32 | [root_v5.28.00c.win32.tar.gz](https://root.cern/download/root_v5.28.00c.win32.tar.gz) |  53M |
+| Windows Visual Studio 10 (dbg) | [root_v5.28.00c.win32.vc10.debug.tar.gz](https://root.cern/download/root_v5.28.00c.win32.vc10.debug.tar.gz) | 143M |
+| Windows Visual Studio 10 | [root_v5.28.00c.win32.vc10.tar.gz](https://root.cern/download/root_v5.28.00c.win32.vc10.tar.gz) |  55M |
+| Windows Visual Studio 90 (dbg) | [root_v5.28.00c.win32.vc90.debug.tar.gz](https://root.cern/download/root_v5.28.00c.win32.vc90.debug.tar.gz) | 140M |
+| Windows Visual Studio 90 | [root_v5.28.00c.win32.vc90.tar.gz](https://root.cern/download/root_v5.28.00c.win32.vc90.tar.gz) |  54M |
+| win32gcc gcc 4.3 | [root_v5.28.00c.win32gcc-gcc-4.3.tar.gz](https://root.cern/download/root_v5.28.00c.win32gcc-gcc-4.3.tar.gz) |  42M |
 
 
 
@@ -71,7 +71,7 @@ To use ROOT directly from AFS:
 The entire ROOT source can be obtained from our public Git repository:
 
 ~~~
-git clone http://root.cern.ch/git/root.git
+git clone http://root.cern/git/root.git
 ~~~
 The release specific tag can be obtained using:
 ~~~

--- a/_releases/release-52800d.md
+++ b/_releases/release-52800d.md
@@ -15,26 +15,26 @@ sidebar:
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v5.28.00d.source.tar.gz](https://root.cern.ch/download/root_v5.28.00d.source.tar.gz) |  30M |
+| source | [root_v5.28.00d.source.tar.gz](https://root.cern/download/root_v5.28.00d.source.tar.gz) |  30M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| Linux slc4 gcc3.4 | [root_v5.28.00d.Linux-slc4-gcc3.4.tar.gz](https://root.cern.ch/download/root_v5.28.00d.Linux-slc4-gcc3.4.tar.gz) |  54M |
-| Linux slc4_amd64 gcc3.4 | [root_v5.28.00d.Linux-slc4_amd64-gcc3.4.tar.gz](https://root.cern.ch/download/root_v5.28.00d.Linux-slc4_amd64-gcc3.4.tar.gz) |  56M |
-| Linux slc5 gcc4.3 | [root_v5.28.00d.Linux-slc5-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.28.00d.Linux-slc5-gcc4.3.tar.gz) |  54M |
-| Linux slc5_amd64 gcc4.3 | [root_v5.28.00d.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.28.00d.Linux-slc5_amd64-gcc4.3.tar.gz) |  55M |
-| macosx106 i386 gcc 4.2 | [root_v5.28.00d.macosx106-i386-gcc-4.2.tar.gz](https://root.cern.ch/download/root_v5.28.00d.macosx106-i386-gcc-4.2.tar.gz) |  44M |
-| macosx106 gcc 4.2 | [root_v5.28.00d.macosx106-x86_64-gcc-4.2.tar.gz](https://root.cern.ch/download/root_v5.28.00d.macosx106-x86_64-gcc-4.2.tar.gz) |  44M |
-| win32 (dbg) | [root_v5.28.00d.win32.debug.tar.gz](https://root.cern.ch/download/root_v5.28.00d.win32.debug.tar.gz) | 108M |
-| win32 | [root_v5.28.00d.win32.tar.gz](https://root.cern.ch/download/root_v5.28.00d.win32.tar.gz) |  53M |
-| Windows Visual Studio 10 (dbg) | [root_v5.28.00d.win32.vc10.debug.tar.gz](https://root.cern.ch/download/root_v5.28.00d.win32.vc10.debug.tar.gz) | 145M |
-| Windows Visual Studio 10 | [root_v5.28.00d.win32.vc10.tar.gz](https://root.cern.ch/download/root_v5.28.00d.win32.vc10.tar.gz) |  56M |
-| Windows Visual Studio 90 (dbg) | [root_v5.28.00d.win32.vc90.debug.tar.gz](https://root.cern.ch/download/root_v5.28.00d.win32.vc90.debug.tar.gz) | 140M |
-| Windows Visual Studio 90 | [root_v5.28.00d.win32.vc90.tar.gz](https://root.cern.ch/download/root_v5.28.00d.win32.vc90.tar.gz) |  54M |
-| win32gcc gcc 4.3 | [root_v5.28.00d.win32gcc-gcc-4.3.tar.gz](https://root.cern.ch/download/root_v5.28.00d.win32gcc-gcc-4.3.tar.gz) |  42M |
+| Linux slc4 gcc3.4 | [root_v5.28.00d.Linux-slc4-gcc3.4.tar.gz](https://root.cern/download/root_v5.28.00d.Linux-slc4-gcc3.4.tar.gz) |  54M |
+| Linux slc4_amd64 gcc3.4 | [root_v5.28.00d.Linux-slc4_amd64-gcc3.4.tar.gz](https://root.cern/download/root_v5.28.00d.Linux-slc4_amd64-gcc3.4.tar.gz) |  56M |
+| Linux slc5 gcc4.3 | [root_v5.28.00d.Linux-slc5-gcc4.3.tar.gz](https://root.cern/download/root_v5.28.00d.Linux-slc5-gcc4.3.tar.gz) |  54M |
+| Linux slc5_amd64 gcc4.3 | [root_v5.28.00d.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern/download/root_v5.28.00d.Linux-slc5_amd64-gcc4.3.tar.gz) |  55M |
+| macosx106 i386 gcc 4.2 | [root_v5.28.00d.macosx106-i386-gcc-4.2.tar.gz](https://root.cern/download/root_v5.28.00d.macosx106-i386-gcc-4.2.tar.gz) |  44M |
+| macosx106 gcc 4.2 | [root_v5.28.00d.macosx106-x86_64-gcc-4.2.tar.gz](https://root.cern/download/root_v5.28.00d.macosx106-x86_64-gcc-4.2.tar.gz) |  44M |
+| win32 (dbg) | [root_v5.28.00d.win32.debug.tar.gz](https://root.cern/download/root_v5.28.00d.win32.debug.tar.gz) | 108M |
+| win32 | [root_v5.28.00d.win32.tar.gz](https://root.cern/download/root_v5.28.00d.win32.tar.gz) |  53M |
+| Windows Visual Studio 10 (dbg) | [root_v5.28.00d.win32.vc10.debug.tar.gz](https://root.cern/download/root_v5.28.00d.win32.vc10.debug.tar.gz) | 145M |
+| Windows Visual Studio 10 | [root_v5.28.00d.win32.vc10.tar.gz](https://root.cern/download/root_v5.28.00d.win32.vc10.tar.gz) |  56M |
+| Windows Visual Studio 90 (dbg) | [root_v5.28.00d.win32.vc90.debug.tar.gz](https://root.cern/download/root_v5.28.00d.win32.vc90.debug.tar.gz) | 140M |
+| Windows Visual Studio 90 | [root_v5.28.00d.win32.vc90.tar.gz](https://root.cern/download/root_v5.28.00d.win32.vc90.tar.gz) |  54M |
+| win32gcc gcc 4.3 | [root_v5.28.00d.win32gcc-gcc-4.3.tar.gz](https://root.cern/download/root_v5.28.00d.win32gcc-gcc-4.3.tar.gz) |  42M |
 
 
 
@@ -70,7 +70,7 @@ To use ROOT directly from AFS:
 The entire ROOT source can be obtained from our public Git repository:
 
 ~~~
-git clone http://root.cern.ch/git/root.git
+git clone http://root.cern/git/root.git
 ~~~
 The release specific tag can be obtained using:
 ~~~

--- a/_releases/release-52800e.md
+++ b/_releases/release-52800e.md
@@ -15,23 +15,23 @@ sidebar:
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v5.28.00e.source.tar.gz](https://root.cern.ch/download/root_v5.28.00e.source.tar.gz) |  30M |
+| source | [root_v5.28.00e.source.tar.gz](https://root.cern/download/root_v5.28.00e.source.tar.gz) |  30M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| Linux slc5 gcc4.3 | [root_v5.28.00e.Linux-slc5-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.28.00e.Linux-slc5-gcc4.3.tar.gz) |  54M |
-| Linux slc5_amd64 gcc4.3 | [root_v5.28.00e.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.28.00e.Linux-slc5_amd64-gcc4.3.tar.gz) |  55M |
-| macosx106 i386 gcc 4.2 | [root_v5.28.00e.macosx106-i386-gcc-4.2.tar.gz](https://root.cern.ch/download/root_v5.28.00e.macosx106-i386-gcc-4.2.tar.gz) |  44M |
-| macosx106 gcc 4.2 | [root_v5.28.00e.macosx106-x86_64-gcc-4.2.tar.gz](https://root.cern.ch/download/root_v5.28.00e.macosx106-x86_64-gcc-4.2.tar.gz) |  44M |
-| win32 (dbg) | [root_v5.28.00e.win32.debug.tar.gz](https://root.cern.ch/download/root_v5.28.00e.win32.debug.tar.gz) | 108M |
-| win32 | [root_v5.28.00e.win32.tar.gz](https://root.cern.ch/download/root_v5.28.00e.win32.tar.gz) |  53M |
-| Windows Visual Studio 10 (dbg) | [root_v5.28.00e.win32.vc10.debug.tar.gz](https://root.cern.ch/download/root_v5.28.00e.win32.vc10.debug.tar.gz) | 145M |
-| Windows Visual Studio 10 | [root_v5.28.00e.win32.vc10.tar.gz](https://root.cern.ch/download/root_v5.28.00e.win32.vc10.tar.gz) |  56M |
-| Windows Visual Studio 90 (dbg) | [root_v5.28.00e.win32.vc90.debug.tar.gz](https://root.cern.ch/download/root_v5.28.00e.win32.vc90.debug.tar.gz) | 140M |
-| Windows Visual Studio 90 | [root_v5.28.00e.win32.vc90.tar.gz](https://root.cern.ch/download/root_v5.28.00e.win32.vc90.tar.gz) |  54M |
+| Linux slc5 gcc4.3 | [root_v5.28.00e.Linux-slc5-gcc4.3.tar.gz](https://root.cern/download/root_v5.28.00e.Linux-slc5-gcc4.3.tar.gz) |  54M |
+| Linux slc5_amd64 gcc4.3 | [root_v5.28.00e.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern/download/root_v5.28.00e.Linux-slc5_amd64-gcc4.3.tar.gz) |  55M |
+| macosx106 i386 gcc 4.2 | [root_v5.28.00e.macosx106-i386-gcc-4.2.tar.gz](https://root.cern/download/root_v5.28.00e.macosx106-i386-gcc-4.2.tar.gz) |  44M |
+| macosx106 gcc 4.2 | [root_v5.28.00e.macosx106-x86_64-gcc-4.2.tar.gz](https://root.cern/download/root_v5.28.00e.macosx106-x86_64-gcc-4.2.tar.gz) |  44M |
+| win32 (dbg) | [root_v5.28.00e.win32.debug.tar.gz](https://root.cern/download/root_v5.28.00e.win32.debug.tar.gz) | 108M |
+| win32 | [root_v5.28.00e.win32.tar.gz](https://root.cern/download/root_v5.28.00e.win32.tar.gz) |  53M |
+| Windows Visual Studio 10 (dbg) | [root_v5.28.00e.win32.vc10.debug.tar.gz](https://root.cern/download/root_v5.28.00e.win32.vc10.debug.tar.gz) | 145M |
+| Windows Visual Studio 10 | [root_v5.28.00e.win32.vc10.tar.gz](https://root.cern/download/root_v5.28.00e.win32.vc10.tar.gz) |  56M |
+| Windows Visual Studio 90 (dbg) | [root_v5.28.00e.win32.vc90.debug.tar.gz](https://root.cern/download/root_v5.28.00e.win32.vc90.debug.tar.gz) | 140M |
+| Windows Visual Studio 90 | [root_v5.28.00e.win32.vc90.tar.gz](https://root.cern/download/root_v5.28.00e.win32.vc90.tar.gz) |  54M |
 
 
 
@@ -68,7 +68,7 @@ To use ROOT directly from AFS:
 The entire ROOT source can be obtained from our public Git repository:
 
 ~~~
-git clone http://root.cern.ch/git/root.git
+git clone http://root.cern/git/root.git
 ~~~
 The release specific tag can be obtained using:
 ~~~

--- a/_releases/release-52800f.md
+++ b/_releases/release-52800f.md
@@ -15,23 +15,23 @@ sidebar:
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v5.28.00f.source.tar.gz](https://root.cern.ch/download/root_v5.28.00f.source.tar.gz) |  30M |
+| source | [root_v5.28.00f.source.tar.gz](https://root.cern/download/root_v5.28.00f.source.tar.gz) |  30M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| Linux slc5 gcc4.3 | [root_v5.28.00f.Linux-slc5-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.28.00f.Linux-slc5-gcc4.3.tar.gz) |  54M |
-| Linux slc5_amd64 gcc4.3 | [root_v5.28.00f.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.28.00f.Linux-slc5_amd64-gcc4.3.tar.gz) |  55M |
-| macosx106 i386 gcc 4.2 | [root_v5.28.00f.macosx106-i386-gcc-4.2.tar.gz](https://root.cern.ch/download/root_v5.28.00f.macosx106-i386-gcc-4.2.tar.gz) |  44M |
-| macosx106 gcc 4.2 | [root_v5.28.00f.macosx106-x86_64-gcc-4.2.tar.gz](https://root.cern.ch/download/root_v5.28.00f.macosx106-x86_64-gcc-4.2.tar.gz) |  44M |
-| win32 (dbg) | [root_v5.28.00f.win32.debug.tar.gz](https://root.cern.ch/download/root_v5.28.00f.win32.debug.tar.gz) | 108M |
-| win32 | [root_v5.28.00f.win32.tar.gz](https://root.cern.ch/download/root_v5.28.00f.win32.tar.gz) |  53M |
-| Windows Visual Studio 10 (dbg) | [root_v5.28.00f.win32.vc10.debug.tar.gz](https://root.cern.ch/download/root_v5.28.00f.win32.vc10.debug.tar.gz) | 145M |
-| Windows Visual Studio 10 | [root_v5.28.00f.win32.vc10.tar.gz](https://root.cern.ch/download/root_v5.28.00f.win32.vc10.tar.gz) |  56M |
-| Windows Visual Studio 90 (dbg) | [root_v5.28.00f.win32.vc90.debug.tar.gz](https://root.cern.ch/download/root_v5.28.00f.win32.vc90.debug.tar.gz) | 140M |
-| Windows Visual Studio 90 | [root_v5.28.00f.win32.vc90.tar.gz](https://root.cern.ch/download/root_v5.28.00f.win32.vc90.tar.gz) |  54M |
+| Linux slc5 gcc4.3 | [root_v5.28.00f.Linux-slc5-gcc4.3.tar.gz](https://root.cern/download/root_v5.28.00f.Linux-slc5-gcc4.3.tar.gz) |  54M |
+| Linux slc5_amd64 gcc4.3 | [root_v5.28.00f.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern/download/root_v5.28.00f.Linux-slc5_amd64-gcc4.3.tar.gz) |  55M |
+| macosx106 i386 gcc 4.2 | [root_v5.28.00f.macosx106-i386-gcc-4.2.tar.gz](https://root.cern/download/root_v5.28.00f.macosx106-i386-gcc-4.2.tar.gz) |  44M |
+| macosx106 gcc 4.2 | [root_v5.28.00f.macosx106-x86_64-gcc-4.2.tar.gz](https://root.cern/download/root_v5.28.00f.macosx106-x86_64-gcc-4.2.tar.gz) |  44M |
+| win32 (dbg) | [root_v5.28.00f.win32.debug.tar.gz](https://root.cern/download/root_v5.28.00f.win32.debug.tar.gz) | 108M |
+| win32 | [root_v5.28.00f.win32.tar.gz](https://root.cern/download/root_v5.28.00f.win32.tar.gz) |  53M |
+| Windows Visual Studio 10 (dbg) | [root_v5.28.00f.win32.vc10.debug.tar.gz](https://root.cern/download/root_v5.28.00f.win32.vc10.debug.tar.gz) | 145M |
+| Windows Visual Studio 10 | [root_v5.28.00f.win32.vc10.tar.gz](https://root.cern/download/root_v5.28.00f.win32.vc10.tar.gz) |  56M |
+| Windows Visual Studio 90 (dbg) | [root_v5.28.00f.win32.vc90.debug.tar.gz](https://root.cern/download/root_v5.28.00f.win32.vc90.debug.tar.gz) | 140M |
+| Windows Visual Studio 90 | [root_v5.28.00f.win32.vc90.tar.gz](https://root.cern/download/root_v5.28.00f.win32.vc90.tar.gz) |  54M |
 
 
 
@@ -67,7 +67,7 @@ To use ROOT directly from AFS:
 The entire ROOT source can be obtained from our public Git repository:
 
 ~~~
-git clone http://root.cern.ch/git/root.git
+git clone http://root.cern/git/root.git
 ~~~
 The release specific tag can be obtained using:
 ~~~

--- a/_releases/release-52800g.md
+++ b/_releases/release-52800g.md
@@ -15,23 +15,23 @@ sidebar:
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v5.28.00g.source.tar.gz](https://root.cern.ch/download/root_v5.28.00g.source.tar.gz) |  30M |
+| source | [root_v5.28.00g.source.tar.gz](https://root.cern/download/root_v5.28.00g.source.tar.gz) |  30M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| Linux slc5 gcc4.3 | [root_v5.28.00g.Linux-slc5-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.28.00g.Linux-slc5-gcc4.3.tar.gz) |  54M |
-| Linux slc5_amd64 gcc4.3 | [root_v5.28.00g.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.28.00g.Linux-slc5_amd64-gcc4.3.tar.gz) |  55M |
-| macosx106 i386 gcc 4.2 | [root_v5.28.00g.macosx106-i386-gcc-4.2.tar.gz](https://root.cern.ch/download/root_v5.28.00g.macosx106-i386-gcc-4.2.tar.gz) |  44M |
-| macosx106 gcc 4.2 | [root_v5.28.00g.macosx106-x86_64-gcc-4.2.tar.gz](https://root.cern.ch/download/root_v5.28.00g.macosx106-x86_64-gcc-4.2.tar.gz) |  44M |
-| win32 (dbg) | [root_v5.28.00g.win32.debug.tar.gz](https://root.cern.ch/download/root_v5.28.00g.win32.debug.tar.gz) | 108M |
-| win32 | [root_v5.28.00g.win32.tar.gz](https://root.cern.ch/download/root_v5.28.00g.win32.tar.gz) |  53M |
-| Windows Visual Studio 10 (dbg) | [root_v5.28.00g.win32.vc10.debug.tar.gz](https://root.cern.ch/download/root_v5.28.00g.win32.vc10.debug.tar.gz) | 145M |
-| Windows Visual Studio 10 | [root_v5.28.00g.win32.vc10.tar.gz](https://root.cern.ch/download/root_v5.28.00g.win32.vc10.tar.gz) |  56M |
-| Windows Visual Studio 90 (dbg) | [root_v5.28.00g.win32.vc90.debug.tar.gz](https://root.cern.ch/download/root_v5.28.00g.win32.vc90.debug.tar.gz) | 140M |
-| Windows Visual Studio 90 | [root_v5.28.00g.win32.vc90.tar.gz](https://root.cern.ch/download/root_v5.28.00g.win32.vc90.tar.gz) |  54M |
+| Linux slc5 gcc4.3 | [root_v5.28.00g.Linux-slc5-gcc4.3.tar.gz](https://root.cern/download/root_v5.28.00g.Linux-slc5-gcc4.3.tar.gz) |  54M |
+| Linux slc5_amd64 gcc4.3 | [root_v5.28.00g.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern/download/root_v5.28.00g.Linux-slc5_amd64-gcc4.3.tar.gz) |  55M |
+| macosx106 i386 gcc 4.2 | [root_v5.28.00g.macosx106-i386-gcc-4.2.tar.gz](https://root.cern/download/root_v5.28.00g.macosx106-i386-gcc-4.2.tar.gz) |  44M |
+| macosx106 gcc 4.2 | [root_v5.28.00g.macosx106-x86_64-gcc-4.2.tar.gz](https://root.cern/download/root_v5.28.00g.macosx106-x86_64-gcc-4.2.tar.gz) |  44M |
+| win32 (dbg) | [root_v5.28.00g.win32.debug.tar.gz](https://root.cern/download/root_v5.28.00g.win32.debug.tar.gz) | 108M |
+| win32 | [root_v5.28.00g.win32.tar.gz](https://root.cern/download/root_v5.28.00g.win32.tar.gz) |  53M |
+| Windows Visual Studio 10 (dbg) | [root_v5.28.00g.win32.vc10.debug.tar.gz](https://root.cern/download/root_v5.28.00g.win32.vc10.debug.tar.gz) | 145M |
+| Windows Visual Studio 10 | [root_v5.28.00g.win32.vc10.tar.gz](https://root.cern/download/root_v5.28.00g.win32.vc10.tar.gz) |  56M |
+| Windows Visual Studio 90 (dbg) | [root_v5.28.00g.win32.vc90.debug.tar.gz](https://root.cern/download/root_v5.28.00g.win32.vc90.debug.tar.gz) | 140M |
+| Windows Visual Studio 90 | [root_v5.28.00g.win32.vc90.tar.gz](https://root.cern/download/root_v5.28.00g.win32.vc90.tar.gz) |  54M |
 
 
 
@@ -67,7 +67,7 @@ To use ROOT directly from AFS:
 The entire ROOT source can be obtained from our public Git repository:
 
 ~~~
-git clone http://root.cern.ch/git/root.git
+git clone http://root.cern/git/root.git
 ~~~
 The release specific tag can be obtained using:
 ~~~

--- a/_releases/release-52800h.md
+++ b/_releases/release-52800h.md
@@ -15,7 +15,7 @@ sidebar:
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v5.28.00h.source.tar.gz](https://root.cern.ch/download/root_v5.28.00h.source.tar.gz) |  30M |
+| source | [root_v5.28.00h.source.tar.gz](https://root.cern/download/root_v5.28.00h.source.tar.gz) |  30M |
 
 
 ## Installations in AFS and CVMFS
@@ -43,7 +43,7 @@ To use ROOT directly from AFS:
 The entire ROOT source can be obtained from our public Git repository:
 
 ~~~
-git clone http://root.cern.ch/git/root.git
+git clone http://root.cern/git/root.git
 ~~~
 The release specific tag can be obtained using:
 ~~~

--- a/_releases/release-52902.md
+++ b/_releases/release-52902.md
@@ -15,27 +15,27 @@ sidebar:
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v5.29.02.source.tar.gz](https://root.cern.ch/download/root_v5.29.02.source.tar.gz) |  30M |
+| source | [root_v5.29.02.source.tar.gz](https://root.cern/download/root_v5.29.02.source.tar.gz) |  30M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| Linux slc4 gcc3.4 | [root_v5.29.02.Linux-slc4-gcc3.4.tar.gz](https://root.cern.ch/download/root_v5.29.02.Linux-slc4-gcc3.4.tar.gz) |  55M |
-| Linux slc4_amd64 gcc3.4 | [root_v5.29.02.Linux-slc4_amd64-gcc3.4.tar.gz](https://root.cern.ch/download/root_v5.29.02.Linux-slc4_amd64-gcc3.4.tar.gz) |  57M |
-| Linux slc5 gcc4.3 | [root_v5.29.02.Linux-slc5-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.29.02.Linux-slc5-gcc4.3.tar.gz) |  55M |
-| Linux slc5_amd64 gcc4.3 | [root_v5.29.02.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.29.02.Linux-slc5_amd64-gcc4.3.tar.gz) |  56M |
-| macosx powerpc gcc 4.0 | [root_v5.29.02.macosx-powerpc-gcc-4.0.tar.gz](https://root.cern.ch/download/root_v5.29.02.macosx-powerpc-gcc-4.0.tar.gz) |  43M |
-| macosx106 i386 gcc 4.2 | [root_v5.29.02.macosx106-i386-gcc-4.2.tar.gz](https://root.cern.ch/download/root_v5.29.02.macosx106-i386-gcc-4.2.tar.gz) |  45M |
-| macosx106 gcc 4.2 | [root_v5.29.02.macosx106-x86_64-gcc-4.2.tar.gz](https://root.cern.ch/download/root_v5.29.02.macosx106-x86_64-gcc-4.2.tar.gz) |  45M |
-| win32 (dbg) | [root_v5.29.02.win32.debug.tar.gz](https://root.cern.ch/download/root_v5.29.02.win32.debug.tar.gz) | 109M |
-| win32 | [root_v5.29.02.win32.tar.gz](https://root.cern.ch/download/root_v5.29.02.win32.tar.gz) |  54M |
-| Windows Visual Studio 10 (dbg) | [root_v5.29.02.win32.vc10.debug.tar.gz](https://root.cern.ch/download/root_v5.29.02.win32.vc10.debug.tar.gz) | 146M |
-| Windows Visual Studio 10 | [root_v5.29.02.win32.vc10.tar.gz](https://root.cern.ch/download/root_v5.29.02.win32.vc10.tar.gz) |  57M |
-| Windows Visual Studio 90 (dbg) | [root_v5.29.02.win32.vc90.debug.tar.gz](https://root.cern.ch/download/root_v5.29.02.win32.vc90.debug.tar.gz) | 142M |
-| Windows Visual Studio 90 | [root_v5.29.02.win32.vc90.tar.gz](https://root.cern.ch/download/root_v5.29.02.win32.vc90.tar.gz) |  55M |
-| win32gcc gcc 4.3 | [root_v5.29.02.win32gcc-gcc-4.3.tar.gz](https://root.cern.ch/download/root_v5.29.02.win32gcc-gcc-4.3.tar.gz) |  43M |
+| Linux slc4 gcc3.4 | [root_v5.29.02.Linux-slc4-gcc3.4.tar.gz](https://root.cern/download/root_v5.29.02.Linux-slc4-gcc3.4.tar.gz) |  55M |
+| Linux slc4_amd64 gcc3.4 | [root_v5.29.02.Linux-slc4_amd64-gcc3.4.tar.gz](https://root.cern/download/root_v5.29.02.Linux-slc4_amd64-gcc3.4.tar.gz) |  57M |
+| Linux slc5 gcc4.3 | [root_v5.29.02.Linux-slc5-gcc4.3.tar.gz](https://root.cern/download/root_v5.29.02.Linux-slc5-gcc4.3.tar.gz) |  55M |
+| Linux slc5_amd64 gcc4.3 | [root_v5.29.02.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern/download/root_v5.29.02.Linux-slc5_amd64-gcc4.3.tar.gz) |  56M |
+| macosx powerpc gcc 4.0 | [root_v5.29.02.macosx-powerpc-gcc-4.0.tar.gz](https://root.cern/download/root_v5.29.02.macosx-powerpc-gcc-4.0.tar.gz) |  43M |
+| macosx106 i386 gcc 4.2 | [root_v5.29.02.macosx106-i386-gcc-4.2.tar.gz](https://root.cern/download/root_v5.29.02.macosx106-i386-gcc-4.2.tar.gz) |  45M |
+| macosx106 gcc 4.2 | [root_v5.29.02.macosx106-x86_64-gcc-4.2.tar.gz](https://root.cern/download/root_v5.29.02.macosx106-x86_64-gcc-4.2.tar.gz) |  45M |
+| win32 (dbg) | [root_v5.29.02.win32.debug.tar.gz](https://root.cern/download/root_v5.29.02.win32.debug.tar.gz) | 109M |
+| win32 | [root_v5.29.02.win32.tar.gz](https://root.cern/download/root_v5.29.02.win32.tar.gz) |  54M |
+| Windows Visual Studio 10 (dbg) | [root_v5.29.02.win32.vc10.debug.tar.gz](https://root.cern/download/root_v5.29.02.win32.vc10.debug.tar.gz) | 146M |
+| Windows Visual Studio 10 | [root_v5.29.02.win32.vc10.tar.gz](https://root.cern/download/root_v5.29.02.win32.vc10.tar.gz) |  57M |
+| Windows Visual Studio 90 (dbg) | [root_v5.29.02.win32.vc90.debug.tar.gz](https://root.cern/download/root_v5.29.02.win32.vc90.debug.tar.gz) | 142M |
+| Windows Visual Studio 90 | [root_v5.29.02.win32.vc90.tar.gz](https://root.cern/download/root_v5.29.02.win32.vc90.tar.gz) |  55M |
+| win32gcc gcc 4.3 | [root_v5.29.02.win32gcc-gcc-4.3.tar.gz](https://root.cern/download/root_v5.29.02.win32gcc-gcc-4.3.tar.gz) |  43M |
 
 
 
@@ -71,7 +71,7 @@ To use ROOT directly from AFS:
 The entire ROOT source can be obtained from our public Git repository:
 
 ~~~
-git clone http://root.cern.ch/git/root.git
+git clone http://root.cern/git/root.git
 ~~~
 The release specific tag can be obtained using:
 ~~~

--- a/_releases/release-53000.md
+++ b/_releases/release-53000.md
@@ -19,46 +19,46 @@ The release notes for this release can be found [here]({{ '/install/all_releases
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| root_v5.30.00 rc1.source | [root_v5.30.00-rc1.source.tar.gz](https://root.cern.ch/download/root_v5.30.00-rc1.source.tar.gz) |  37M |
-| root_v5.30.00 rc2.source | [root_v5.30.00-rc2.source.tar.gz](https://root.cern.ch/download/root_v5.30.00-rc2.source.tar.gz) |  37M |
-| source | [root_v5.30.00.source.tar.gz](https://root.cern.ch/download/root_v5.30.00.source.tar.gz) |  39M |
+| root_v5.30.00 rc1.source | [root_v5.30.00-rc1.source.tar.gz](https://root.cern/download/root_v5.30.00-rc1.source.tar.gz) |  37M |
+| root_v5.30.00 rc2.source | [root_v5.30.00-rc2.source.tar.gz](https://root.cern/download/root_v5.30.00-rc2.source.tar.gz) |  37M |
+| source | [root_v5.30.00.source.tar.gz](https://root.cern/download/root_v5.30.00.source.tar.gz) |  39M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| root_v5.30.00 rc1.Linux slc5 gcc4.3 | [root_v5.30.00-rc1.Linux-slc5-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.30.00-rc1.Linux-slc5-gcc4.3.tar.gz) |  55M |
-| root_v5.30.00 rc1.Linux slc5_amd64 gcc4.3 | [root_v5.30.00-rc1.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.30.00-rc1.Linux-slc5_amd64-gcc4.3.tar.gz) |  56M |
-| root_v5.30.00 rc1.macosx106 i386 gcc 4.2 | [root_v5.30.00-rc1.macosx106-i386-gcc-4.2.tar.gz](https://root.cern.ch/download/root_v5.30.00-rc1.macosx106-i386-gcc-4.2.tar.gz) |  45M |
-| root_v5.30.00 rc1.macosx106 gcc 4.2 | [root_v5.30.00-rc1.macosx106-x86_64-gcc-4.2.tar.gz](https://root.cern.ch/download/root_v5.30.00-rc1.macosx106-x86_64-gcc-4.2.tar.gz) |  45M |
-| root_v5.30.00 rc1.win32 (dbg) | [root_v5.30.00-rc1.win32.debug.tar.gz](https://root.cern.ch/download/root_v5.30.00-rc1.win32.debug.tar.gz) | 109M |
-| root_v5.30.00 rc1.win32 | [root_v5.30.00-rc1.win32.tar.gz](https://root.cern.ch/download/root_v5.30.00-rc1.win32.tar.gz) |  54M |
-| root_v5.30.00 rc1.Windows Visual Studio 10 (dbg) | [root_v5.30.00-rc1.win32.vc10.debug.tar.gz](https://root.cern.ch/download/root_v5.30.00-rc1.win32.vc10.debug.tar.gz) | 147M |
-| root_v5.30.00 rc1.Windows Visual Studio 10 | [root_v5.30.00-rc1.win32.vc10.tar.gz](https://root.cern.ch/download/root_v5.30.00-rc1.win32.vc10.tar.gz) |  57M |
-| root_v5.30.00 rc1.Windows Visual Studio 90 (dbg) | [root_v5.30.00-rc1.win32.vc90.debug.tar.gz](https://root.cern.ch/download/root_v5.30.00-rc1.win32.vc90.debug.tar.gz) | 142M |
-| root_v5.30.00 rc1.Windows Visual Studio 90 | [root_v5.30.00-rc1.win32.vc90.tar.gz](https://root.cern.ch/download/root_v5.30.00-rc1.win32.vc90.tar.gz) |  55M |
-| root_v5.30.00 rc2.Linux slc5 gcc4.3 | [root_v5.30.00-rc2.Linux-slc5-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.30.00-rc2.Linux-slc5-gcc4.3.tar.gz) |  55M |
-| root_v5.30.00 rc2.Linux slc5_amd64 gcc4.3 | [root_v5.30.00-rc2.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.30.00-rc2.Linux-slc5_amd64-gcc4.3.tar.gz) |  56M |
-| root_v5.30.00 rc2.macosx106 i386 gcc 4.2 | [root_v5.30.00-rc2.macosx106-i386-gcc-4.2.tar.gz](https://root.cern.ch/download/root_v5.30.00-rc2.macosx106-i386-gcc-4.2.tar.gz) |  45M |
-| root_v5.30.00 rc2.macosx106 gcc 4.2 | [root_v5.30.00-rc2.macosx106-x86_64-gcc-4.2.tar.gz](https://root.cern.ch/download/root_v5.30.00-rc2.macosx106-x86_64-gcc-4.2.tar.gz) |  45M |
-| root_v5.30.00 rc2.win32 (dbg) | [root_v5.30.00-rc2.win32.debug.tar.gz](https://root.cern.ch/download/root_v5.30.00-rc2.win32.debug.tar.gz) | 109M |
-| root_v5.30.00 rc2.win32 | [root_v5.30.00-rc2.win32.tar.gz](https://root.cern.ch/download/root_v5.30.00-rc2.win32.tar.gz) |  54M |
-| root_v5.30.00 rc2.Windows Visual Studio 10 (dbg) | [root_v5.30.00-rc2.win32.vc10.debug.tar.gz](https://root.cern.ch/download/root_v5.30.00-rc2.win32.vc10.debug.tar.gz) | 147M |
-| root_v5.30.00 rc2.Windows Visual Studio 10 | [root_v5.30.00-rc2.win32.vc10.tar.gz](https://root.cern.ch/download/root_v5.30.00-rc2.win32.vc10.tar.gz) |  57M |
-| root_v5.30.00 rc2.Windows Visual Studio 90 (dbg) | [root_v5.30.00-rc2.win32.vc90.debug.tar.gz](https://root.cern.ch/download/root_v5.30.00-rc2.win32.vc90.debug.tar.gz) | 142M |
-| root_v5.30.00 rc2.Windows Visual Studio 90 | [root_v5.30.00-rc2.win32.vc90.tar.gz](https://root.cern.ch/download/root_v5.30.00-rc2.win32.vc90.tar.gz) |  55M |
-| Linux slc5 gcc4.3 | [root_v5.30.00.Linux-slc5-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.30.00.Linux-slc5-gcc4.3.tar.gz) |  55M |
-| Linux slc5_amd64 gcc4.3 | [root_v5.30.00.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.30.00.Linux-slc5_amd64-gcc4.3.tar.gz) |  56M |
-| macosx106 i386 gcc 4.2 | [root_v5.30.00.macosx106-i386-gcc-4.2.tar.gz](https://root.cern.ch/download/root_v5.30.00.macosx106-i386-gcc-4.2.tar.gz) |  45M |
-| macosx106 gcc 4.2 | [root_v5.30.00.macosx106-x86_64-gcc-4.2.tar.gz](https://root.cern.ch/download/root_v5.30.00.macosx106-x86_64-gcc-4.2.tar.gz) |  45M |
-| win32 (dbg) | [root_v5.30.00.win32.debug.tar.gz](https://root.cern.ch/download/root_v5.30.00.win32.debug.tar.gz) | 110M |
-| win32 | [root_v5.30.00.win32.tar.gz](https://root.cern.ch/download/root_v5.30.00.win32.tar.gz) |  54M |
-| Windows Visual Studio 10 (dbg) | [root_v5.30.00.win32.vc10.debug.tar.gz](https://root.cern.ch/download/root_v5.30.00.win32.vc10.debug.tar.gz) | 147M |
-| Windows Visual Studio 10 | [root_v5.30.00.win32.vc10.tar.gz](https://root.cern.ch/download/root_v5.30.00.win32.vc10.tar.gz) |  57M |
-| Windows Visual Studio 90 (dbg) | [root_v5.30.00.win32.vc90.debug.tar.gz](https://root.cern.ch/download/root_v5.30.00.win32.vc90.debug.tar.gz) | 143M |
-| Windows Visual Studio 90 | [root_v5.30.00.win32.vc90.tar.gz](https://root.cern.ch/download/root_v5.30.00.win32.vc90.tar.gz) |  56M |
-| win32gcc gcc 4.3 | [root_v5.30.00.win32gcc-gcc-4.3.tar.gz](https://root.cern.ch/download/root_v5.30.00.win32gcc-gcc-4.3.tar.gz) |  44M |
+| root_v5.30.00 rc1.Linux slc5 gcc4.3 | [root_v5.30.00-rc1.Linux-slc5-gcc4.3.tar.gz](https://root.cern/download/root_v5.30.00-rc1.Linux-slc5-gcc4.3.tar.gz) |  55M |
+| root_v5.30.00 rc1.Linux slc5_amd64 gcc4.3 | [root_v5.30.00-rc1.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern/download/root_v5.30.00-rc1.Linux-slc5_amd64-gcc4.3.tar.gz) |  56M |
+| root_v5.30.00 rc1.macosx106 i386 gcc 4.2 | [root_v5.30.00-rc1.macosx106-i386-gcc-4.2.tar.gz](https://root.cern/download/root_v5.30.00-rc1.macosx106-i386-gcc-4.2.tar.gz) |  45M |
+| root_v5.30.00 rc1.macosx106 gcc 4.2 | [root_v5.30.00-rc1.macosx106-x86_64-gcc-4.2.tar.gz](https://root.cern/download/root_v5.30.00-rc1.macosx106-x86_64-gcc-4.2.tar.gz) |  45M |
+| root_v5.30.00 rc1.win32 (dbg) | [root_v5.30.00-rc1.win32.debug.tar.gz](https://root.cern/download/root_v5.30.00-rc1.win32.debug.tar.gz) | 109M |
+| root_v5.30.00 rc1.win32 | [root_v5.30.00-rc1.win32.tar.gz](https://root.cern/download/root_v5.30.00-rc1.win32.tar.gz) |  54M |
+| root_v5.30.00 rc1.Windows Visual Studio 10 (dbg) | [root_v5.30.00-rc1.win32.vc10.debug.tar.gz](https://root.cern/download/root_v5.30.00-rc1.win32.vc10.debug.tar.gz) | 147M |
+| root_v5.30.00 rc1.Windows Visual Studio 10 | [root_v5.30.00-rc1.win32.vc10.tar.gz](https://root.cern/download/root_v5.30.00-rc1.win32.vc10.tar.gz) |  57M |
+| root_v5.30.00 rc1.Windows Visual Studio 90 (dbg) | [root_v5.30.00-rc1.win32.vc90.debug.tar.gz](https://root.cern/download/root_v5.30.00-rc1.win32.vc90.debug.tar.gz) | 142M |
+| root_v5.30.00 rc1.Windows Visual Studio 90 | [root_v5.30.00-rc1.win32.vc90.tar.gz](https://root.cern/download/root_v5.30.00-rc1.win32.vc90.tar.gz) |  55M |
+| root_v5.30.00 rc2.Linux slc5 gcc4.3 | [root_v5.30.00-rc2.Linux-slc5-gcc4.3.tar.gz](https://root.cern/download/root_v5.30.00-rc2.Linux-slc5-gcc4.3.tar.gz) |  55M |
+| root_v5.30.00 rc2.Linux slc5_amd64 gcc4.3 | [root_v5.30.00-rc2.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern/download/root_v5.30.00-rc2.Linux-slc5_amd64-gcc4.3.tar.gz) |  56M |
+| root_v5.30.00 rc2.macosx106 i386 gcc 4.2 | [root_v5.30.00-rc2.macosx106-i386-gcc-4.2.tar.gz](https://root.cern/download/root_v5.30.00-rc2.macosx106-i386-gcc-4.2.tar.gz) |  45M |
+| root_v5.30.00 rc2.macosx106 gcc 4.2 | [root_v5.30.00-rc2.macosx106-x86_64-gcc-4.2.tar.gz](https://root.cern/download/root_v5.30.00-rc2.macosx106-x86_64-gcc-4.2.tar.gz) |  45M |
+| root_v5.30.00 rc2.win32 (dbg) | [root_v5.30.00-rc2.win32.debug.tar.gz](https://root.cern/download/root_v5.30.00-rc2.win32.debug.tar.gz) | 109M |
+| root_v5.30.00 rc2.win32 | [root_v5.30.00-rc2.win32.tar.gz](https://root.cern/download/root_v5.30.00-rc2.win32.tar.gz) |  54M |
+| root_v5.30.00 rc2.Windows Visual Studio 10 (dbg) | [root_v5.30.00-rc2.win32.vc10.debug.tar.gz](https://root.cern/download/root_v5.30.00-rc2.win32.vc10.debug.tar.gz) | 147M |
+| root_v5.30.00 rc2.Windows Visual Studio 10 | [root_v5.30.00-rc2.win32.vc10.tar.gz](https://root.cern/download/root_v5.30.00-rc2.win32.vc10.tar.gz) |  57M |
+| root_v5.30.00 rc2.Windows Visual Studio 90 (dbg) | [root_v5.30.00-rc2.win32.vc90.debug.tar.gz](https://root.cern/download/root_v5.30.00-rc2.win32.vc90.debug.tar.gz) | 142M |
+| root_v5.30.00 rc2.Windows Visual Studio 90 | [root_v5.30.00-rc2.win32.vc90.tar.gz](https://root.cern/download/root_v5.30.00-rc2.win32.vc90.tar.gz) |  55M |
+| Linux slc5 gcc4.3 | [root_v5.30.00.Linux-slc5-gcc4.3.tar.gz](https://root.cern/download/root_v5.30.00.Linux-slc5-gcc4.3.tar.gz) |  55M |
+| Linux slc5_amd64 gcc4.3 | [root_v5.30.00.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern/download/root_v5.30.00.Linux-slc5_amd64-gcc4.3.tar.gz) |  56M |
+| macosx106 i386 gcc 4.2 | [root_v5.30.00.macosx106-i386-gcc-4.2.tar.gz](https://root.cern/download/root_v5.30.00.macosx106-i386-gcc-4.2.tar.gz) |  45M |
+| macosx106 gcc 4.2 | [root_v5.30.00.macosx106-x86_64-gcc-4.2.tar.gz](https://root.cern/download/root_v5.30.00.macosx106-x86_64-gcc-4.2.tar.gz) |  45M |
+| win32 (dbg) | [root_v5.30.00.win32.debug.tar.gz](https://root.cern/download/root_v5.30.00.win32.debug.tar.gz) | 110M |
+| win32 | [root_v5.30.00.win32.tar.gz](https://root.cern/download/root_v5.30.00.win32.tar.gz) |  54M |
+| Windows Visual Studio 10 (dbg) | [root_v5.30.00.win32.vc10.debug.tar.gz](https://root.cern/download/root_v5.30.00.win32.vc10.debug.tar.gz) | 147M |
+| Windows Visual Studio 10 | [root_v5.30.00.win32.vc10.tar.gz](https://root.cern/download/root_v5.30.00.win32.vc10.tar.gz) |  57M |
+| Windows Visual Studio 90 (dbg) | [root_v5.30.00.win32.vc90.debug.tar.gz](https://root.cern/download/root_v5.30.00.win32.vc90.debug.tar.gz) | 143M |
+| Windows Visual Studio 90 | [root_v5.30.00.win32.vc90.tar.gz](https://root.cern/download/root_v5.30.00.win32.vc90.tar.gz) |  56M |
+| win32gcc gcc 4.3 | [root_v5.30.00.win32gcc-gcc-4.3.tar.gz](https://root.cern/download/root_v5.30.00.win32gcc-gcc-4.3.tar.gz) |  44M |
 
 
 
@@ -96,7 +96,7 @@ To use ROOT directly from AFS:
 The entire ROOT source can be obtained from our public Git repository:
 
 ~~~
-git clone http://root.cern.ch/git/root.git
+git clone http://root.cern/git/root.git
 ~~~
 The release specific tag can be obtained using:
 ~~~

--- a/_releases/release-53001.md
+++ b/_releases/release-53001.md
@@ -13,30 +13,30 @@ sidebar:
 
 ## Release Notes
 
-The release notes for this release can be found [here](https://root.cern.ch/root/html530/notes/release-notes.html#patch-releases)
+The release notes for this release can be found [here](https://root.cern/root/html530/notes/release-notes.html#patch-releases)
 
 ## Source distribution
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v5.30.01.source.tar.gz](https://root.cern.ch/download/root_v5.30.01.source.tar.gz) |  39M |
+| source | [root_v5.30.01.source.tar.gz](https://root.cern/download/root_v5.30.01.source.tar.gz) |  39M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| Linux slc5 gcc4.3 | [root_v5.30.01.Linux-slc5-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.30.01.Linux-slc5-gcc4.3.tar.gz) |  55M |
-| Linux slc5_amd64 gcc4.3 | [root_v5.30.01.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.30.01.Linux-slc5_amd64-gcc4.3.tar.gz) |  56M |
-| macosx106 i386 gcc 4.2 | [root_v5.30.01.macosx106-i386-gcc-4.2.tar.gz](https://root.cern.ch/download/root_v5.30.01.macosx106-i386-gcc-4.2.tar.gz) |  45M |
-| macosx106 gcc 4.2 | [root_v5.30.01.macosx106-x86_64-gcc-4.2.tar.gz](https://root.cern.ch/download/root_v5.30.01.macosx106-x86_64-gcc-4.2.tar.gz) |  45M |
-| win32 (dbg) | [root_v5.30.01.win32.debug.tar.gz](https://root.cern.ch/download/root_v5.30.01.win32.debug.tar.gz) | 110M |
-| win32 | [root_v5.30.01.win32.tar.gz](https://root.cern.ch/download/root_v5.30.01.win32.tar.gz) |  54M |
-| Windows Visual Studio 10 (dbg) | [root_v5.30.01.win32.vc10.debug.tar.gz](https://root.cern.ch/download/root_v5.30.01.win32.vc10.debug.tar.gz) | 147M |
-| Windows Visual Studio 10 | [root_v5.30.01.win32.vc10.tar.gz](https://root.cern.ch/download/root_v5.30.01.win32.vc10.tar.gz) |  57M |
-| Windows Visual Studio 90 (dbg) | [root_v5.30.01.win32.vc90.debug.tar.gz](https://root.cern.ch/download/root_v5.30.01.win32.vc90.debug.tar.gz) | 143M |
-| Windows Visual Studio 90 | [root_v5.30.01.win32.vc90.tar.gz](https://root.cern.ch/download/root_v5.30.01.win32.vc90.tar.gz) |  56M |
-| win32gcc gcc 4.3 | [root_v5.30.01.win32gcc-gcc-4.3.tar.gz](https://root.cern.ch/download/root_v5.30.01.win32gcc-gcc-4.3.tar.gz) |  44M |
+| Linux slc5 gcc4.3 | [root_v5.30.01.Linux-slc5-gcc4.3.tar.gz](https://root.cern/download/root_v5.30.01.Linux-slc5-gcc4.3.tar.gz) |  55M |
+| Linux slc5_amd64 gcc4.3 | [root_v5.30.01.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern/download/root_v5.30.01.Linux-slc5_amd64-gcc4.3.tar.gz) |  56M |
+| macosx106 i386 gcc 4.2 | [root_v5.30.01.macosx106-i386-gcc-4.2.tar.gz](https://root.cern/download/root_v5.30.01.macosx106-i386-gcc-4.2.tar.gz) |  45M |
+| macosx106 gcc 4.2 | [root_v5.30.01.macosx106-x86_64-gcc-4.2.tar.gz](https://root.cern/download/root_v5.30.01.macosx106-x86_64-gcc-4.2.tar.gz) |  45M |
+| win32 (dbg) | [root_v5.30.01.win32.debug.tar.gz](https://root.cern/download/root_v5.30.01.win32.debug.tar.gz) | 110M |
+| win32 | [root_v5.30.01.win32.tar.gz](https://root.cern/download/root_v5.30.01.win32.tar.gz) |  54M |
+| Windows Visual Studio 10 (dbg) | [root_v5.30.01.win32.vc10.debug.tar.gz](https://root.cern/download/root_v5.30.01.win32.vc10.debug.tar.gz) | 147M |
+| Windows Visual Studio 10 | [root_v5.30.01.win32.vc10.tar.gz](https://root.cern/download/root_v5.30.01.win32.vc10.tar.gz) |  57M |
+| Windows Visual Studio 90 (dbg) | [root_v5.30.01.win32.vc90.debug.tar.gz](https://root.cern/download/root_v5.30.01.win32.vc90.debug.tar.gz) | 143M |
+| Windows Visual Studio 90 | [root_v5.30.01.win32.vc90.tar.gz](https://root.cern/download/root_v5.30.01.win32.vc90.tar.gz) |  56M |
+| win32gcc gcc 4.3 | [root_v5.30.01.win32gcc-gcc-4.3.tar.gz](https://root.cern/download/root_v5.30.01.win32gcc-gcc-4.3.tar.gz) |  44M |
 
 
 
@@ -72,7 +72,7 @@ To use ROOT directly from AFS:
 The entire ROOT source can be obtained from our public Git repository:
 
 ~~~
-git clone http://root.cern.ch/git/root.git
+git clone http://root.cern/git/root.git
 ~~~
 The release specific tag can be obtained using:
 ~~~

--- a/_releases/release-53002.md
+++ b/_releases/release-53002.md
@@ -13,29 +13,29 @@ sidebar:
 
 ## Release Notes
 
-The release notes for this release can be found [here](https://root.cern.ch/root/html530/notes/release-notes.html#patch-releases)
+The release notes for this release can be found [here](https://root.cern/root/html530/notes/release-notes.html#patch-releases)
 
 ## Source distribution
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v5.30.02.source.tar.gz](https://root.cern.ch/download/root_v5.30.02.source.tar.gz) |  39M |
+| source | [root_v5.30.02.source.tar.gz](https://root.cern/download/root_v5.30.02.source.tar.gz) |  39M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| Linux slc5 gcc4.3 | [root_v5.30.02.Linux-slc5-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.30.02.Linux-slc5-gcc4.3.tar.gz) |  55M |
-| Linux slc5_amd64 gcc4.3 | [root_v5.30.02.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.30.02.Linux-slc5_amd64-gcc4.3.tar.gz) |  56M |
-| macosx106 i386 gcc 4.2 | [root_v5.30.02.macosx106-i386-gcc-4.2.tar.gz](https://root.cern.ch/download/root_v5.30.02.macosx106-i386-gcc-4.2.tar.gz) |  45M |
-| macosx106 gcc 4.2 | [root_v5.30.02.macosx106-x86_64-gcc-4.2.tar.gz](https://root.cern.ch/download/root_v5.30.02.macosx106-x86_64-gcc-4.2.tar.gz) |  45M |
-| win32 (dbg) | [root_v5.30.02.win32.debug.tar.gz](https://root.cern.ch/download/root_v5.30.02.win32.debug.tar.gz) | 110M |
-| win32 | [root_v5.30.02.win32.tar.gz](https://root.cern.ch/download/root_v5.30.02.win32.tar.gz) |  54M |
-| Windows Visual Studio 10 (dbg) | [root_v5.30.02.win32.vc10.debug.tar.gz](https://root.cern.ch/download/root_v5.30.02.win32.vc10.debug.tar.gz) | 147M |
-| Windows Visual Studio 10 | [root_v5.30.02.win32.vc10.tar.gz](https://root.cern.ch/download/root_v5.30.02.win32.vc10.tar.gz) |  57M |
-| Windows Visual Studio 90 (dbg) | [root_v5.30.02.win32.vc90.debug.tar.gz](https://root.cern.ch/download/root_v5.30.02.win32.vc90.debug.tar.gz) | 143M |
-| Windows Visual Studio 90 | [root_v5.30.02.win32.vc90.tar.gz](https://root.cern.ch/download/root_v5.30.02.win32.vc90.tar.gz) |  56M |
+| Linux slc5 gcc4.3 | [root_v5.30.02.Linux-slc5-gcc4.3.tar.gz](https://root.cern/download/root_v5.30.02.Linux-slc5-gcc4.3.tar.gz) |  55M |
+| Linux slc5_amd64 gcc4.3 | [root_v5.30.02.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern/download/root_v5.30.02.Linux-slc5_amd64-gcc4.3.tar.gz) |  56M |
+| macosx106 i386 gcc 4.2 | [root_v5.30.02.macosx106-i386-gcc-4.2.tar.gz](https://root.cern/download/root_v5.30.02.macosx106-i386-gcc-4.2.tar.gz) |  45M |
+| macosx106 gcc 4.2 | [root_v5.30.02.macosx106-x86_64-gcc-4.2.tar.gz](https://root.cern/download/root_v5.30.02.macosx106-x86_64-gcc-4.2.tar.gz) |  45M |
+| win32 (dbg) | [root_v5.30.02.win32.debug.tar.gz](https://root.cern/download/root_v5.30.02.win32.debug.tar.gz) | 110M |
+| win32 | [root_v5.30.02.win32.tar.gz](https://root.cern/download/root_v5.30.02.win32.tar.gz) |  54M |
+| Windows Visual Studio 10 (dbg) | [root_v5.30.02.win32.vc10.debug.tar.gz](https://root.cern/download/root_v5.30.02.win32.vc10.debug.tar.gz) | 147M |
+| Windows Visual Studio 10 | [root_v5.30.02.win32.vc10.tar.gz](https://root.cern/download/root_v5.30.02.win32.vc10.tar.gz) |  57M |
+| Windows Visual Studio 90 (dbg) | [root_v5.30.02.win32.vc90.debug.tar.gz](https://root.cern/download/root_v5.30.02.win32.vc90.debug.tar.gz) | 143M |
+| Windows Visual Studio 90 | [root_v5.30.02.win32.vc90.tar.gz](https://root.cern/download/root_v5.30.02.win32.vc90.tar.gz) |  56M |
 
 
 
@@ -73,7 +73,7 @@ To use ROOT directly from AFS:
 The entire ROOT source can be obtained from our public Git repository:
 
 ~~~
-git clone http://root.cern.ch/git/root.git
+git clone http://root.cern/git/root.git
 ~~~
 The release specific tag can be obtained using:
 ~~~

--- a/_releases/release-53003.md
+++ b/_releases/release-53003.md
@@ -13,29 +13,29 @@ sidebar:
 
 ## Release Notes
 
-The release notes for this release can be found [here](https://root.cern.ch/root/html530/notes/release-notes.html#patch-releases)
+The release notes for this release can be found [here](https://root.cern/root/html530/notes/release-notes.html#patch-releases)
 
 ## Source distribution
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v5.30.03.source.tar.gz](https://root.cern.ch/download/root_v5.30.03.source.tar.gz) |  39M |
+| source | [root_v5.30.03.source.tar.gz](https://root.cern/download/root_v5.30.03.source.tar.gz) |  39M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| Linux slc5 gcc4.3 | [root_v5.30.03.Linux-slc5-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.30.03.Linux-slc5-gcc4.3.tar.gz) |  55M |
-| Linux slc5_amd64 gcc4.3 | [root_v5.30.03.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.30.03.Linux-slc5_amd64-gcc4.3.tar.gz) |  56M |
-| macosx106 i386 gcc 4.2 | [root_v5.30.03.macosx106-i386-gcc-4.2.tar.gz](https://root.cern.ch/download/root_v5.30.03.macosx106-i386-gcc-4.2.tar.gz) |  45M |
-| macosx106 gcc 4.2 | [root_v5.30.03.macosx106-x86_64-gcc-4.2.tar.gz](https://root.cern.ch/download/root_v5.30.03.macosx106-x86_64-gcc-4.2.tar.gz) |  46M |
-| win32 (dbg) | [root_v5.30.03.win32.debug.tar.gz](https://root.cern.ch/download/root_v5.30.03.win32.debug.tar.gz) | 109M |
-| win32 | [root_v5.30.03.win32.tar.gz](https://root.cern.ch/download/root_v5.30.03.win32.tar.gz) |  54M |
-| Windows Visual Studio 10 (dbg) | [root_v5.30.03.win32.vc10.debug.tar.gz](https://root.cern.ch/download/root_v5.30.03.win32.vc10.debug.tar.gz) | 147M |
-| Windows Visual Studio 10 | [root_v5.30.03.win32.vc10.tar.gz](https://root.cern.ch/download/root_v5.30.03.win32.vc10.tar.gz) |  57M |
-| Windows Visual Studio 90 (dbg) | [root_v5.30.03.win32.vc90.debug.tar.gz](https://root.cern.ch/download/root_v5.30.03.win32.vc90.debug.tar.gz) | 143M |
-| Windows Visual Studio 90 | [root_v5.30.03.win32.vc90.tar.gz](https://root.cern.ch/download/root_v5.30.03.win32.vc90.tar.gz) |  56M |
+| Linux slc5 gcc4.3 | [root_v5.30.03.Linux-slc5-gcc4.3.tar.gz](https://root.cern/download/root_v5.30.03.Linux-slc5-gcc4.3.tar.gz) |  55M |
+| Linux slc5_amd64 gcc4.3 | [root_v5.30.03.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern/download/root_v5.30.03.Linux-slc5_amd64-gcc4.3.tar.gz) |  56M |
+| macosx106 i386 gcc 4.2 | [root_v5.30.03.macosx106-i386-gcc-4.2.tar.gz](https://root.cern/download/root_v5.30.03.macosx106-i386-gcc-4.2.tar.gz) |  45M |
+| macosx106 gcc 4.2 | [root_v5.30.03.macosx106-x86_64-gcc-4.2.tar.gz](https://root.cern/download/root_v5.30.03.macosx106-x86_64-gcc-4.2.tar.gz) |  46M |
+| win32 (dbg) | [root_v5.30.03.win32.debug.tar.gz](https://root.cern/download/root_v5.30.03.win32.debug.tar.gz) | 109M |
+| win32 | [root_v5.30.03.win32.tar.gz](https://root.cern/download/root_v5.30.03.win32.tar.gz) |  54M |
+| Windows Visual Studio 10 (dbg) | [root_v5.30.03.win32.vc10.debug.tar.gz](https://root.cern/download/root_v5.30.03.win32.vc10.debug.tar.gz) | 147M |
+| Windows Visual Studio 10 | [root_v5.30.03.win32.vc10.tar.gz](https://root.cern/download/root_v5.30.03.win32.vc10.tar.gz) |  57M |
+| Windows Visual Studio 90 (dbg) | [root_v5.30.03.win32.vc90.debug.tar.gz](https://root.cern/download/root_v5.30.03.win32.vc90.debug.tar.gz) | 143M |
+| Windows Visual Studio 90 | [root_v5.30.03.win32.vc90.tar.gz](https://root.cern/download/root_v5.30.03.win32.vc90.tar.gz) |  56M |
 
 
 
@@ -71,7 +71,7 @@ To use ROOT directly from AFS:
 The entire ROOT source can be obtained from our public Git repository:
 
 ~~~
-git clone http://root.cern.ch/git/root.git
+git clone http://root.cern/git/root.git
 ~~~
 The release specific tag can be obtained using:
 ~~~

--- a/_releases/release-53004.md
+++ b/_releases/release-53004.md
@@ -13,29 +13,29 @@ sidebar:
 
 ## Release Notes
 
-The release notes for this release can be found [here](https://root.cern.ch/root/html530/notes/release-notes.html#patch-releases)
+The release notes for this release can be found [here](https://root.cern/root/html530/notes/release-notes.html#patch-releases)
 
 ## Source distribution
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v5.30.04.source.tar.gz](https://root.cern.ch/download/root_v5.30.04.source.tar.gz) |  39M |
+| source | [root_v5.30.04.source.tar.gz](https://root.cern/download/root_v5.30.04.source.tar.gz) |  39M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| Linux slc5 gcc4.3 | [root_v5.30.04.Linux-slc5-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.30.04.Linux-slc5-gcc4.3.tar.gz) |  55M |
-| Linux slc5_amd64 gcc4.3 | [root_v5.30.04.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.30.04.Linux-slc5_amd64-gcc4.3.tar.gz) |  57M |
-| macosx106 i386 gcc 4.2 | [root_v5.30.04.macosx106-i386-gcc-4.2.tar.gz](https://root.cern.ch/download/root_v5.30.04.macosx106-i386-gcc-4.2.tar.gz) |  45M |
-| macosx106 gcc 4.2 | [root_v5.30.04.macosx106-x86_64-gcc-4.2.tar.gz](https://root.cern.ch/download/root_v5.30.04.macosx106-x86_64-gcc-4.2.tar.gz) |  46M |
-| win32 (dbg) | [root_v5.30.04.win32.debug.tar.gz](https://root.cern.ch/download/root_v5.30.04.win32.debug.tar.gz) | 109M |
-| win32 | [root_v5.30.04.win32.tar.gz](https://root.cern.ch/download/root_v5.30.04.win32.tar.gz) |  54M |
-| Windows Visual Studio 10 (dbg) | [root_v5.30.04.win32.vc10.debug.tar.gz](https://root.cern.ch/download/root_v5.30.04.win32.vc10.debug.tar.gz) | 147M |
-| Windows Visual Studio 10 | [root_v5.30.04.win32.vc10.tar.gz](https://root.cern.ch/download/root_v5.30.04.win32.vc10.tar.gz) |  57M |
-| Windows Visual Studio 90 (dbg) | [root_v5.30.04.win32.vc90.debug.tar.gz](https://root.cern.ch/download/root_v5.30.04.win32.vc90.debug.tar.gz) | 143M |
-| Windows Visual Studio 90 | [root_v5.30.04.win32.vc90.tar.gz](https://root.cern.ch/download/root_v5.30.04.win32.vc90.tar.gz) |  56M |
+| Linux slc5 gcc4.3 | [root_v5.30.04.Linux-slc5-gcc4.3.tar.gz](https://root.cern/download/root_v5.30.04.Linux-slc5-gcc4.3.tar.gz) |  55M |
+| Linux slc5_amd64 gcc4.3 | [root_v5.30.04.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern/download/root_v5.30.04.Linux-slc5_amd64-gcc4.3.tar.gz) |  57M |
+| macosx106 i386 gcc 4.2 | [root_v5.30.04.macosx106-i386-gcc-4.2.tar.gz](https://root.cern/download/root_v5.30.04.macosx106-i386-gcc-4.2.tar.gz) |  45M |
+| macosx106 gcc 4.2 | [root_v5.30.04.macosx106-x86_64-gcc-4.2.tar.gz](https://root.cern/download/root_v5.30.04.macosx106-x86_64-gcc-4.2.tar.gz) |  46M |
+| win32 (dbg) | [root_v5.30.04.win32.debug.tar.gz](https://root.cern/download/root_v5.30.04.win32.debug.tar.gz) | 109M |
+| win32 | [root_v5.30.04.win32.tar.gz](https://root.cern/download/root_v5.30.04.win32.tar.gz) |  54M |
+| Windows Visual Studio 10 (dbg) | [root_v5.30.04.win32.vc10.debug.tar.gz](https://root.cern/download/root_v5.30.04.win32.vc10.debug.tar.gz) | 147M |
+| Windows Visual Studio 10 | [root_v5.30.04.win32.vc10.tar.gz](https://root.cern/download/root_v5.30.04.win32.vc10.tar.gz) |  57M |
+| Windows Visual Studio 90 (dbg) | [root_v5.30.04.win32.vc90.debug.tar.gz](https://root.cern/download/root_v5.30.04.win32.vc90.debug.tar.gz) | 143M |
+| Windows Visual Studio 90 | [root_v5.30.04.win32.vc90.tar.gz](https://root.cern/download/root_v5.30.04.win32.vc90.tar.gz) |  56M |
 
 
 
@@ -69,7 +69,7 @@ To use ROOT directly from AFS:
 The entire ROOT source can be obtained from our public Git repository:
 
 ~~~
-git clone http://root.cern.ch/git/root.git
+git clone http://root.cern/git/root.git
 ~~~
 The release specific tag can be obtained using:
 ~~~

--- a/_releases/release-53005.md
+++ b/_releases/release-53005.md
@@ -13,13 +13,13 @@ sidebar:
 
 ## Release Notes
 
-The release notes for this release can be found [here](https://root.cern.ch/root/html530/notes/release-notes.html#patch-releases)
+The release notes for this release can be found [here](https://root.cern/root/html530/notes/release-notes.html#patch-releases)
 
 ## Source distribution
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v5.30.05.source.tar.gz](https://root.cern.ch/download/root_v5.30.05.source.tar.gz) |  39M |
+| source | [root_v5.30.05.source.tar.gz](https://root.cern/download/root_v5.30.05.source.tar.gz) |  39M |
 
 
 
@@ -49,7 +49,7 @@ To use ROOT directly from AFS:
 The entire ROOT source can be obtained from our public Git repository:
 
 ~~~
-git clone http://root.cern.ch/git/root.git
+git clone http://root.cern/git/root.git
 ~~~
 The release specific tag can be obtained using:
 ~~~

--- a/_releases/release-53006.md
+++ b/_releases/release-53006.md
@@ -13,29 +13,29 @@ sidebar:
 
 ## Release Notes
 
-The release notes for this release can be found [here](https://root.cern.ch/root/html530/notes/release-notes.html#patch-releases)
+The release notes for this release can be found [here](https://root.cern/root/html530/notes/release-notes.html#patch-releases)
 
 ## Source distribution
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v5.30.06.source.tar.gz](https://root.cern.ch/download/root_v5.30.06.source.tar.gz) |  39M |
+| source | [root_v5.30.06.source.tar.gz](https://root.cern/download/root_v5.30.06.source.tar.gz) |  39M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| Linux slc5 gcc4.3 | [root_v5.30.06.Linux-slc5-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.30.06.Linux-slc5-gcc4.3.tar.gz) |  55M |
-| Linux slc5_amd64 gcc4.3 | [root_v5.30.06.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.30.06.Linux-slc5_amd64-gcc4.3.tar.gz) |  57M |
-| macosx106 i386 gcc 4.2 | [root_v5.30.06.macosx106-i386-gcc-4.2.tar.gz](https://root.cern.ch/download/root_v5.30.06.macosx106-i386-gcc-4.2.tar.gz) |  45M |
-| macosx106 gcc 4.2 | [root_v5.30.06.macosx106-x86_64-gcc-4.2.tar.gz](https://root.cern.ch/download/root_v5.30.06.macosx106-x86_64-gcc-4.2.tar.gz) |  46M |
-| win32 (dbg) | [root_v5.30.06.win32.debug.tar.gz](https://root.cern.ch/download/root_v5.30.06.win32.debug.tar.gz) | 147M |
-| win32 | [root_v5.30.06.win32.tar.gz](https://root.cern.ch/download/root_v5.30.06.win32.tar.gz) |  57M |
-| Windows Visual Studio 10 (dbg) | [root_v5.30.06.win32.vc10.debug.tar.gz](https://root.cern.ch/download/root_v5.30.06.win32.vc10.debug.tar.gz) | 147M |
-| Windows Visual Studio 10 | [root_v5.30.06.win32.vc10.tar.gz](https://root.cern.ch/download/root_v5.30.06.win32.vc10.tar.gz) |  57M |
-| Windows Visual Studio 90 (dbg) | [root_v5.30.06.win32.vc90.debug.tar.gz](https://root.cern.ch/download/root_v5.30.06.win32.vc90.debug.tar.gz) | 143M |
-| Windows Visual Studio 90 | [root_v5.30.06.win32.vc90.tar.gz](https://root.cern.ch/download/root_v5.30.06.win32.vc90.tar.gz) |  56M |
+| Linux slc5 gcc4.3 | [root_v5.30.06.Linux-slc5-gcc4.3.tar.gz](https://root.cern/download/root_v5.30.06.Linux-slc5-gcc4.3.tar.gz) |  55M |
+| Linux slc5_amd64 gcc4.3 | [root_v5.30.06.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern/download/root_v5.30.06.Linux-slc5_amd64-gcc4.3.tar.gz) |  57M |
+| macosx106 i386 gcc 4.2 | [root_v5.30.06.macosx106-i386-gcc-4.2.tar.gz](https://root.cern/download/root_v5.30.06.macosx106-i386-gcc-4.2.tar.gz) |  45M |
+| macosx106 gcc 4.2 | [root_v5.30.06.macosx106-x86_64-gcc-4.2.tar.gz](https://root.cern/download/root_v5.30.06.macosx106-x86_64-gcc-4.2.tar.gz) |  46M |
+| win32 (dbg) | [root_v5.30.06.win32.debug.tar.gz](https://root.cern/download/root_v5.30.06.win32.debug.tar.gz) | 147M |
+| win32 | [root_v5.30.06.win32.tar.gz](https://root.cern/download/root_v5.30.06.win32.tar.gz) |  57M |
+| Windows Visual Studio 10 (dbg) | [root_v5.30.06.win32.vc10.debug.tar.gz](https://root.cern/download/root_v5.30.06.win32.vc10.debug.tar.gz) | 147M |
+| Windows Visual Studio 10 | [root_v5.30.06.win32.vc10.tar.gz](https://root.cern/download/root_v5.30.06.win32.vc10.tar.gz) |  57M |
+| Windows Visual Studio 90 (dbg) | [root_v5.30.06.win32.vc90.debug.tar.gz](https://root.cern/download/root_v5.30.06.win32.vc90.debug.tar.gz) | 143M |
+| Windows Visual Studio 90 | [root_v5.30.06.win32.vc90.tar.gz](https://root.cern/download/root_v5.30.06.win32.vc90.tar.gz) |  56M |
 
 
 
@@ -65,7 +65,7 @@ To use ROOT directly from AFS:
 The entire ROOT source can be obtained from our public Git repository:
 
 ~~~
-git clone http://root.cern.ch/git/root.git
+git clone http://root.cern/git/root.git
 ~~~
 The release specific tag can be obtained using:
 ~~~

--- a/_releases/release-53200.md
+++ b/_releases/release-53200.md
@@ -19,56 +19,56 @@ The release notes for this release can be found [here]({{ '/install/all_releases
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| root_v5.32.00 rc1.source | [root_v5.32.00-rc1.source.tar.gz](https://root.cern.ch/download/root_v5.32.00-rc1.source.tar.gz) |  52M |
-| root_v5.32.00 rc2.source | [root_v5.32.00-rc2.source.tar.gz](https://root.cern.ch/download/root_v5.32.00-rc2.source.tar.gz) |  52M |
-| source | [root_v5.32.00.source.tar.gz](https://root.cern.ch/download/root_v5.32.00.source.tar.gz) |  53M |
+| root_v5.32.00 rc1.source | [root_v5.32.00-rc1.source.tar.gz](https://root.cern/download/root_v5.32.00-rc1.source.tar.gz) |  52M |
+| root_v5.32.00 rc2.source | [root_v5.32.00-rc2.source.tar.gz](https://root.cern/download/root_v5.32.00-rc2.source.tar.gz) |  52M |
+| source | [root_v5.32.00.source.tar.gz](https://root.cern/download/root_v5.32.00.source.tar.gz) |  53M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| root_v5.32.00 rc1.Linux slc5 gcc4.3 | [root_v5.32.00-rc1.Linux-slc5-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.32.00-rc1.Linux-slc5-gcc4.3.tar.gz) |  46M |
-| root_v5.32.00 rc1.Linux slc5_amd64 gcc4.3 | [root_v5.32.00-rc1.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.32.00-rc1.Linux-slc5_amd64-gcc4.3.tar.gz) |  47M |
-| root_v5.32.00 rc1.aix5 | [root_v5.32.00-rc1.aix5.tar.gz](https://root.cern.ch/download/root_v5.32.00-rc1.aix5.tar.gz) |  71M |
-| root_v5.32.00 rc1.OsX 10.7 i386 (dbg) | [root_v5.32.00-rc1.macosx64-10.7-i386.debug.tar.gz](https://root.cern.ch/download/root_v5.32.00-rc1.macosx64-10.7-i386.debug.tar.gz) |  46M |
-| root_v5.32.00 rc1.macosx106 i386 gcc 4.2 | [root_v5.32.00-rc1.macosx106-i386-gcc-4.2.tar.gz](https://root.cern.ch/download/root_v5.32.00-rc1.macosx106-i386-gcc-4.2.tar.gz) |  42M |
-| root_v5.32.00 rc1.macosx106 gcc 4.2 | [root_v5.32.00-rc1.macosx106-x86_64-gcc-4.2.tar.gz](https://root.cern.ch/download/root_v5.32.00-rc1.macosx106-x86_64-gcc-4.2.tar.gz) |  43M |
-| root_v5.32.00 rc1.solaris64CC5 5.11 i386 | [root_v5.32.00-rc1.solaris64CC5-5.11-i386.tar.gz](https://root.cern.ch/download/root_v5.32.00-rc1.solaris64CC5-5.11-i386.tar.gz) |  55M |
-| root_v5.32.00 rc1.win32 (dbg) | [root_v5.32.00-rc1.win32.debug.tar.gz](https://root.cern.ch/download/root_v5.32.00-rc1.win32.debug.tar.gz) | 109M |
-| root_v5.32.00 rc1.win32 | [root_v5.32.00-rc1.win32.tar.gz](https://root.cern.ch/download/root_v5.32.00-rc1.win32.tar.gz) |  54M |
-| root_v5.32.00 rc1.Windows Visual Studio 10 (dbg) | [root_v5.32.00-rc1.win32.vc10.debug.tar.gz](https://root.cern.ch/download/root_v5.32.00-rc1.win32.vc10.debug.tar.gz) | 147M |
-| root_v5.32.00 rc1.Windows Visual Studio 10 | [root_v5.32.00-rc1.win32.vc10.tar.gz](https://root.cern.ch/download/root_v5.32.00-rc1.win32.vc10.tar.gz) |  57M |
-| root_v5.32.00 rc1.Windows Visual Studio 90 (dbg) | [root_v5.32.00-rc1.win32.vc90.debug.tar.gz](https://root.cern.ch/download/root_v5.32.00-rc1.win32.vc90.debug.tar.gz) | 142M |
-| root_v5.32.00 rc1.Windows Visual Studio 90 | [root_v5.32.00-rc1.win32.vc90.tar.gz](https://root.cern.ch/download/root_v5.32.00-rc1.win32.vc90.tar.gz) |  56M |
-| root_v5.32.00 rc1.win32gcc gcc 4.3 | [root_v5.32.00-rc1.win32gcc-gcc-4.3.tar.gz](https://root.cern.ch/download/root_v5.32.00-rc1.win32gcc-gcc-4.3.tar.gz) |  44M |
-| root_v5.32.00 rc2.Linux slc5 gcc4.3 | [root_v5.32.00-rc2.Linux-slc5-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.32.00-rc2.Linux-slc5-gcc4.3.tar.gz) |  46M |
-| root_v5.32.00 rc2.Linux slc5_amd64 gcc4.3 | [root_v5.32.00-rc2.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.32.00-rc2.Linux-slc5_amd64-gcc4.3.tar.gz) |  47M |
-| root_v5.32.00 rc2.aix5 (dbg) | [root_v5.32.00-rc2.aix5.debug.tar.gz](https://root.cern.ch/download/root_v5.32.00-rc2.aix5.debug.tar.gz) | 141M |
-| root_v5.32.00 rc2.OsX 10.7 i386 | [root_v5.32.00-rc2.macosx64-10.7-i386.tar.gz](https://root.cern.ch/download/root_v5.32.00-rc2.macosx64-10.7-i386.tar.gz) |  46M |
-| root_v5.32.00 rc2.macosx106 i386 gcc 4.2 | [root_v5.32.00-rc2.macosx106-i386-gcc-4.2.tar.gz](https://root.cern.ch/download/root_v5.32.00-rc2.macosx106-i386-gcc-4.2.tar.gz) |  42M |
-| root_v5.32.00 rc2.macosx106 gcc 4.2 | [root_v5.32.00-rc2.macosx106-x86_64-gcc-4.2.tar.gz](https://root.cern.ch/download/root_v5.32.00-rc2.macosx106-x86_64-gcc-4.2.tar.gz) |  43M |
-| root_v5.32.00 rc2.solaris64CC5 5.11 i386 | [root_v5.32.00-rc2.solaris64CC5-5.11-i386.tar.gz](https://root.cern.ch/download/root_v5.32.00-rc2.solaris64CC5-5.11-i386.tar.gz) |  54M |
-| root_v5.32.00 rc2.win32 (dbg) | [root_v5.32.00-rc2.win32.debug.tar.gz](https://root.cern.ch/download/root_v5.32.00-rc2.win32.debug.tar.gz) | 109M |
-| root_v5.32.00 rc2.win32 | [root_v5.32.00-rc2.win32.tar.gz](https://root.cern.ch/download/root_v5.32.00-rc2.win32.tar.gz) |  54M |
-| root_v5.32.00 rc2.Windows Visual Studio 10 (dbg) | [root_v5.32.00-rc2.win32.vc10.debug.tar.gz](https://root.cern.ch/download/root_v5.32.00-rc2.win32.vc10.debug.tar.gz) | 147M |
-| root_v5.32.00 rc2.Windows Visual Studio 10 | [root_v5.32.00-rc2.win32.vc10.tar.gz](https://root.cern.ch/download/root_v5.32.00-rc2.win32.vc10.tar.gz) |  57M |
-| root_v5.32.00 rc2.Windows Visual Studio 90 (dbg) | [root_v5.32.00-rc2.win32.vc90.debug.tar.gz](https://root.cern.ch/download/root_v5.32.00-rc2.win32.vc90.debug.tar.gz) | 142M |
-| root_v5.32.00 rc2.Windows Visual Studio 90 | [root_v5.32.00-rc2.win32.vc90.tar.gz](https://root.cern.ch/download/root_v5.32.00-rc2.win32.vc90.tar.gz) |  56M |
-| Linux slc5 gcc4.3 | [root_v5.32.00.Linux-slc5-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.32.00.Linux-slc5-gcc4.3.tar.gz) |  47M |
-| Linux slc5_amd64 gcc4.3 | [root_v5.32.00.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.32.00.Linux-slc5_amd64-gcc4.3.tar.gz) |  48M |
-| aix5 | [root_v5.32.00.aix5.tar.gz](https://root.cern.ch/download/root_v5.32.00.aix5.tar.gz) |  71M |
-| OsX 10.7 i386 | [root_v5.32.00.macosx64-10.7-i386.tar.gz](https://root.cern.ch/download/root_v5.32.00.macosx64-10.7-i386.tar.gz) |  46M |
-| macosx106 i386 gcc 4.2 | [root_v5.32.00.macosx106-i386-gcc-4.2.tar.gz](https://root.cern.ch/download/root_v5.32.00.macosx106-i386-gcc-4.2.tar.gz) |  42M |
-| macosx106 gcc 4.2 | [root_v5.32.00.macosx106-x86_64-gcc-4.2.tar.gz](https://root.cern.ch/download/root_v5.32.00.macosx106-x86_64-gcc-4.2.tar.gz) |  43M |
-| solaris64CC5 5.11 i386 | [root_v5.32.00.solaris64CC5-5.11-i386.tar.gz](https://root.cern.ch/download/root_v5.32.00.solaris64CC5-5.11-i386.tar.gz) |  55M |
-| win32 (dbg) | [root_v5.32.00.win32.debug.tar.gz](https://root.cern.ch/download/root_v5.32.00.win32.debug.tar.gz) | 109M |
-| win32 | [root_v5.32.00.win32.tar.gz](https://root.cern.ch/download/root_v5.32.00.win32.tar.gz) |  54M |
-| Windows Visual Studio 10 (dbg) | [root_v5.32.00.win32.vc10.debug.tar.gz](https://root.cern.ch/download/root_v5.32.00.win32.vc10.debug.tar.gz) | 147M |
-| Windows Visual Studio 10 | [root_v5.32.00.win32.vc10.tar.gz](https://root.cern.ch/download/root_v5.32.00.win32.vc10.tar.gz) |  57M |
-| Windows Visual Studio 90 (dbg) | [root_v5.32.00.win32.vc90.debug.tar.gz](https://root.cern.ch/download/root_v5.32.00.win32.vc90.debug.tar.gz) | 143M |
-| Windows Visual Studio 90 | [root_v5.32.00.win32.vc90.tar.gz](https://root.cern.ch/download/root_v5.32.00.win32.vc90.tar.gz) |  56M |
-| win32gcc gcc 4.3 | [root_v5.32.00.win32gcc-gcc-4.3.tar.gz](https://root.cern.ch/download/root_v5.32.00.win32gcc-gcc-4.3.tar.gz) |  45M |
+| root_v5.32.00 rc1.Linux slc5 gcc4.3 | [root_v5.32.00-rc1.Linux-slc5-gcc4.3.tar.gz](https://root.cern/download/root_v5.32.00-rc1.Linux-slc5-gcc4.3.tar.gz) |  46M |
+| root_v5.32.00 rc1.Linux slc5_amd64 gcc4.3 | [root_v5.32.00-rc1.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern/download/root_v5.32.00-rc1.Linux-slc5_amd64-gcc4.3.tar.gz) |  47M |
+| root_v5.32.00 rc1.aix5 | [root_v5.32.00-rc1.aix5.tar.gz](https://root.cern/download/root_v5.32.00-rc1.aix5.tar.gz) |  71M |
+| root_v5.32.00 rc1.OsX 10.7 i386 (dbg) | [root_v5.32.00-rc1.macosx64-10.7-i386.debug.tar.gz](https://root.cern/download/root_v5.32.00-rc1.macosx64-10.7-i386.debug.tar.gz) |  46M |
+| root_v5.32.00 rc1.macosx106 i386 gcc 4.2 | [root_v5.32.00-rc1.macosx106-i386-gcc-4.2.tar.gz](https://root.cern/download/root_v5.32.00-rc1.macosx106-i386-gcc-4.2.tar.gz) |  42M |
+| root_v5.32.00 rc1.macosx106 gcc 4.2 | [root_v5.32.00-rc1.macosx106-x86_64-gcc-4.2.tar.gz](https://root.cern/download/root_v5.32.00-rc1.macosx106-x86_64-gcc-4.2.tar.gz) |  43M |
+| root_v5.32.00 rc1.solaris64CC5 5.11 i386 | [root_v5.32.00-rc1.solaris64CC5-5.11-i386.tar.gz](https://root.cern/download/root_v5.32.00-rc1.solaris64CC5-5.11-i386.tar.gz) |  55M |
+| root_v5.32.00 rc1.win32 (dbg) | [root_v5.32.00-rc1.win32.debug.tar.gz](https://root.cern/download/root_v5.32.00-rc1.win32.debug.tar.gz) | 109M |
+| root_v5.32.00 rc1.win32 | [root_v5.32.00-rc1.win32.tar.gz](https://root.cern/download/root_v5.32.00-rc1.win32.tar.gz) |  54M |
+| root_v5.32.00 rc1.Windows Visual Studio 10 (dbg) | [root_v5.32.00-rc1.win32.vc10.debug.tar.gz](https://root.cern/download/root_v5.32.00-rc1.win32.vc10.debug.tar.gz) | 147M |
+| root_v5.32.00 rc1.Windows Visual Studio 10 | [root_v5.32.00-rc1.win32.vc10.tar.gz](https://root.cern/download/root_v5.32.00-rc1.win32.vc10.tar.gz) |  57M |
+| root_v5.32.00 rc1.Windows Visual Studio 90 (dbg) | [root_v5.32.00-rc1.win32.vc90.debug.tar.gz](https://root.cern/download/root_v5.32.00-rc1.win32.vc90.debug.tar.gz) | 142M |
+| root_v5.32.00 rc1.Windows Visual Studio 90 | [root_v5.32.00-rc1.win32.vc90.tar.gz](https://root.cern/download/root_v5.32.00-rc1.win32.vc90.tar.gz) |  56M |
+| root_v5.32.00 rc1.win32gcc gcc 4.3 | [root_v5.32.00-rc1.win32gcc-gcc-4.3.tar.gz](https://root.cern/download/root_v5.32.00-rc1.win32gcc-gcc-4.3.tar.gz) |  44M |
+| root_v5.32.00 rc2.Linux slc5 gcc4.3 | [root_v5.32.00-rc2.Linux-slc5-gcc4.3.tar.gz](https://root.cern/download/root_v5.32.00-rc2.Linux-slc5-gcc4.3.tar.gz) |  46M |
+| root_v5.32.00 rc2.Linux slc5_amd64 gcc4.3 | [root_v5.32.00-rc2.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern/download/root_v5.32.00-rc2.Linux-slc5_amd64-gcc4.3.tar.gz) |  47M |
+| root_v5.32.00 rc2.aix5 (dbg) | [root_v5.32.00-rc2.aix5.debug.tar.gz](https://root.cern/download/root_v5.32.00-rc2.aix5.debug.tar.gz) | 141M |
+| root_v5.32.00 rc2.OsX 10.7 i386 | [root_v5.32.00-rc2.macosx64-10.7-i386.tar.gz](https://root.cern/download/root_v5.32.00-rc2.macosx64-10.7-i386.tar.gz) |  46M |
+| root_v5.32.00 rc2.macosx106 i386 gcc 4.2 | [root_v5.32.00-rc2.macosx106-i386-gcc-4.2.tar.gz](https://root.cern/download/root_v5.32.00-rc2.macosx106-i386-gcc-4.2.tar.gz) |  42M |
+| root_v5.32.00 rc2.macosx106 gcc 4.2 | [root_v5.32.00-rc2.macosx106-x86_64-gcc-4.2.tar.gz](https://root.cern/download/root_v5.32.00-rc2.macosx106-x86_64-gcc-4.2.tar.gz) |  43M |
+| root_v5.32.00 rc2.solaris64CC5 5.11 i386 | [root_v5.32.00-rc2.solaris64CC5-5.11-i386.tar.gz](https://root.cern/download/root_v5.32.00-rc2.solaris64CC5-5.11-i386.tar.gz) |  54M |
+| root_v5.32.00 rc2.win32 (dbg) | [root_v5.32.00-rc2.win32.debug.tar.gz](https://root.cern/download/root_v5.32.00-rc2.win32.debug.tar.gz) | 109M |
+| root_v5.32.00 rc2.win32 | [root_v5.32.00-rc2.win32.tar.gz](https://root.cern/download/root_v5.32.00-rc2.win32.tar.gz) |  54M |
+| root_v5.32.00 rc2.Windows Visual Studio 10 (dbg) | [root_v5.32.00-rc2.win32.vc10.debug.tar.gz](https://root.cern/download/root_v5.32.00-rc2.win32.vc10.debug.tar.gz) | 147M |
+| root_v5.32.00 rc2.Windows Visual Studio 10 | [root_v5.32.00-rc2.win32.vc10.tar.gz](https://root.cern/download/root_v5.32.00-rc2.win32.vc10.tar.gz) |  57M |
+| root_v5.32.00 rc2.Windows Visual Studio 90 (dbg) | [root_v5.32.00-rc2.win32.vc90.debug.tar.gz](https://root.cern/download/root_v5.32.00-rc2.win32.vc90.debug.tar.gz) | 142M |
+| root_v5.32.00 rc2.Windows Visual Studio 90 | [root_v5.32.00-rc2.win32.vc90.tar.gz](https://root.cern/download/root_v5.32.00-rc2.win32.vc90.tar.gz) |  56M |
+| Linux slc5 gcc4.3 | [root_v5.32.00.Linux-slc5-gcc4.3.tar.gz](https://root.cern/download/root_v5.32.00.Linux-slc5-gcc4.3.tar.gz) |  47M |
+| Linux slc5_amd64 gcc4.3 | [root_v5.32.00.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern/download/root_v5.32.00.Linux-slc5_amd64-gcc4.3.tar.gz) |  48M |
+| aix5 | [root_v5.32.00.aix5.tar.gz](https://root.cern/download/root_v5.32.00.aix5.tar.gz) |  71M |
+| OsX 10.7 i386 | [root_v5.32.00.macosx64-10.7-i386.tar.gz](https://root.cern/download/root_v5.32.00.macosx64-10.7-i386.tar.gz) |  46M |
+| macosx106 i386 gcc 4.2 | [root_v5.32.00.macosx106-i386-gcc-4.2.tar.gz](https://root.cern/download/root_v5.32.00.macosx106-i386-gcc-4.2.tar.gz) |  42M |
+| macosx106 gcc 4.2 | [root_v5.32.00.macosx106-x86_64-gcc-4.2.tar.gz](https://root.cern/download/root_v5.32.00.macosx106-x86_64-gcc-4.2.tar.gz) |  43M |
+| solaris64CC5 5.11 i386 | [root_v5.32.00.solaris64CC5-5.11-i386.tar.gz](https://root.cern/download/root_v5.32.00.solaris64CC5-5.11-i386.tar.gz) |  55M |
+| win32 (dbg) | [root_v5.32.00.win32.debug.tar.gz](https://root.cern/download/root_v5.32.00.win32.debug.tar.gz) | 109M |
+| win32 | [root_v5.32.00.win32.tar.gz](https://root.cern/download/root_v5.32.00.win32.tar.gz) |  54M |
+| Windows Visual Studio 10 (dbg) | [root_v5.32.00.win32.vc10.debug.tar.gz](https://root.cern/download/root_v5.32.00.win32.vc10.debug.tar.gz) | 147M |
+| Windows Visual Studio 10 | [root_v5.32.00.win32.vc10.tar.gz](https://root.cern/download/root_v5.32.00.win32.vc10.tar.gz) |  57M |
+| Windows Visual Studio 90 (dbg) | [root_v5.32.00.win32.vc90.debug.tar.gz](https://root.cern/download/root_v5.32.00.win32.vc90.debug.tar.gz) | 143M |
+| Windows Visual Studio 90 | [root_v5.32.00.win32.vc90.tar.gz](https://root.cern/download/root_v5.32.00.win32.vc90.tar.gz) |  56M |
+| win32gcc gcc 4.3 | [root_v5.32.00.win32gcc-gcc-4.3.tar.gz](https://root.cern/download/root_v5.32.00.win32gcc-gcc-4.3.tar.gz) |  45M |
 
 
 
@@ -104,7 +104,7 @@ To use ROOT directly from AFS:
 The entire ROOT source can be obtained from our public Git repository:
 
 ~~~
-git clone http://root.cern.ch/git/root.git
+git clone http://root.cern/git/root.git
 ~~~
 The release specific tag can be obtained using:
 ~~~

--- a/_releases/release-53201.md
+++ b/_releases/release-53201.md
@@ -13,31 +13,31 @@ sidebar:
 
 ## Release Notes
 
-The release notes for this release can be found [here](https://root.cern.ch/root/html532/notes/release-notes.html#patch-releases)
+The release notes for this release can be found [here](https://root.cern/root/html532/notes/release-notes.html#patch-releases)
 
 ## Source distribution
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v5.32.01.source.tar.gz](https://root.cern.ch/download/root_v5.32.01.source.tar.gz) |  53M |
+| source | [root_v5.32.01.source.tar.gz](https://root.cern/download/root_v5.32.01.source.tar.gz) |  53M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| Linux slc5 gcc4.3 | [root_v5.32.01.Linux-slc5-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.32.01.Linux-slc5-gcc4.3.tar.gz) |  47M |
-| Linux slc5_amd64 gcc4.3 | [root_v5.32.01.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.32.01.Linux-slc5_amd64-gcc4.3.tar.gz) |  48M |
-| aix5 | [root_v5.32.01.aix5.tar.gz](https://root.cern.ch/download/root_v5.32.01.aix5.tar.gz) |  71M |
-| linuxx8664gcc gcc 4.3 | [root_v5.32.01.linuxx8664gcc-gcc-4.3.tar.gz](https://root.cern.ch/download/root_v5.32.01.linuxx8664gcc-gcc-4.3.tar.gz) |  48M |
-| OsX 10.7 i386 | [root_v5.32.01.macosx64-10.7-i386.tar.gz](https://root.cern.ch/download/root_v5.32.01.macosx64-10.7-i386.tar.gz) |  46M |
-| macosx106 i386 gcc 4.2 | [root_v5.32.01.macosx106-i386-gcc-4.2.tar.gz](https://root.cern.ch/download/root_v5.32.01.macosx106-i386-gcc-4.2.tar.gz) |  42M |
-| macosx106 gcc 4.2 | [root_v5.32.01.macosx106-x86_64-gcc-4.2.tar.gz](https://root.cern.ch/download/root_v5.32.01.macosx106-x86_64-gcc-4.2.tar.gz) |  43M |
-| solaris64CC5 5.11 i386 | [root_v5.32.01.solaris64CC5-5.11-i386.tar.gz](https://root.cern.ch/download/root_v5.32.01.solaris64CC5-5.11-i386.tar.gz) |  57M |
-| Windows Visual Studio 10 (dbg) | [root_v5.32.01.win32.vc10.debug.tar.gz](https://root.cern.ch/download/root_v5.32.01.win32.vc10.debug.tar.gz) | 148M |
-| Windows Visual Studio 10 | [root_v5.32.01.win32.vc10.tar.gz](https://root.cern.ch/download/root_v5.32.01.win32.vc10.tar.gz) |  58M |
-| Windows Visual Studio 90 (dbg) | [root_v5.32.01.win32.vc90.debug.tar.gz](https://root.cern.ch/download/root_v5.32.01.win32.vc90.debug.tar.gz) | 144M |
-| Windows Visual Studio 90 | [root_v5.32.01.win32.vc90.tar.gz](https://root.cern.ch/download/root_v5.32.01.win32.vc90.tar.gz) |  56M |
+| Linux slc5 gcc4.3 | [root_v5.32.01.Linux-slc5-gcc4.3.tar.gz](https://root.cern/download/root_v5.32.01.Linux-slc5-gcc4.3.tar.gz) |  47M |
+| Linux slc5_amd64 gcc4.3 | [root_v5.32.01.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern/download/root_v5.32.01.Linux-slc5_amd64-gcc4.3.tar.gz) |  48M |
+| aix5 | [root_v5.32.01.aix5.tar.gz](https://root.cern/download/root_v5.32.01.aix5.tar.gz) |  71M |
+| linuxx8664gcc gcc 4.3 | [root_v5.32.01.linuxx8664gcc-gcc-4.3.tar.gz](https://root.cern/download/root_v5.32.01.linuxx8664gcc-gcc-4.3.tar.gz) |  48M |
+| OsX 10.7 i386 | [root_v5.32.01.macosx64-10.7-i386.tar.gz](https://root.cern/download/root_v5.32.01.macosx64-10.7-i386.tar.gz) |  46M |
+| macosx106 i386 gcc 4.2 | [root_v5.32.01.macosx106-i386-gcc-4.2.tar.gz](https://root.cern/download/root_v5.32.01.macosx106-i386-gcc-4.2.tar.gz) |  42M |
+| macosx106 gcc 4.2 | [root_v5.32.01.macosx106-x86_64-gcc-4.2.tar.gz](https://root.cern/download/root_v5.32.01.macosx106-x86_64-gcc-4.2.tar.gz) |  43M |
+| solaris64CC5 5.11 i386 | [root_v5.32.01.solaris64CC5-5.11-i386.tar.gz](https://root.cern/download/root_v5.32.01.solaris64CC5-5.11-i386.tar.gz) |  57M |
+| Windows Visual Studio 10 (dbg) | [root_v5.32.01.win32.vc10.debug.tar.gz](https://root.cern/download/root_v5.32.01.win32.vc10.debug.tar.gz) | 148M |
+| Windows Visual Studio 10 | [root_v5.32.01.win32.vc10.tar.gz](https://root.cern/download/root_v5.32.01.win32.vc10.tar.gz) |  58M |
+| Windows Visual Studio 90 (dbg) | [root_v5.32.01.win32.vc90.debug.tar.gz](https://root.cern/download/root_v5.32.01.win32.vc90.debug.tar.gz) | 144M |
+| Windows Visual Studio 90 | [root_v5.32.01.win32.vc90.tar.gz](https://root.cern/download/root_v5.32.01.win32.vc90.tar.gz) |  56M |
 
 
 
@@ -68,7 +68,7 @@ To use ROOT directly from AFS:
 The entire ROOT source can be obtained from our public Git repository:
 
 ~~~
-git clone http://root.cern.ch/git/root.git
+git clone http://root.cern/git/root.git
 ~~~
 The release specific tag can be obtained using:
 ~~~

--- a/_releases/release-53202.md
+++ b/_releases/release-53202.md
@@ -13,27 +13,27 @@ sidebar:
 
 ## Release Notes
 
-The release notes for this release can be found [here](https://root.cern.ch/root/html532/notes/release-notes.html#patch-releases)
+The release notes for this release can be found [here](https://root.cern/root/html532/notes/release-notes.html#patch-releases)
 
 ## Source distribution
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v5.32.02.source.tar.gz](https://root.cern.ch/download/root_v5.32.02.source.tar.gz) |  53M |
+| source | [root_v5.32.02.source.tar.gz](https://root.cern/download/root_v5.32.02.source.tar.gz) |  53M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| Linux slc5 gcc4.3 | [root_v5.32.02.Linux-slc5-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.32.02.Linux-slc5-gcc4.3.tar.gz) |  47M |
-| Linux slc5_amd64 gcc4.3 | [root_v5.32.02.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.32.02.Linux-slc5_amd64-gcc4.3.tar.gz) |  48M |
-| macosx106 i386 gcc 4.2 | [root_v5.32.02.macosx106-i386-gcc-4.2.tar.gz](https://root.cern.ch/download/root_v5.32.02.macosx106-i386-gcc-4.2.tar.gz) |  42M |
-| macosx106 gcc 4.2 | [root_v5.32.02.macosx106-x86_64-gcc-4.2.tar.gz](https://root.cern.ch/download/root_v5.32.02.macosx106-x86_64-gcc-4.2.tar.gz) |  43M |
-| Windows Visual Studio 10 (dbg) | [root_v5.32.02.win32.vc10.debug.tar.gz](https://root.cern.ch/download/root_v5.32.02.win32.vc10.debug.tar.gz) | 148M |
-| Windows Visual Studio 10 | [root_v5.32.02.win32.vc10.tar.gz](https://root.cern.ch/download/root_v5.32.02.win32.vc10.tar.gz) |  58M |
-| Windows Visual Studio 90 (dbg) | [root_v5.32.02.win32.vc90.debug.tar.gz](https://root.cern.ch/download/root_v5.32.02.win32.vc90.debug.tar.gz) | 144M |
-| Windows Visual Studio 90 | [root_v5.32.02.win32.vc90.tar.gz](https://root.cern.ch/download/root_v5.32.02.win32.vc90.tar.gz) |  56M |
+| Linux slc5 gcc4.3 | [root_v5.32.02.Linux-slc5-gcc4.3.tar.gz](https://root.cern/download/root_v5.32.02.Linux-slc5-gcc4.3.tar.gz) |  47M |
+| Linux slc5_amd64 gcc4.3 | [root_v5.32.02.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern/download/root_v5.32.02.Linux-slc5_amd64-gcc4.3.tar.gz) |  48M |
+| macosx106 i386 gcc 4.2 | [root_v5.32.02.macosx106-i386-gcc-4.2.tar.gz](https://root.cern/download/root_v5.32.02.macosx106-i386-gcc-4.2.tar.gz) |  42M |
+| macosx106 gcc 4.2 | [root_v5.32.02.macosx106-x86_64-gcc-4.2.tar.gz](https://root.cern/download/root_v5.32.02.macosx106-x86_64-gcc-4.2.tar.gz) |  43M |
+| Windows Visual Studio 10 (dbg) | [root_v5.32.02.win32.vc10.debug.tar.gz](https://root.cern/download/root_v5.32.02.win32.vc10.debug.tar.gz) | 148M |
+| Windows Visual Studio 10 | [root_v5.32.02.win32.vc10.tar.gz](https://root.cern/download/root_v5.32.02.win32.vc10.tar.gz) |  58M |
+| Windows Visual Studio 90 (dbg) | [root_v5.32.02.win32.vc90.debug.tar.gz](https://root.cern/download/root_v5.32.02.win32.vc90.debug.tar.gz) | 144M |
+| Windows Visual Studio 90 | [root_v5.32.02.win32.vc90.tar.gz](https://root.cern/download/root_v5.32.02.win32.vc90.tar.gz) |  56M |
 
 
 
@@ -66,7 +66,7 @@ To use ROOT directly from AFS:
 The entire ROOT source can be obtained from our public Git repository:
 
 ~~~
-git clone http://root.cern.ch/git/root.git
+git clone http://root.cern/git/root.git
 ~~~
 The release specific tag can be obtained using:
 ~~~

--- a/_releases/release-53203.md
+++ b/_releases/release-53203.md
@@ -13,28 +13,28 @@ sidebar:
 
 ## Release Notes
 
-The release notes for this release can be found [here](https://root.cern.ch/root/html532/notes/release-notes.html#patch-releases)
+The release notes for this release can be found [here](https://root.cern/root/html532/notes/release-notes.html#patch-releases)
 
 ## Source distribution
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v5.32.03.source.tar.gz](https://root.cern.ch/download/root_v5.32.03.source.tar.gz) |  53M |
+| source | [root_v5.32.03.source.tar.gz](https://root.cern/download/root_v5.32.03.source.tar.gz) |  53M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| Linux slc5 gcc4.3 | [root_v5.32.03.Linux-slc5-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.32.03.Linux-slc5-gcc4.3.tar.gz) |  47M |
-| Linux slc5_amd64 gcc4.3 | [root_v5.32.03.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.32.03.Linux-slc5_amd64-gcc4.3.tar.gz) |  48M |
-| OsX 10.7 i386 | [root_v5.32.03.macosx64-10.7-i386.tar.gz](https://root.cern.ch/download/root_v5.32.03.macosx64-10.7-i386.tar.gz) |  45M |
-| macosx106 i386 gcc 4.2 | [root_v5.32.03.macosx106-i386-gcc-4.2.tar.gz](https://root.cern.ch/download/root_v5.32.03.macosx106-i386-gcc-4.2.tar.gz) |  42M |
-| macosx106 gcc 4.2 | [root_v5.32.03.macosx106-x86_64-gcc-4.2.tar.gz](https://root.cern.ch/download/root_v5.32.03.macosx106-x86_64-gcc-4.2.tar.gz) |  43M |
-| Windows Visual Studio 10 (dbg) | [root_v5.32.03.win32.vc10.debug.tar.gz](https://root.cern.ch/download/root_v5.32.03.win32.vc10.debug.tar.gz) | 148M |
-| Windows Visual Studio 10 | [root_v5.32.03.win32.vc10.tar.gz](https://root.cern.ch/download/root_v5.32.03.win32.vc10.tar.gz) |  58M |
-| Windows Visual Studio 90 (dbg) | [root_v5.32.03.win32.vc90.debug.tar.gz](https://root.cern.ch/download/root_v5.32.03.win32.vc90.debug.tar.gz) | 144M |
-| Windows Visual Studio 90 | [root_v5.32.03.win32.vc90.tar.gz](https://root.cern.ch/download/root_v5.32.03.win32.vc90.tar.gz) |  56M |
+| Linux slc5 gcc4.3 | [root_v5.32.03.Linux-slc5-gcc4.3.tar.gz](https://root.cern/download/root_v5.32.03.Linux-slc5-gcc4.3.tar.gz) |  47M |
+| Linux slc5_amd64 gcc4.3 | [root_v5.32.03.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern/download/root_v5.32.03.Linux-slc5_amd64-gcc4.3.tar.gz) |  48M |
+| OsX 10.7 i386 | [root_v5.32.03.macosx64-10.7-i386.tar.gz](https://root.cern/download/root_v5.32.03.macosx64-10.7-i386.tar.gz) |  45M |
+| macosx106 i386 gcc 4.2 | [root_v5.32.03.macosx106-i386-gcc-4.2.tar.gz](https://root.cern/download/root_v5.32.03.macosx106-i386-gcc-4.2.tar.gz) |  42M |
+| macosx106 gcc 4.2 | [root_v5.32.03.macosx106-x86_64-gcc-4.2.tar.gz](https://root.cern/download/root_v5.32.03.macosx106-x86_64-gcc-4.2.tar.gz) |  43M |
+| Windows Visual Studio 10 (dbg) | [root_v5.32.03.win32.vc10.debug.tar.gz](https://root.cern/download/root_v5.32.03.win32.vc10.debug.tar.gz) | 148M |
+| Windows Visual Studio 10 | [root_v5.32.03.win32.vc10.tar.gz](https://root.cern/download/root_v5.32.03.win32.vc10.tar.gz) |  58M |
+| Windows Visual Studio 90 (dbg) | [root_v5.32.03.win32.vc90.debug.tar.gz](https://root.cern/download/root_v5.32.03.win32.vc90.debug.tar.gz) | 144M |
+| Windows Visual Studio 90 | [root_v5.32.03.win32.vc90.tar.gz](https://root.cern/download/root_v5.32.03.win32.vc90.tar.gz) |  56M |
 
 
 
@@ -67,7 +67,7 @@ To use ROOT directly from AFS:
 The entire ROOT source can be obtained from our public Git repository:
 
 ~~~
-git clone http://root.cern.ch/git/root.git
+git clone http://root.cern/git/root.git
 ~~~
 The release specific tag can be obtained using:
 ~~~

--- a/_releases/release-53204.md
+++ b/_releases/release-53204.md
@@ -13,28 +13,28 @@ sidebar:
 
 ## Release Notes
 
-The release notes for this release can be found [here](https://root.cern.ch/root/html532/notes/release-notes.html#patch-releases)
+The release notes for this release can be found [here](https://root.cern/root/html532/notes/release-notes.html#patch-releases)
 
 ## Source distribution
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v5.32.04.source.tar.gz](https://root.cern.ch/download/root_v5.32.04.source.tar.gz) |  53M |
+| source | [root_v5.32.04.source.tar.gz](https://root.cern/download/root_v5.32.04.source.tar.gz) |  53M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| Linux slc5 gcc4.3 | [root_v5.32.04.Linux-slc5-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.32.04.Linux-slc5-gcc4.3.tar.gz) |  47M |
-| Linux slc5_amd64 gcc4.3 | [root_v5.32.04.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.32.04.Linux-slc5_amd64-gcc4.3.tar.gz) |  47M |
-| Scientific Linux Cern 6_amd64 gcc4.6 | [root_v5.32.04.Linux-slc6_amd64-gcc4.6.tar.gz](https://root.cern.ch/download/root_v5.32.04.Linux-slc6_amd64-gcc4.6.tar.gz) |  47M |
-| macosx106 i386 gcc 4.2 | [root_v5.32.04.macosx106-i386-gcc-4.2.tar.gz](https://root.cern.ch/download/root_v5.32.04.macosx106-i386-gcc-4.2.tar.gz) |  42M |
-| macosx106 gcc 4.2 | [root_v5.32.04.macosx106-x86_64-gcc-4.2.tar.gz](https://root.cern.ch/download/root_v5.32.04.macosx106-x86_64-gcc-4.2.tar.gz) |  43M |
-| Windows Visual Studio 10 (dbg) | [root_v5.32.04.win32.vc10.debug.tar.gz](https://root.cern.ch/download/root_v5.32.04.win32.vc10.debug.tar.gz) | 148M |
-| Windows Visual Studio 10 | [root_v5.32.04.win32.vc10.tar.gz](https://root.cern.ch/download/root_v5.32.04.win32.vc10.tar.gz) |  58M |
-| Windows Visual Studio 90 (dbg) | [root_v5.32.04.win32.vc90.debug.tar.gz](https://root.cern.ch/download/root_v5.32.04.win32.vc90.debug.tar.gz) | 144M |
-| Windows Visual Studio 90 | [root_v5.32.04.win32.vc90.tar.gz](https://root.cern.ch/download/root_v5.32.04.win32.vc90.tar.gz) |  56M |
+| Linux slc5 gcc4.3 | [root_v5.32.04.Linux-slc5-gcc4.3.tar.gz](https://root.cern/download/root_v5.32.04.Linux-slc5-gcc4.3.tar.gz) |  47M |
+| Linux slc5_amd64 gcc4.3 | [root_v5.32.04.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern/download/root_v5.32.04.Linux-slc5_amd64-gcc4.3.tar.gz) |  47M |
+| Scientific Linux Cern 6_amd64 gcc4.6 | [root_v5.32.04.Linux-slc6_amd64-gcc4.6.tar.gz](https://root.cern/download/root_v5.32.04.Linux-slc6_amd64-gcc4.6.tar.gz) |  47M |
+| macosx106 i386 gcc 4.2 | [root_v5.32.04.macosx106-i386-gcc-4.2.tar.gz](https://root.cern/download/root_v5.32.04.macosx106-i386-gcc-4.2.tar.gz) |  42M |
+| macosx106 gcc 4.2 | [root_v5.32.04.macosx106-x86_64-gcc-4.2.tar.gz](https://root.cern/download/root_v5.32.04.macosx106-x86_64-gcc-4.2.tar.gz) |  43M |
+| Windows Visual Studio 10 (dbg) | [root_v5.32.04.win32.vc10.debug.tar.gz](https://root.cern/download/root_v5.32.04.win32.vc10.debug.tar.gz) | 148M |
+| Windows Visual Studio 10 | [root_v5.32.04.win32.vc10.tar.gz](https://root.cern/download/root_v5.32.04.win32.vc10.tar.gz) |  58M |
+| Windows Visual Studio 90 (dbg) | [root_v5.32.04.win32.vc90.debug.tar.gz](https://root.cern/download/root_v5.32.04.win32.vc90.debug.tar.gz) | 144M |
+| Windows Visual Studio 90 | [root_v5.32.04.win32.vc90.tar.gz](https://root.cern/download/root_v5.32.04.win32.vc90.tar.gz) |  56M |
 
 
 
@@ -69,7 +69,7 @@ To use ROOT directly from AFS:
 The entire ROOT source can be obtained from our public Git repository:
 
 ~~~
-git clone http://root.cern.ch/git/root.git
+git clone http://root.cern/git/root.git
 ~~~
 The release specific tag can be obtained using:
 ~~~

--- a/_releases/release-53302.md
+++ b/_releases/release-53302.md
@@ -15,22 +15,22 @@ sidebar:
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v5.33.02.source.tar.gz](https://root.cern.ch/download/root_v5.33.02.source.tar.gz) |  53M |
+| source | [root_v5.33.02.source.tar.gz](https://root.cern/download/root_v5.33.02.source.tar.gz) |  53M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| Linux slc5 gcc4.3 | [root_v5.33.02.Linux-slc5-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.33.02.Linux-slc5-gcc4.3.tar.gz) |  47M |
-| Linux slc5_amd64 gcc4.3 | [root_v5.33.02.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.33.02.Linux-slc5_amd64-gcc4.3.tar.gz) |  48M |
-| OsX 10.7 i386 | [root_v5.33.02.macosx64-10.7-i386.tar.gz](https://root.cern.ch/download/root_v5.33.02.macosx64-10.7-i386.tar.gz) |  46M |
-| macosx106 i386 gcc 4.2 | [root_v5.33.02.macosx106-i386-gcc-4.2.tar.gz](https://root.cern.ch/download/root_v5.33.02.macosx106-i386-gcc-4.2.tar.gz) |  42M |
-| macosx106 gcc 4.2 | [root_v5.33.02.macosx106-x86_64-gcc-4.2.tar.gz](https://root.cern.ch/download/root_v5.33.02.macosx106-x86_64-gcc-4.2.tar.gz) |  43M |
-| Windows Visual Studio 10 (dbg) | [root_v5.33.02.win32.vc10.debug.tar.gz](https://root.cern.ch/download/root_v5.33.02.win32.vc10.debug.tar.gz) | 149M |
-| Windows Visual Studio 10 | [root_v5.33.02.win32.vc10.tar.gz](https://root.cern.ch/download/root_v5.33.02.win32.vc10.tar.gz) |  58M |
-| Windows Visual Studio 90 (dbg) | [root_v5.33.02.win32.vc90.debug.tar.gz](https://root.cern.ch/download/root_v5.33.02.win32.vc90.debug.tar.gz) | 144M |
-| Windows Visual Studio 90 | [root_v5.33.02.win32.vc90.tar.gz](https://root.cern.ch/download/root_v5.33.02.win32.vc90.tar.gz) |  56M |
+| Linux slc5 gcc4.3 | [root_v5.33.02.Linux-slc5-gcc4.3.tar.gz](https://root.cern/download/root_v5.33.02.Linux-slc5-gcc4.3.tar.gz) |  47M |
+| Linux slc5_amd64 gcc4.3 | [root_v5.33.02.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern/download/root_v5.33.02.Linux-slc5_amd64-gcc4.3.tar.gz) |  48M |
+| OsX 10.7 i386 | [root_v5.33.02.macosx64-10.7-i386.tar.gz](https://root.cern/download/root_v5.33.02.macosx64-10.7-i386.tar.gz) |  46M |
+| macosx106 i386 gcc 4.2 | [root_v5.33.02.macosx106-i386-gcc-4.2.tar.gz](https://root.cern/download/root_v5.33.02.macosx106-i386-gcc-4.2.tar.gz) |  42M |
+| macosx106 gcc 4.2 | [root_v5.33.02.macosx106-x86_64-gcc-4.2.tar.gz](https://root.cern/download/root_v5.33.02.macosx106-x86_64-gcc-4.2.tar.gz) |  43M |
+| Windows Visual Studio 10 (dbg) | [root_v5.33.02.win32.vc10.debug.tar.gz](https://root.cern/download/root_v5.33.02.win32.vc10.debug.tar.gz) | 149M |
+| Windows Visual Studio 10 | [root_v5.33.02.win32.vc10.tar.gz](https://root.cern/download/root_v5.33.02.win32.vc10.tar.gz) |  58M |
+| Windows Visual Studio 90 (dbg) | [root_v5.33.02.win32.vc90.debug.tar.gz](https://root.cern/download/root_v5.33.02.win32.vc90.debug.tar.gz) | 144M |
+| Windows Visual Studio 90 | [root_v5.33.02.win32.vc90.tar.gz](https://root.cern/download/root_v5.33.02.win32.vc90.tar.gz) |  56M |
 
 
 
@@ -61,7 +61,7 @@ To use ROOT directly from AFS:
 The entire ROOT source can be obtained from our public Git repository:
 
 ~~~
-git clone http://root.cern.ch/git/root.git
+git clone http://root.cern/git/root.git
 ~~~
 The release specific tag can be obtained using:
 ~~~

--- a/_releases/release-53400.md
+++ b/_releases/release-53400.md
@@ -19,33 +19,33 @@ The release notes for this release can be found [here]({{ '/install/all_releases
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| root_v5.34.00 rc1.source | [root_v5.34.00-rc1.source.tar.gz](https://root.cern.ch/download/root_v5.34.00-rc1.source.tar.gz) |  53M |
-| source | [root_v5.34.00.source.tar.gz](https://root.cern.ch/download/root_v5.34.00.source.tar.gz) |  54M |
+| root_v5.34.00 rc1.source | [root_v5.34.00-rc1.source.tar.gz](https://root.cern/download/root_v5.34.00-rc1.source.tar.gz) |  53M |
+| source | [root_v5.34.00.source.tar.gz](https://root.cern/download/root_v5.34.00.source.tar.gz) |  54M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| root_v5.34.00 rc1.Linux slc5 gcc4.3 | [root_v5.34.00-rc1.Linux-slc5-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.34.00-rc1.Linux-slc5-gcc4.3.tar.gz) |  47M |
-| root_v5.34.00 rc1.Linux slc5_amd64 gcc4.3 | [root_v5.34.00-rc1.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.34.00-rc1.Linux-slc5_amd64-gcc4.3.tar.gz) |  49M |
-| root_v5.34.00 rc1.OsX 10.7 i386 | [root_v5.34.00-rc1.macosx64-10.7-i386.tar.gz](https://root.cern.ch/download/root_v5.34.00-rc1.macosx64-10.7-i386.tar.gz) |  46M |
-| root_v5.34.00 rc1.macosx106 i386 gcc 4.2 | [root_v5.34.00-rc1.macosx106-i386-gcc-4.2.tar.gz](https://root.cern.ch/download/root_v5.34.00-rc1.macosx106-i386-gcc-4.2.tar.gz) |  42M |
-| root_v5.34.00 rc1.macosx106 gcc 4.2 | [root_v5.34.00-rc1.macosx106-x86_64-gcc-4.2.tar.gz](https://root.cern.ch/download/root_v5.34.00-rc1.macosx106-x86_64-gcc-4.2.tar.gz) |  44M |
-| root_v5.34.00 rc1.Windows Visual Studio 10 (dbg) | [root_v5.34.00-rc1.win32.vc10.debug.tar.gz](https://root.cern.ch/download/root_v5.34.00-rc1.win32.vc10.debug.tar.gz) | 147M |
-| root_v5.34.00 rc1.Windows Visual Studio 10 | [root_v5.34.00-rc1.win32.vc10.tar.gz](https://root.cern.ch/download/root_v5.34.00-rc1.win32.vc10.tar.gz) |  58M |
-| root_v5.34.00 rc1.Windows Visual Studio 90 (dbg) | [root_v5.34.00-rc1.win32.vc90.debug.tar.gz](https://root.cern.ch/download/root_v5.34.00-rc1.win32.vc90.debug.tar.gz) | 142M |
-| root_v5.34.00 rc1.Windows Visual Studio 90 | [root_v5.34.00-rc1.win32.vc90.tar.gz](https://root.cern.ch/download/root_v5.34.00-rc1.win32.vc90.tar.gz) |  56M |
-| Linux slc5 gcc4.3 | [root_v5.34.00.Linux-slc5-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.34.00.Linux-slc5-gcc4.3.tar.gz) |  47M |
-| Linux slc5_amd64 gcc4.3 | [root_v5.34.00.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.34.00.Linux-slc5_amd64-gcc4.3.tar.gz) |  49M |
-| Scientific Linux Cern 6_amd64 gcc4.6 | [root_v5.34.00.Linux-slc6_amd64-gcc4.6.tar.gz](https://root.cern.ch/download/root_v5.34.00.Linux-slc6_amd64-gcc4.6.tar.gz) |  45M |
-| OsX 10.7 i386 | [root_v5.34.00.macosx64-10.7-i386.tar.gz](https://root.cern.ch/download/root_v5.34.00.macosx64-10.7-i386.tar.gz) |  46M |
-| macosx106 i386 gcc 4.2 | [root_v5.34.00.macosx106-i386-gcc-4.2.tar.gz](https://root.cern.ch/download/root_v5.34.00.macosx106-i386-gcc-4.2.tar.gz) |  42M |
-| macosx106 gcc 4.2 | [root_v5.34.00.macosx106-x86_64-gcc-4.2.tar.gz](https://root.cern.ch/download/root_v5.34.00.macosx106-x86_64-gcc-4.2.tar.gz) |  44M |
-| Windows Visual Studio 10 (dbg) | [root_v5.34.00.win32.vc10.debug.tar.gz](https://root.cern.ch/download/root_v5.34.00.win32.vc10.debug.tar.gz) | 150M |
-| Windows Visual Studio 10 | [root_v5.34.00.win32.vc10.tar.gz](https://root.cern.ch/download/root_v5.34.00.win32.vc10.tar.gz) |  59M |
-| Windows Visual Studio 90 (dbg) | [root_v5.34.00.win32.vc90.debug.tar.gz](https://root.cern.ch/download/root_v5.34.00.win32.vc90.debug.tar.gz) | 145M |
-| Windows Visual Studio 90 | [root_v5.34.00.win32.vc90.tar.gz](https://root.cern.ch/download/root_v5.34.00.win32.vc90.tar.gz) |  57M |
+| root_v5.34.00 rc1.Linux slc5 gcc4.3 | [root_v5.34.00-rc1.Linux-slc5-gcc4.3.tar.gz](https://root.cern/download/root_v5.34.00-rc1.Linux-slc5-gcc4.3.tar.gz) |  47M |
+| root_v5.34.00 rc1.Linux slc5_amd64 gcc4.3 | [root_v5.34.00-rc1.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern/download/root_v5.34.00-rc1.Linux-slc5_amd64-gcc4.3.tar.gz) |  49M |
+| root_v5.34.00 rc1.OsX 10.7 i386 | [root_v5.34.00-rc1.macosx64-10.7-i386.tar.gz](https://root.cern/download/root_v5.34.00-rc1.macosx64-10.7-i386.tar.gz) |  46M |
+| root_v5.34.00 rc1.macosx106 i386 gcc 4.2 | [root_v5.34.00-rc1.macosx106-i386-gcc-4.2.tar.gz](https://root.cern/download/root_v5.34.00-rc1.macosx106-i386-gcc-4.2.tar.gz) |  42M |
+| root_v5.34.00 rc1.macosx106 gcc 4.2 | [root_v5.34.00-rc1.macosx106-x86_64-gcc-4.2.tar.gz](https://root.cern/download/root_v5.34.00-rc1.macosx106-x86_64-gcc-4.2.tar.gz) |  44M |
+| root_v5.34.00 rc1.Windows Visual Studio 10 (dbg) | [root_v5.34.00-rc1.win32.vc10.debug.tar.gz](https://root.cern/download/root_v5.34.00-rc1.win32.vc10.debug.tar.gz) | 147M |
+| root_v5.34.00 rc1.Windows Visual Studio 10 | [root_v5.34.00-rc1.win32.vc10.tar.gz](https://root.cern/download/root_v5.34.00-rc1.win32.vc10.tar.gz) |  58M |
+| root_v5.34.00 rc1.Windows Visual Studio 90 (dbg) | [root_v5.34.00-rc1.win32.vc90.debug.tar.gz](https://root.cern/download/root_v5.34.00-rc1.win32.vc90.debug.tar.gz) | 142M |
+| root_v5.34.00 rc1.Windows Visual Studio 90 | [root_v5.34.00-rc1.win32.vc90.tar.gz](https://root.cern/download/root_v5.34.00-rc1.win32.vc90.tar.gz) |  56M |
+| Linux slc5 gcc4.3 | [root_v5.34.00.Linux-slc5-gcc4.3.tar.gz](https://root.cern/download/root_v5.34.00.Linux-slc5-gcc4.3.tar.gz) |  47M |
+| Linux slc5_amd64 gcc4.3 | [root_v5.34.00.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern/download/root_v5.34.00.Linux-slc5_amd64-gcc4.3.tar.gz) |  49M |
+| Scientific Linux Cern 6_amd64 gcc4.6 | [root_v5.34.00.Linux-slc6_amd64-gcc4.6.tar.gz](https://root.cern/download/root_v5.34.00.Linux-slc6_amd64-gcc4.6.tar.gz) |  45M |
+| OsX 10.7 i386 | [root_v5.34.00.macosx64-10.7-i386.tar.gz](https://root.cern/download/root_v5.34.00.macosx64-10.7-i386.tar.gz) |  46M |
+| macosx106 i386 gcc 4.2 | [root_v5.34.00.macosx106-i386-gcc-4.2.tar.gz](https://root.cern/download/root_v5.34.00.macosx106-i386-gcc-4.2.tar.gz) |  42M |
+| macosx106 gcc 4.2 | [root_v5.34.00.macosx106-x86_64-gcc-4.2.tar.gz](https://root.cern/download/root_v5.34.00.macosx106-x86_64-gcc-4.2.tar.gz) |  44M |
+| Windows Visual Studio 10 (dbg) | [root_v5.34.00.win32.vc10.debug.tar.gz](https://root.cern/download/root_v5.34.00.win32.vc10.debug.tar.gz) | 150M |
+| Windows Visual Studio 10 | [root_v5.34.00.win32.vc10.tar.gz](https://root.cern/download/root_v5.34.00.win32.vc10.tar.gz) |  59M |
+| Windows Visual Studio 90 (dbg) | [root_v5.34.00.win32.vc90.debug.tar.gz](https://root.cern/download/root_v5.34.00.win32.vc90.debug.tar.gz) | 145M |
+| Windows Visual Studio 90 | [root_v5.34.00.win32.vc90.tar.gz](https://root.cern/download/root_v5.34.00.win32.vc90.tar.gz) |  57M |
 
 
 
@@ -80,7 +80,7 @@ To use ROOT directly from AFS:
 The entire ROOT source can be obtained from our public Git repository:
 
 ~~~
-git clone http://root.cern.ch/git/root.git
+git clone http://root.cern/git/root.git
 ~~~
 The release specific tag can be obtained using:
 ~~~

--- a/_releases/release-53401.md
+++ b/_releases/release-53401.md
@@ -19,22 +19,22 @@ The release notes for this release can be found [here]({{ '/install/all_releases
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v5.34.01.source.tar.gz](https://root.cern.ch/download/root_v5.34.01.source.tar.gz) |  54M |
+| source | [root_v5.34.01.source.tar.gz](https://root.cern/download/root_v5.34.01.source.tar.gz) |  54M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| Linux slc5 gcc4.3 | [root_v5.34.01.Linux-slc5-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.34.01.Linux-slc5-gcc4.3.tar.gz) |  48M |
-| Linux slc5_amd64 gcc4.3 | [root_v5.34.01.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.34.01.Linux-slc5_amd64-gcc4.3.tar.gz) |  48M |
-| Scientific Linux Cern 6_amd64 gcc4.6 | [root_v5.34.01.Linux-slc6_amd64-gcc4.6.tar.gz](https://root.cern.ch/download/root_v5.34.01.Linux-slc6_amd64-gcc4.6.tar.gz) |  48M |
-| macosx106 i386 gcc 4.2 | [root_v5.34.01.macosx106-i386-gcc-4.2.tar.gz](https://root.cern.ch/download/root_v5.34.01.macosx106-i386-gcc-4.2.tar.gz) |  42M |
-| macosx106 gcc 4.2 | [root_v5.34.01.macosx106-x86_64-gcc-4.2.tar.gz](https://root.cern.ch/download/root_v5.34.01.macosx106-x86_64-gcc-4.2.tar.gz) |  44M |
-| Windows Visual Studio 10 (dbg) | [root_v5.34.01.win32.vc10.debug.tar.gz](https://root.cern.ch/download/root_v5.34.01.win32.vc10.debug.tar.gz) | 150M |
-| Windows Visual Studio 10 | [root_v5.34.01.win32.vc10.tar.gz](https://root.cern.ch/download/root_v5.34.01.win32.vc10.tar.gz) |  59M |
-| Windows Visual Studio 90 (dbg) | [root_v5.34.01.win32.vc90.debug.tar.gz](https://root.cern.ch/download/root_v5.34.01.win32.vc90.debug.tar.gz) | 146M |
-| Windows Visual Studio 90 | [root_v5.34.01.win32.vc90.tar.gz](https://root.cern.ch/download/root_v5.34.01.win32.vc90.tar.gz) |  57M |
+| Linux slc5 gcc4.3 | [root_v5.34.01.Linux-slc5-gcc4.3.tar.gz](https://root.cern/download/root_v5.34.01.Linux-slc5-gcc4.3.tar.gz) |  48M |
+| Linux slc5_amd64 gcc4.3 | [root_v5.34.01.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern/download/root_v5.34.01.Linux-slc5_amd64-gcc4.3.tar.gz) |  48M |
+| Scientific Linux Cern 6_amd64 gcc4.6 | [root_v5.34.01.Linux-slc6_amd64-gcc4.6.tar.gz](https://root.cern/download/root_v5.34.01.Linux-slc6_amd64-gcc4.6.tar.gz) |  48M |
+| macosx106 i386 gcc 4.2 | [root_v5.34.01.macosx106-i386-gcc-4.2.tar.gz](https://root.cern/download/root_v5.34.01.macosx106-i386-gcc-4.2.tar.gz) |  42M |
+| macosx106 gcc 4.2 | [root_v5.34.01.macosx106-x86_64-gcc-4.2.tar.gz](https://root.cern/download/root_v5.34.01.macosx106-x86_64-gcc-4.2.tar.gz) |  44M |
+| Windows Visual Studio 10 (dbg) | [root_v5.34.01.win32.vc10.debug.tar.gz](https://root.cern/download/root_v5.34.01.win32.vc10.debug.tar.gz) | 150M |
+| Windows Visual Studio 10 | [root_v5.34.01.win32.vc10.tar.gz](https://root.cern/download/root_v5.34.01.win32.vc10.tar.gz) |  59M |
+| Windows Visual Studio 90 (dbg) | [root_v5.34.01.win32.vc90.debug.tar.gz](https://root.cern/download/root_v5.34.01.win32.vc90.debug.tar.gz) | 146M |
+| Windows Visual Studio 90 | [root_v5.34.01.win32.vc90.tar.gz](https://root.cern/download/root_v5.34.01.win32.vc90.tar.gz) |  57M |
 
 
 
@@ -69,7 +69,7 @@ To use ROOT directly from AFS:
 The entire ROOT source can be obtained from our public Git repository:
 
 ~~~
-git clone http://root.cern.ch/git/root.git
+git clone http://root.cern/git/root.git
 ~~~
 The release specific tag can be obtained using:
 ~~~

--- a/_releases/release-53402.md
+++ b/_releases/release-53402.md
@@ -19,26 +19,26 @@ The release notes for this release can be found [here]({{ '/install/all_releases
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v5.34.02.source.tar.gz](https://root.cern.ch/download/root_v5.34.02.source.tar.gz) |  54M |
+| source | [root_v5.34.02.source.tar.gz](https://root.cern/download/root_v5.34.02.source.tar.gz) |  54M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| Linux slc5 gcc4.3 | [root_v5.34.02.Linux-slc5-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.34.02.Linux-slc5-gcc4.3.tar.gz) |  48M |
-| Linux slc5_amd64 gcc4.3 | [root_v5.34.02.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.34.02.Linux-slc5_amd64-gcc4.3.tar.gz) |  48M |
-| Scientific Linux Cern 6_amd64 gcc4.6 | [root_v5.34.02.Linux-slc6_amd64-gcc4.6.tar.gz](https://root.cern.ch/download/root_v5.34.02.Linux-slc6_amd64-gcc4.6.tar.gz) |  48M |
-| aix5 | [root_v5.34.02.aix5.tar.gz](https://root.cern.ch/download/root_v5.34.02.aix5.tar.gz) |  73M |
-| OsX 10.7 i386 | [root_v5.34.02.macosx64-10.7-i386.tar.gz](https://root.cern.ch/download/root_v5.34.02.macosx64-10.7-i386.tar.gz) |  44M |
-| OsX 10.8 i386 | [root_v5.34.02.macosx64-10.8-i386.tar.gz](https://root.cern.ch/download/root_v5.34.02.macosx64-10.8-i386.tar.gz) |  46M |
-| macosx106 i386 gcc 4.2 | [root_v5.34.02.macosx106-i386-gcc-4.2.tar.gz](https://root.cern.ch/download/root_v5.34.02.macosx106-i386-gcc-4.2.tar.gz) |  42M |
-| macosx106 gcc 4.2 | [root_v5.34.02.macosx106-x86_64-gcc-4.2.tar.gz](https://root.cern.ch/download/root_v5.34.02.macosx106-x86_64-gcc-4.2.tar.gz) |  44M |
-| solaris64CC5 5.11 i386 | [root_v5.34.02.solaris64CC5-5.11-i386.tar.gz](https://root.cern.ch/download/root_v5.34.02.solaris64CC5-5.11-i386.tar.gz) |  57M |
-| Windows Visual Studio 10 (dbg) | [root_v5.34.02.win32.vc10.debug.tar.gz](https://root.cern.ch/download/root_v5.34.02.win32.vc10.debug.tar.gz) | 150M |
-| Windows Visual Studio 10 | [root_v5.34.02.win32.vc10.tar.gz](https://root.cern.ch/download/root_v5.34.02.win32.vc10.tar.gz) |  59M |
-| Windows Visual Studio 90 (dbg) | [root_v5.34.02.win32.vc90.debug.tar.gz](https://root.cern.ch/download/root_v5.34.02.win32.vc90.debug.tar.gz) | 146M |
-| Windows Visual Studio 90 | [root_v5.34.02.win32.vc90.tar.gz](https://root.cern.ch/download/root_v5.34.02.win32.vc90.tar.gz) |  57M |
+| Linux slc5 gcc4.3 | [root_v5.34.02.Linux-slc5-gcc4.3.tar.gz](https://root.cern/download/root_v5.34.02.Linux-slc5-gcc4.3.tar.gz) |  48M |
+| Linux slc5_amd64 gcc4.3 | [root_v5.34.02.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern/download/root_v5.34.02.Linux-slc5_amd64-gcc4.3.tar.gz) |  48M |
+| Scientific Linux Cern 6_amd64 gcc4.6 | [root_v5.34.02.Linux-slc6_amd64-gcc4.6.tar.gz](https://root.cern/download/root_v5.34.02.Linux-slc6_amd64-gcc4.6.tar.gz) |  48M |
+| aix5 | [root_v5.34.02.aix5.tar.gz](https://root.cern/download/root_v5.34.02.aix5.tar.gz) |  73M |
+| OsX 10.7 i386 | [root_v5.34.02.macosx64-10.7-i386.tar.gz](https://root.cern/download/root_v5.34.02.macosx64-10.7-i386.tar.gz) |  44M |
+| OsX 10.8 i386 | [root_v5.34.02.macosx64-10.8-i386.tar.gz](https://root.cern/download/root_v5.34.02.macosx64-10.8-i386.tar.gz) |  46M |
+| macosx106 i386 gcc 4.2 | [root_v5.34.02.macosx106-i386-gcc-4.2.tar.gz](https://root.cern/download/root_v5.34.02.macosx106-i386-gcc-4.2.tar.gz) |  42M |
+| macosx106 gcc 4.2 | [root_v5.34.02.macosx106-x86_64-gcc-4.2.tar.gz](https://root.cern/download/root_v5.34.02.macosx106-x86_64-gcc-4.2.tar.gz) |  44M |
+| solaris64CC5 5.11 i386 | [root_v5.34.02.solaris64CC5-5.11-i386.tar.gz](https://root.cern/download/root_v5.34.02.solaris64CC5-5.11-i386.tar.gz) |  57M |
+| Windows Visual Studio 10 (dbg) | [root_v5.34.02.win32.vc10.debug.tar.gz](https://root.cern/download/root_v5.34.02.win32.vc10.debug.tar.gz) | 150M |
+| Windows Visual Studio 10 | [root_v5.34.02.win32.vc10.tar.gz](https://root.cern/download/root_v5.34.02.win32.vc10.tar.gz) |  59M |
+| Windows Visual Studio 90 (dbg) | [root_v5.34.02.win32.vc90.debug.tar.gz](https://root.cern/download/root_v5.34.02.win32.vc90.debug.tar.gz) | 146M |
+| Windows Visual Studio 90 | [root_v5.34.02.win32.vc90.tar.gz](https://root.cern/download/root_v5.34.02.win32.vc90.tar.gz) |  57M |
 
 
 
@@ -73,7 +73,7 @@ To use ROOT directly from AFS:
 The entire ROOT source can be obtained from our public Git repository:
 
 ~~~
-git clone http://root.cern.ch/git/root.git
+git clone http://root.cern/git/root.git
 ~~~
 The release specific tag can be obtained using:
 ~~~

--- a/_releases/release-53403.md
+++ b/_releases/release-53403.md
@@ -18,24 +18,24 @@ The release notes for this release can be found [here]({{ '/install/all_releases
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v5.34.03.source.tar.gz](https://root.cern.ch/download/root_v5.34.03.source.tar.gz) |  54M |
+| source | [root_v5.34.03.source.tar.gz](https://root.cern/download/root_v5.34.03.source.tar.gz) |  54M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| Linux slc5 gcc4.3 | [root_v5.34.03.Linux-slc5-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.34.03.Linux-slc5-gcc4.3.tar.gz) |  48M |
-| Linux slc5_amd64 gcc4.3 | [root_v5.34.03.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.34.03.Linux-slc5_amd64-gcc4.3.tar.gz) |  48M |
-| Scientific Linux Cern 6_amd64 gcc4.4 | [root_v5.34.03.Linux-slc6_amd64-gcc4.4.tar.gz](https://root.cern.ch/download/root_v5.34.03.Linux-slc6_amd64-gcc4.4.tar.gz) |  43M |
-| Scientific Linux Cern 6_amd64 gcc4.6 | [root_v5.34.03.Linux-slc6_amd64-gcc4.6.tar.gz](https://root.cern.ch/download/root_v5.34.03.Linux-slc6_amd64-gcc4.6.tar.gz) |  48M |
-| OsX 10.8 i386 | [root_v5.34.03.macosx64-10.8-i386.tar.gz](https://root.cern.ch/download/root_v5.34.03.macosx64-10.8-i386.tar.gz) |  46M |
-| macosx106 i386 gcc 4.2 | [root_v5.34.03.macosx106-i386-gcc-4.2.tar.gz](https://root.cern.ch/download/root_v5.34.03.macosx106-i386-gcc-4.2.tar.gz) |  42M |
-| macosx106 gcc 4.2 | [root_v5.34.03.macosx106-x86_64-gcc-4.2.tar.gz](https://root.cern.ch/download/root_v5.34.03.macosx106-x86_64-gcc-4.2.tar.gz) |  44M |
-| Windows Visual Studio 10 (dbg) | [root_v5.34.03.win32.vc10.debug.tar.gz](https://root.cern.ch/download/root_v5.34.03.win32.vc10.debug.tar.gz) | 150M |
-| Windows Visual Studio 10 | [root_v5.34.03.win32.vc10.tar.gz](https://root.cern.ch/download/root_v5.34.03.win32.vc10.tar.gz) |  59M |
-| Windows Visual Studio 90 (dbg) | [root_v5.34.03.win32.vc90.debug.tar.gz](https://root.cern.ch/download/root_v5.34.03.win32.vc90.debug.tar.gz) | 144M |
-| Windows Visual Studio 90 | [root_v5.34.03.win32.vc90.tar.gz](https://root.cern.ch/download/root_v5.34.03.win32.vc90.tar.gz) |  57M |
+| Linux slc5 gcc4.3 | [root_v5.34.03.Linux-slc5-gcc4.3.tar.gz](https://root.cern/download/root_v5.34.03.Linux-slc5-gcc4.3.tar.gz) |  48M |
+| Linux slc5_amd64 gcc4.3 | [root_v5.34.03.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern/download/root_v5.34.03.Linux-slc5_amd64-gcc4.3.tar.gz) |  48M |
+| Scientific Linux Cern 6_amd64 gcc4.4 | [root_v5.34.03.Linux-slc6_amd64-gcc4.4.tar.gz](https://root.cern/download/root_v5.34.03.Linux-slc6_amd64-gcc4.4.tar.gz) |  43M |
+| Scientific Linux Cern 6_amd64 gcc4.6 | [root_v5.34.03.Linux-slc6_amd64-gcc4.6.tar.gz](https://root.cern/download/root_v5.34.03.Linux-slc6_amd64-gcc4.6.tar.gz) |  48M |
+| OsX 10.8 i386 | [root_v5.34.03.macosx64-10.8-i386.tar.gz](https://root.cern/download/root_v5.34.03.macosx64-10.8-i386.tar.gz) |  46M |
+| macosx106 i386 gcc 4.2 | [root_v5.34.03.macosx106-i386-gcc-4.2.tar.gz](https://root.cern/download/root_v5.34.03.macosx106-i386-gcc-4.2.tar.gz) |  42M |
+| macosx106 gcc 4.2 | [root_v5.34.03.macosx106-x86_64-gcc-4.2.tar.gz](https://root.cern/download/root_v5.34.03.macosx106-x86_64-gcc-4.2.tar.gz) |  44M |
+| Windows Visual Studio 10 (dbg) | [root_v5.34.03.win32.vc10.debug.tar.gz](https://root.cern/download/root_v5.34.03.win32.vc10.debug.tar.gz) | 150M |
+| Windows Visual Studio 10 | [root_v5.34.03.win32.vc10.tar.gz](https://root.cern/download/root_v5.34.03.win32.vc10.tar.gz) |  59M |
+| Windows Visual Studio 90 (dbg) | [root_v5.34.03.win32.vc90.debug.tar.gz](https://root.cern/download/root_v5.34.03.win32.vc90.debug.tar.gz) | 144M |
+| Windows Visual Studio 90 | [root_v5.34.03.win32.vc90.tar.gz](https://root.cern/download/root_v5.34.03.win32.vc90.tar.gz) |  57M |
 
 
 
@@ -70,7 +70,7 @@ To use ROOT directly from AFS:
 The entire ROOT source can be obtained from our public Git repository:
 
 ~~~
-git clone http://root.cern.ch/git/root.git
+git clone http://root.cern/git/root.git
 ~~~
 The release specific tag can be obtained using:
 ~~~

--- a/_releases/release-53404.md
+++ b/_releases/release-53404.md
@@ -19,28 +19,28 @@ The release notes for this release can be found [here]({{ '/install/all_releases
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v5.34.04.source.tar.gz](https://root.cern.ch/download/root_v5.34.04.source.tar.gz) |  61M |
+| source | [root_v5.34.04.source.tar.gz](https://root.cern/download/root_v5.34.04.source.tar.gz) |  61M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| Linux slc5 gcc4.3 | [root_v5.34.04.Linux-slc5-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.34.04.Linux-slc5-gcc4.3.tar.gz) |  55M |
-| Linux slc5_amd64 gcc4.3 | [root_v5.34.04.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.34.04.Linux-slc5_amd64-gcc4.3.tar.gz) |  56M |
-| Scientific Linux Cern 6_amd64 gcc4.4 | [root_v5.34.04.Linux-slc6_amd64-gcc4.4.tar.gz](https://root.cern.ch/download/root_v5.34.04.Linux-slc6_amd64-gcc4.4.tar.gz) |  50M |
-| Scientific Linux Cern 6_amd64 gcc4.6 | [root_v5.34.04.Linux-slc6_amd64-gcc4.6.tar.gz](https://root.cern.ch/download/root_v5.34.04.Linux-slc6_amd64-gcc4.6.tar.gz) |  53M |
-| OsX 10.8 i386 | [root_v5.34.04.macosx64-10.8-i386.tar.gz](https://root.cern.ch/download/root_v5.34.04.macosx64-10.8-i386.tar.gz) |  54M |
-| macosx106 i386 gcc 4.2 | [root_v5.34.04.macosx106-i386-gcc-4.2.tar.gz](https://root.cern.ch/download/root_v5.34.04.macosx106-i386-gcc-4.2.tar.gz) |  50M |
-| macosx106 gcc 4.2 | [root_v5.34.04.macosx106-x86_64-gcc-4.2.tar.gz](https://root.cern.ch/download/root_v5.34.04.macosx106-x86_64-gcc-4.2.tar.gz) |  52M |
-| Windows Visual Studio 10 (dbg) | [root_v5.34.04.win32.vc10.debug.tar.gz](https://root.cern.ch/download/root_v5.34.04.win32.vc10.debug.tar.gz) | 160M |
-| Windows Visual Studio 10.python26 (dbg) | [root_v5.34.04.win32.vc10.python26.debug.tar.gz](https://root.cern.ch/download/root_v5.34.04.win32.vc10.python26.debug.tar.gz) | 160M |
-| Windows Visual Studio 10.python26 | [root_v5.34.04.win32.vc10.python26.tar.gz](https://root.cern.ch/download/root_v5.34.04.win32.vc10.python26.tar.gz) |  67M |
-| Windows Visual Studio 10 | [root_v5.34.04.win32.vc10.tar.gz](https://root.cern.ch/download/root_v5.34.04.win32.vc10.tar.gz) |  67M |
-| Windows Visual Studio 90 (dbg) | [root_v5.34.04.win32.vc90.debug.tar.gz](https://root.cern.ch/download/root_v5.34.04.win32.vc90.debug.tar.gz) | 153M |
-| Windows Visual Studio 90.python26 (dbg) | [root_v5.34.04.win32.vc90.python26.debug.tar.gz](https://root.cern.ch/download/root_v5.34.04.win32.vc90.python26.debug.tar.gz) | 153M |
-| Windows Visual Studio 90.python26 | [root_v5.34.04.win32.vc90.python26.tar.gz](https://root.cern.ch/download/root_v5.34.04.win32.vc90.python26.tar.gz) |  64M |
-| Windows Visual Studio 90 | [root_v5.34.04.win32.vc90.tar.gz](https://root.cern.ch/download/root_v5.34.04.win32.vc90.tar.gz) |  64M |
+| Linux slc5 gcc4.3 | [root_v5.34.04.Linux-slc5-gcc4.3.tar.gz](https://root.cern/download/root_v5.34.04.Linux-slc5-gcc4.3.tar.gz) |  55M |
+| Linux slc5_amd64 gcc4.3 | [root_v5.34.04.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern/download/root_v5.34.04.Linux-slc5_amd64-gcc4.3.tar.gz) |  56M |
+| Scientific Linux Cern 6_amd64 gcc4.4 | [root_v5.34.04.Linux-slc6_amd64-gcc4.4.tar.gz](https://root.cern/download/root_v5.34.04.Linux-slc6_amd64-gcc4.4.tar.gz) |  50M |
+| Scientific Linux Cern 6_amd64 gcc4.6 | [root_v5.34.04.Linux-slc6_amd64-gcc4.6.tar.gz](https://root.cern/download/root_v5.34.04.Linux-slc6_amd64-gcc4.6.tar.gz) |  53M |
+| OsX 10.8 i386 | [root_v5.34.04.macosx64-10.8-i386.tar.gz](https://root.cern/download/root_v5.34.04.macosx64-10.8-i386.tar.gz) |  54M |
+| macosx106 i386 gcc 4.2 | [root_v5.34.04.macosx106-i386-gcc-4.2.tar.gz](https://root.cern/download/root_v5.34.04.macosx106-i386-gcc-4.2.tar.gz) |  50M |
+| macosx106 gcc 4.2 | [root_v5.34.04.macosx106-x86_64-gcc-4.2.tar.gz](https://root.cern/download/root_v5.34.04.macosx106-x86_64-gcc-4.2.tar.gz) |  52M |
+| Windows Visual Studio 10 (dbg) | [root_v5.34.04.win32.vc10.debug.tar.gz](https://root.cern/download/root_v5.34.04.win32.vc10.debug.tar.gz) | 160M |
+| Windows Visual Studio 10.python26 (dbg) | [root_v5.34.04.win32.vc10.python26.debug.tar.gz](https://root.cern/download/root_v5.34.04.win32.vc10.python26.debug.tar.gz) | 160M |
+| Windows Visual Studio 10.python26 | [root_v5.34.04.win32.vc10.python26.tar.gz](https://root.cern/download/root_v5.34.04.win32.vc10.python26.tar.gz) |  67M |
+| Windows Visual Studio 10 | [root_v5.34.04.win32.vc10.tar.gz](https://root.cern/download/root_v5.34.04.win32.vc10.tar.gz) |  67M |
+| Windows Visual Studio 90 (dbg) | [root_v5.34.04.win32.vc90.debug.tar.gz](https://root.cern/download/root_v5.34.04.win32.vc90.debug.tar.gz) | 153M |
+| Windows Visual Studio 90.python26 (dbg) | [root_v5.34.04.win32.vc90.python26.debug.tar.gz](https://root.cern/download/root_v5.34.04.win32.vc90.python26.debug.tar.gz) | 153M |
+| Windows Visual Studio 90.python26 | [root_v5.34.04.win32.vc90.python26.tar.gz](https://root.cern/download/root_v5.34.04.win32.vc90.python26.tar.gz) |  64M |
+| Windows Visual Studio 90 | [root_v5.34.04.win32.vc90.tar.gz](https://root.cern/download/root_v5.34.04.win32.vc90.tar.gz) |  64M |
 
 
 
@@ -75,7 +75,7 @@ To use ROOT directly from AFS:
 The entire ROOT source can be obtained from our public Git repository:
 
 ~~~
-git clone http://root.cern.ch/git/root.git
+git clone http://root.cern/git/root.git
 ~~~
 The release specific tag can be obtained using:
 ~~~

--- a/_releases/release-53405.md
+++ b/_releases/release-53405.md
@@ -18,24 +18,24 @@ The release notes for this release can be found [here]({{ '/install/all_releases
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v5.34.05.source.tar.gz](https://root.cern.ch/download/root_v5.34.05.source.tar.gz) |  61M |
+| source | [root_v5.34.05.source.tar.gz](https://root.cern/download/root_v5.34.05.source.tar.gz) |  61M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| Linux slc5 gcc4.3 | [root_v5.34.05.Linux-slc5-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.34.05.Linux-slc5-gcc4.3.tar.gz) |  55M |
-| Linux slc5_amd64 gcc4.3 | [root_v5.34.05.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.34.05.Linux-slc5_amd64-gcc4.3.tar.gz) |  56M |
-| Scientific Linux Cern 6_amd64 gcc4.4 | [root_v5.34.05.Linux-slc6_amd64-gcc4.4.tar.gz](https://root.cern.ch/download/root_v5.34.05.Linux-slc6_amd64-gcc4.4.tar.gz) |  50M |
-| Scientific Linux Cern 6_amd64 gcc4.6 | [root_v5.34.05.Linux-slc6_amd64-gcc4.6.tar.gz](https://root.cern.ch/download/root_v5.34.05.Linux-slc6_amd64-gcc4.6.tar.gz) |  53M |
-| OsX 10.8 i386 | [root_v5.34.05.macosx64-10.8-i386.tar.gz](https://root.cern.ch/download/root_v5.34.05.macosx64-10.8-i386.tar.gz) |  54M |
-| macosx106 i386 gcc 4.2 | [root_v5.34.05.macosx106-i386-gcc-4.2.tar.gz](https://root.cern.ch/download/root_v5.34.05.macosx106-i386-gcc-4.2.tar.gz) |  50M |
-| macosx106 gcc 4.2 | [root_v5.34.05.macosx106-x86_64-gcc-4.2.tar.gz](https://root.cern.ch/download/root_v5.34.05.macosx106-x86_64-gcc-4.2.tar.gz) |  52M |
-| Windows Visual Studio 10 (dbg) | [root_v5.34.05.win32.vc10.debug.tar.gz](https://root.cern.ch/download/root_v5.34.05.win32.vc10.debug.tar.gz) | 160M |
-| Windows Visual Studio 10 | [root_v5.34.05.win32.vc10.tar.gz](https://root.cern.ch/download/root_v5.34.05.win32.vc10.tar.gz) |  67M |
-| Windows Visual Studio 90 (dbg) | [root_v5.34.05.win32.vc90.debug.tar.gz](https://root.cern.ch/download/root_v5.34.05.win32.vc90.debug.tar.gz) | 154M |
-| Windows Visual Studio 90 | [root_v5.34.05.win32.vc90.tar.gz](https://root.cern.ch/download/root_v5.34.05.win32.vc90.tar.gz) |  64M |
+| Linux slc5 gcc4.3 | [root_v5.34.05.Linux-slc5-gcc4.3.tar.gz](https://root.cern/download/root_v5.34.05.Linux-slc5-gcc4.3.tar.gz) |  55M |
+| Linux slc5_amd64 gcc4.3 | [root_v5.34.05.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern/download/root_v5.34.05.Linux-slc5_amd64-gcc4.3.tar.gz) |  56M |
+| Scientific Linux Cern 6_amd64 gcc4.4 | [root_v5.34.05.Linux-slc6_amd64-gcc4.4.tar.gz](https://root.cern/download/root_v5.34.05.Linux-slc6_amd64-gcc4.4.tar.gz) |  50M |
+| Scientific Linux Cern 6_amd64 gcc4.6 | [root_v5.34.05.Linux-slc6_amd64-gcc4.6.tar.gz](https://root.cern/download/root_v5.34.05.Linux-slc6_amd64-gcc4.6.tar.gz) |  53M |
+| OsX 10.8 i386 | [root_v5.34.05.macosx64-10.8-i386.tar.gz](https://root.cern/download/root_v5.34.05.macosx64-10.8-i386.tar.gz) |  54M |
+| macosx106 i386 gcc 4.2 | [root_v5.34.05.macosx106-i386-gcc-4.2.tar.gz](https://root.cern/download/root_v5.34.05.macosx106-i386-gcc-4.2.tar.gz) |  50M |
+| macosx106 gcc 4.2 | [root_v5.34.05.macosx106-x86_64-gcc-4.2.tar.gz](https://root.cern/download/root_v5.34.05.macosx106-x86_64-gcc-4.2.tar.gz) |  52M |
+| Windows Visual Studio 10 (dbg) | [root_v5.34.05.win32.vc10.debug.tar.gz](https://root.cern/download/root_v5.34.05.win32.vc10.debug.tar.gz) | 160M |
+| Windows Visual Studio 10 | [root_v5.34.05.win32.vc10.tar.gz](https://root.cern/download/root_v5.34.05.win32.vc10.tar.gz) |  67M |
+| Windows Visual Studio 90 (dbg) | [root_v5.34.05.win32.vc90.debug.tar.gz](https://root.cern/download/root_v5.34.05.win32.vc90.debug.tar.gz) | 154M |
+| Windows Visual Studio 90 | [root_v5.34.05.win32.vc90.tar.gz](https://root.cern/download/root_v5.34.05.win32.vc90.tar.gz) |  64M |
 
 
 
@@ -70,7 +70,7 @@ To use ROOT directly from AFS:
 The entire ROOT source can be obtained from our public Git repository:
 
 ~~~
-git clone http://root.cern.ch/git/root.git
+git clone http://root.cern/git/root.git
 ~~~
 The release specific tag can be obtained using:
 ~~~

--- a/_releases/release-53406.md
+++ b/_releases/release-53406.md
@@ -19,23 +19,23 @@ The release notes for this release can be found [here]({{ '/install/all_releases
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v5.34.06.source.tar.gz](https://root.cern.ch/download/root_v5.34.06.source.tar.gz) |  64M |
+| source | [root_v5.34.06.source.tar.gz](https://root.cern/download/root_v5.34.06.source.tar.gz) |  64M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| Linux slc5 gcc4.3 | [root_v5.34.06.Linux-slc5-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.34.06.Linux-slc5-gcc4.3.tar.gz) |  56M |
-| Linux slc5_amd64 gcc4.3 | [root_v5.34.06.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.34.06.Linux-slc5_amd64-gcc4.3.tar.gz) |  56M |
-| Scientific Linux Cern 6_amd64 gcc4.4 | [root_v5.34.06.Linux-slc6_amd64-gcc4.4.tar.gz](https://root.cern.ch/download/root_v5.34.06.Linux-slc6_amd64-gcc4.4.tar.gz) |  54M |
-| Scientific Linux Cern 6_amd64 gcc4.6 | [root_v5.34.06.Linux-slc6_amd64-gcc4.6.tar.gz](https://root.cern.ch/download/root_v5.34.06.Linux-slc6_amd64-gcc4.6.tar.gz) |  57M |
-| macosx106 i386 gcc 4.2 | [root_v5.34.06.macosx106-i386-gcc-4.2.tar.gz](https://root.cern.ch/download/root_v5.34.06.macosx106-i386-gcc-4.2.tar.gz) |  50M |
-| macosx106 gcc 4.2 | [root_v5.34.06.macosx106-x86_64-gcc-4.2.tar.gz](https://root.cern.ch/download/root_v5.34.06.macosx106-x86_64-gcc-4.2.tar.gz) |  52M |
-| Windows Visual Studio 10 (dbg) | [root_v5.34.06.win32.vc10.debug.tar.gz](https://root.cern.ch/download/root_v5.34.06.win32.vc10.debug.tar.gz) | 162M |
-| Windows Visual Studio 10 | [root_v5.34.06.win32.vc10.tar.gz](https://root.cern.ch/download/root_v5.34.06.win32.vc10.tar.gz) |  67M |
-| Windows Visual Studio 90 (dbg) | [root_v5.34.06.win32.vc90.debug.tar.gz](https://root.cern.ch/download/root_v5.34.06.win32.vc90.debug.tar.gz) | 155M |
-| Windows Visual Studio 90 | [root_v5.34.06.win32.vc90.tar.gz](https://root.cern.ch/download/root_v5.34.06.win32.vc90.tar.gz) |  65M |
+| Linux slc5 gcc4.3 | [root_v5.34.06.Linux-slc5-gcc4.3.tar.gz](https://root.cern/download/root_v5.34.06.Linux-slc5-gcc4.3.tar.gz) |  56M |
+| Linux slc5_amd64 gcc4.3 | [root_v5.34.06.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern/download/root_v5.34.06.Linux-slc5_amd64-gcc4.3.tar.gz) |  56M |
+| Scientific Linux Cern 6_amd64 gcc4.4 | [root_v5.34.06.Linux-slc6_amd64-gcc4.4.tar.gz](https://root.cern/download/root_v5.34.06.Linux-slc6_amd64-gcc4.4.tar.gz) |  54M |
+| Scientific Linux Cern 6_amd64 gcc4.6 | [root_v5.34.06.Linux-slc6_amd64-gcc4.6.tar.gz](https://root.cern/download/root_v5.34.06.Linux-slc6_amd64-gcc4.6.tar.gz) |  57M |
+| macosx106 i386 gcc 4.2 | [root_v5.34.06.macosx106-i386-gcc-4.2.tar.gz](https://root.cern/download/root_v5.34.06.macosx106-i386-gcc-4.2.tar.gz) |  50M |
+| macosx106 gcc 4.2 | [root_v5.34.06.macosx106-x86_64-gcc-4.2.tar.gz](https://root.cern/download/root_v5.34.06.macosx106-x86_64-gcc-4.2.tar.gz) |  52M |
+| Windows Visual Studio 10 (dbg) | [root_v5.34.06.win32.vc10.debug.tar.gz](https://root.cern/download/root_v5.34.06.win32.vc10.debug.tar.gz) | 162M |
+| Windows Visual Studio 10 | [root_v5.34.06.win32.vc10.tar.gz](https://root.cern/download/root_v5.34.06.win32.vc10.tar.gz) |  67M |
+| Windows Visual Studio 90 (dbg) | [root_v5.34.06.win32.vc90.debug.tar.gz](https://root.cern/download/root_v5.34.06.win32.vc90.debug.tar.gz) | 155M |
+| Windows Visual Studio 90 | [root_v5.34.06.win32.vc90.tar.gz](https://root.cern/download/root_v5.34.06.win32.vc90.tar.gz) |  65M |
 
 
 
@@ -70,7 +70,7 @@ To use ROOT directly from AFS:
 The entire ROOT source can be obtained from our public Git repository:
 
 ~~~
-git clone http://root.cern.ch/git/root.git
+git clone http://root.cern/git/root.git
 ~~~
 The release specific tag can be obtained using:
 ~~~

--- a/_releases/release-53407.md
+++ b/_releases/release-53407.md
@@ -19,23 +19,23 @@ The release notes for this release can be found [here]({{ '/install/all_releases
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v5.34.07.source.tar.gz](https://root.cern.ch/download/root_v5.34.07.source.tar.gz) |  64M |
+| source | [root_v5.34.07.source.tar.gz](https://root.cern/download/root_v5.34.07.source.tar.gz) |  64M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| Linux slc5 gcc4.3 | [root_v5.34.07.Linux-slc5-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.34.07.Linux-slc5-gcc4.3.tar.gz) |  56M |
-| Linux slc5_amd64 gcc4.3 | [root_v5.34.07.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.34.07.Linux-slc5_amd64-gcc4.3.tar.gz) |  56M |
-| Scientific Linux Cern 6_amd64 gcc4.4 | [root_v5.34.07.Linux-slc6_amd64-gcc4.4.tar.gz](https://root.cern.ch/download/root_v5.34.07.Linux-slc6_amd64-gcc4.4.tar.gz) |  54M |
-| Scientific Linux Cern 6_amd64 gcc4.6 | [root_v5.34.07.Linux-slc6_amd64-gcc4.6.tar.gz](https://root.cern.ch/download/root_v5.34.07.Linux-slc6_amd64-gcc4.6.tar.gz) |  57M |
-| macosx106 i386 gcc 4.2 | [root_v5.34.07.macosx106-i386-gcc-4.2.tar.gz](https://root.cern.ch/download/root_v5.34.07.macosx106-i386-gcc-4.2.tar.gz) |  50M |
-| macosx106 gcc 4.2 | [root_v5.34.07.macosx106-x86_64-gcc-4.2.tar.gz](https://root.cern.ch/download/root_v5.34.07.macosx106-x86_64-gcc-4.2.tar.gz) |  52M |
-| Windows Visual Studio 10 (dbg) | [root_v5.34.07.win32.vc10.debug.tar.gz](https://root.cern.ch/download/root_v5.34.07.win32.vc10.debug.tar.gz) | 162M |
-| Windows Visual Studio 10 | [root_v5.34.07.win32.vc10.tar.gz](https://root.cern.ch/download/root_v5.34.07.win32.vc10.tar.gz) |  67M |
-| Windows Visual Studio 90 (dbg) | [root_v5.34.07.win32.vc90.debug.tar.gz](https://root.cern.ch/download/root_v5.34.07.win32.vc90.debug.tar.gz) | 155M |
-| Windows Visual Studio 90 | [root_v5.34.07.win32.vc90.tar.gz](https://root.cern.ch/download/root_v5.34.07.win32.vc90.tar.gz) |  65M |
+| Linux slc5 gcc4.3 | [root_v5.34.07.Linux-slc5-gcc4.3.tar.gz](https://root.cern/download/root_v5.34.07.Linux-slc5-gcc4.3.tar.gz) |  56M |
+| Linux slc5_amd64 gcc4.3 | [root_v5.34.07.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern/download/root_v5.34.07.Linux-slc5_amd64-gcc4.3.tar.gz) |  56M |
+| Scientific Linux Cern 6_amd64 gcc4.4 | [root_v5.34.07.Linux-slc6_amd64-gcc4.4.tar.gz](https://root.cern/download/root_v5.34.07.Linux-slc6_amd64-gcc4.4.tar.gz) |  54M |
+| Scientific Linux Cern 6_amd64 gcc4.6 | [root_v5.34.07.Linux-slc6_amd64-gcc4.6.tar.gz](https://root.cern/download/root_v5.34.07.Linux-slc6_amd64-gcc4.6.tar.gz) |  57M |
+| macosx106 i386 gcc 4.2 | [root_v5.34.07.macosx106-i386-gcc-4.2.tar.gz](https://root.cern/download/root_v5.34.07.macosx106-i386-gcc-4.2.tar.gz) |  50M |
+| macosx106 gcc 4.2 | [root_v5.34.07.macosx106-x86_64-gcc-4.2.tar.gz](https://root.cern/download/root_v5.34.07.macosx106-x86_64-gcc-4.2.tar.gz) |  52M |
+| Windows Visual Studio 10 (dbg) | [root_v5.34.07.win32.vc10.debug.tar.gz](https://root.cern/download/root_v5.34.07.win32.vc10.debug.tar.gz) | 162M |
+| Windows Visual Studio 10 | [root_v5.34.07.win32.vc10.tar.gz](https://root.cern/download/root_v5.34.07.win32.vc10.tar.gz) |  67M |
+| Windows Visual Studio 90 (dbg) | [root_v5.34.07.win32.vc90.debug.tar.gz](https://root.cern/download/root_v5.34.07.win32.vc90.debug.tar.gz) | 155M |
+| Windows Visual Studio 90 | [root_v5.34.07.win32.vc90.tar.gz](https://root.cern/download/root_v5.34.07.win32.vc90.tar.gz) |  65M |
 
 
 
@@ -70,7 +70,7 @@ To use ROOT directly from AFS:
 The entire ROOT source can be obtained from our public Git repository:
 
 ~~~
-git clone http://root.cern.ch/git/root.git
+git clone http://root.cern/git/root.git
 ~~~
 The release specific tag can be obtained using:
 ~~~

--- a/_releases/release-53408.md
+++ b/_releases/release-53408.md
@@ -19,19 +19,19 @@ The release notes for this release can be found [here]({{ '/install/all_releases
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v5.34.08.source.tar.gz](https://root.cern.ch/download/root_v5.34.08.source.tar.gz) |  63M |
+| source | [root_v5.34.08.source.tar.gz](https://root.cern/download/root_v5.34.08.source.tar.gz) |  63M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| Linux slc5 gcc4.3 | [root_v5.34.08.Linux-slc5-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.34.08.Linux-slc5-gcc4.3.tar.gz) |  56M |
-| Linux slc5_amd64 gcc4.3 | [root_v5.34.08.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.34.08.Linux-slc5_amd64-gcc4.3.tar.gz) |  56M |
-| Scientific Linux Cern 6_amd64 gcc4.4 | [root_v5.34.08.Linux-slc6_amd64-gcc4.4.tar.gz](https://root.cern.ch/download/root_v5.34.08.Linux-slc6_amd64-gcc4.4.tar.gz) |  54M |
-| Scientific Linux Cern 6_amd64 gcc4.6 | [root_v5.34.08.Linux-slc6_amd64-gcc4.6.tar.gz](https://root.cern.ch/download/root_v5.34.08.Linux-slc6_amd64-gcc4.6.tar.gz) |  57M |
-| macosx106 i386 gcc 4.2 | [root_v5.34.08.macosx106-i386-gcc-4.2.tar.gz](https://root.cern.ch/download/root_v5.34.08.macosx106-i386-gcc-4.2.tar.gz) |  50M |
-| macosx106 gcc 4.2 | [root_v5.34.08.macosx106-x86_64-gcc-4.2.tar.gz](https://root.cern.ch/download/root_v5.34.08.macosx106-x86_64-gcc-4.2.tar.gz) |  52M |
+| Linux slc5 gcc4.3 | [root_v5.34.08.Linux-slc5-gcc4.3.tar.gz](https://root.cern/download/root_v5.34.08.Linux-slc5-gcc4.3.tar.gz) |  56M |
+| Linux slc5_amd64 gcc4.3 | [root_v5.34.08.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern/download/root_v5.34.08.Linux-slc5_amd64-gcc4.3.tar.gz) |  56M |
+| Scientific Linux Cern 6_amd64 gcc4.4 | [root_v5.34.08.Linux-slc6_amd64-gcc4.4.tar.gz](https://root.cern/download/root_v5.34.08.Linux-slc6_amd64-gcc4.4.tar.gz) |  54M |
+| Scientific Linux Cern 6_amd64 gcc4.6 | [root_v5.34.08.Linux-slc6_amd64-gcc4.6.tar.gz](https://root.cern/download/root_v5.34.08.Linux-slc6_amd64-gcc4.6.tar.gz) |  57M |
+| macosx106 i386 gcc 4.2 | [root_v5.34.08.macosx106-i386-gcc-4.2.tar.gz](https://root.cern/download/root_v5.34.08.macosx106-i386-gcc-4.2.tar.gz) |  50M |
+| macosx106 gcc 4.2 | [root_v5.34.08.macosx106-x86_64-gcc-4.2.tar.gz](https://root.cern/download/root_v5.34.08.macosx106-x86_64-gcc-4.2.tar.gz) |  52M |
 
 
 
@@ -67,7 +67,7 @@ To use ROOT directly from AFS:
 The entire ROOT source can be obtained from our public Git repository:
 
 ~~~
-git clone http://root.cern.ch/git/root.git
+git clone http://root.cern/git/root.git
 ~~~
 The release specific tag can be obtained using:
 ~~~

--- a/_releases/release-53409.md
+++ b/_releases/release-53409.md
@@ -19,23 +19,23 @@ The release notes for this release can be found [here]({{ '/install/all_releases
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v5.34.09.source.tar.gz](https://root.cern.ch/download/root_v5.34.09.source.tar.gz) |  63M |
+| source | [root_v5.34.09.source.tar.gz](https://root.cern/download/root_v5.34.09.source.tar.gz) |  63M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| Linux slc5 gcc4.3 | [root_v5.34.09.Linux-slc5-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.34.09.Linux-slc5-gcc4.3.tar.gz) |  56M |
-| Linux slc5_amd64 gcc4.3 | [root_v5.34.09.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.34.09.Linux-slc5_amd64-gcc4.3.tar.gz) |  57M |
-| Scientific Linux Cern 6_amd64 gcc4.4 | [root_v5.34.09.Linux-slc6_amd64-gcc4.4.tar.gz](https://root.cern.ch/download/root_v5.34.09.Linux-slc6_amd64-gcc4.4.tar.gz) |  54M |
-| Scientific Linux Cern 6_amd64 gcc4.6 | [root_v5.34.09.Linux-slc6_amd64-gcc4.6.tar.gz](https://root.cern.ch/download/root_v5.34.09.Linux-slc6_amd64-gcc4.6.tar.gz) |  57M |
-| macosx106 i386 gcc 4.2 | [root_v5.34.09.macosx106-i386-gcc-4.2.tar.gz](https://root.cern.ch/download/root_v5.34.09.macosx106-i386-gcc-4.2.tar.gz) |  50M |
-| macosx106 gcc 4.2 | [root_v5.34.09.macosx106-x86_64-gcc-4.2.tar.gz](https://root.cern.ch/download/root_v5.34.09.macosx106-x86_64-gcc-4.2.tar.gz) |  52M |
-| Windows Visual Studio 10 (dbg) | [root_v5.34.09.win32.vc10.debug.tar.gz](https://root.cern.ch/download/root_v5.34.09.win32.vc10.debug.tar.gz) | 161M |
-| Windows Visual Studio 10 | [root_v5.34.09.win32.vc10.tar.gz](https://root.cern.ch/download/root_v5.34.09.win32.vc10.tar.gz) |  67M |
-| Windows Visual Studio 90 (dbg) | [root_v5.34.09.win32.vc90.debug.tar.gz](https://root.cern.ch/download/root_v5.34.09.win32.vc90.debug.tar.gz) | 156M |
-| Windows Visual Studio 90 | [root_v5.34.09.win32.vc90.tar.gz](https://root.cern.ch/download/root_v5.34.09.win32.vc90.tar.gz) |  65M |
+| Linux slc5 gcc4.3 | [root_v5.34.09.Linux-slc5-gcc4.3.tar.gz](https://root.cern/download/root_v5.34.09.Linux-slc5-gcc4.3.tar.gz) |  56M |
+| Linux slc5_amd64 gcc4.3 | [root_v5.34.09.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern/download/root_v5.34.09.Linux-slc5_amd64-gcc4.3.tar.gz) |  57M |
+| Scientific Linux Cern 6_amd64 gcc4.4 | [root_v5.34.09.Linux-slc6_amd64-gcc4.4.tar.gz](https://root.cern/download/root_v5.34.09.Linux-slc6_amd64-gcc4.4.tar.gz) |  54M |
+| Scientific Linux Cern 6_amd64 gcc4.6 | [root_v5.34.09.Linux-slc6_amd64-gcc4.6.tar.gz](https://root.cern/download/root_v5.34.09.Linux-slc6_amd64-gcc4.6.tar.gz) |  57M |
+| macosx106 i386 gcc 4.2 | [root_v5.34.09.macosx106-i386-gcc-4.2.tar.gz](https://root.cern/download/root_v5.34.09.macosx106-i386-gcc-4.2.tar.gz) |  50M |
+| macosx106 gcc 4.2 | [root_v5.34.09.macosx106-x86_64-gcc-4.2.tar.gz](https://root.cern/download/root_v5.34.09.macosx106-x86_64-gcc-4.2.tar.gz) |  52M |
+| Windows Visual Studio 10 (dbg) | [root_v5.34.09.win32.vc10.debug.tar.gz](https://root.cern/download/root_v5.34.09.win32.vc10.debug.tar.gz) | 161M |
+| Windows Visual Studio 10 | [root_v5.34.09.win32.vc10.tar.gz](https://root.cern/download/root_v5.34.09.win32.vc10.tar.gz) |  67M |
+| Windows Visual Studio 90 (dbg) | [root_v5.34.09.win32.vc90.debug.tar.gz](https://root.cern/download/root_v5.34.09.win32.vc90.debug.tar.gz) | 156M |
+| Windows Visual Studio 90 | [root_v5.34.09.win32.vc90.tar.gz](https://root.cern/download/root_v5.34.09.win32.vc90.tar.gz) |  65M |
 
 
 
@@ -70,7 +70,7 @@ To use ROOT directly from AFS:
 The entire ROOT source can be obtained from our public Git repository:
 
 ~~~
-git clone http://root.cern.ch/git/root.git
+git clone http://root.cern/git/root.git
 ~~~
 The release specific tag can be obtained using:
 ~~~

--- a/_releases/release-53410.md
+++ b/_releases/release-53410.md
@@ -19,23 +19,23 @@ The release notes for this release can be found [here]({{ '/install/all_releases
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v5.34.10.source.tar.gz](https://root.cern.ch/download/root_v5.34.10.source.tar.gz) |  64M |
+| source | [root_v5.34.10.source.tar.gz](https://root.cern/download/root_v5.34.10.source.tar.gz) |  64M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| Linux slc5 gcc4.3 | [root_v5.34.10.Linux-slc5-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.34.10.Linux-slc5-gcc4.3.tar.gz) |  56M |
-| Linux slc5_amd64 gcc4.3 | [root_v5.34.10.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.34.10.Linux-slc5_amd64-gcc4.3.tar.gz) |  57M |
-| Scientific Linux Cern 6_amd64 gcc4.4 | [root_v5.34.10.Linux-slc6_amd64-gcc4.4.tar.gz](https://root.cern.ch/download/root_v5.34.10.Linux-slc6_amd64-gcc4.4.tar.gz) |  54M |
-| Scientific Linux Cern 6_amd64 gcc4.6 | [root_v5.34.10.Linux-slc6_amd64-gcc4.6.tar.gz](https://root.cern.ch/download/root_v5.34.10.Linux-slc6_amd64-gcc4.6.tar.gz) |  57M |
-| macosx106 i386 gcc 4.2 | [root_v5.34.10.macosx106-i386-gcc-4.2.tar.gz](https://root.cern.ch/download/root_v5.34.10.macosx106-i386-gcc-4.2.tar.gz) |  50M |
-| macosx106 gcc 4.2 | [root_v5.34.10.macosx106-x86_64-gcc-4.2.tar.gz](https://root.cern.ch/download/root_v5.34.10.macosx106-x86_64-gcc-4.2.tar.gz) |  52M |
-| Windows Visual Studio 10 (dbg) | [root_v5.34.10.win32.vc10.debug.tar.gz](https://root.cern.ch/download/root_v5.34.10.win32.vc10.debug.tar.gz) | 162M |
-| Windows Visual Studio 10 | [root_v5.34.10.win32.vc10.tar.gz](https://root.cern.ch/download/root_v5.34.10.win32.vc10.tar.gz) |  67M |
-| Windows Visual Studio 90 (dbg) | [root_v5.34.10.win32.vc90.debug.tar.gz](https://root.cern.ch/download/root_v5.34.10.win32.vc90.debug.tar.gz) | 155M |
-| Windows Visual Studio 90 | [root_v5.34.10.win32.vc90.tar.gz](https://root.cern.ch/download/root_v5.34.10.win32.vc90.tar.gz) |  65M |
+| Linux slc5 gcc4.3 | [root_v5.34.10.Linux-slc5-gcc4.3.tar.gz](https://root.cern/download/root_v5.34.10.Linux-slc5-gcc4.3.tar.gz) |  56M |
+| Linux slc5_amd64 gcc4.3 | [root_v5.34.10.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern/download/root_v5.34.10.Linux-slc5_amd64-gcc4.3.tar.gz) |  57M |
+| Scientific Linux Cern 6_amd64 gcc4.4 | [root_v5.34.10.Linux-slc6_amd64-gcc4.4.tar.gz](https://root.cern/download/root_v5.34.10.Linux-slc6_amd64-gcc4.4.tar.gz) |  54M |
+| Scientific Linux Cern 6_amd64 gcc4.6 | [root_v5.34.10.Linux-slc6_amd64-gcc4.6.tar.gz](https://root.cern/download/root_v5.34.10.Linux-slc6_amd64-gcc4.6.tar.gz) |  57M |
+| macosx106 i386 gcc 4.2 | [root_v5.34.10.macosx106-i386-gcc-4.2.tar.gz](https://root.cern/download/root_v5.34.10.macosx106-i386-gcc-4.2.tar.gz) |  50M |
+| macosx106 gcc 4.2 | [root_v5.34.10.macosx106-x86_64-gcc-4.2.tar.gz](https://root.cern/download/root_v5.34.10.macosx106-x86_64-gcc-4.2.tar.gz) |  52M |
+| Windows Visual Studio 10 (dbg) | [root_v5.34.10.win32.vc10.debug.tar.gz](https://root.cern/download/root_v5.34.10.win32.vc10.debug.tar.gz) | 162M |
+| Windows Visual Studio 10 | [root_v5.34.10.win32.vc10.tar.gz](https://root.cern/download/root_v5.34.10.win32.vc10.tar.gz) |  67M |
+| Windows Visual Studio 90 (dbg) | [root_v5.34.10.win32.vc90.debug.tar.gz](https://root.cern/download/root_v5.34.10.win32.vc90.debug.tar.gz) | 155M |
+| Windows Visual Studio 90 | [root_v5.34.10.win32.vc90.tar.gz](https://root.cern/download/root_v5.34.10.win32.vc90.tar.gz) |  65M |
 
 
 
@@ -73,7 +73,7 @@ To use ROOT directly from AFS:
 The entire ROOT source can be obtained from our public Git repository:
 
 ~~~
-git clone http://root.cern.ch/git/root.git
+git clone http://root.cern/git/root.git
 ~~~
 The release specific tag can be obtained using:
 ~~~

--- a/_releases/release-53411.md
+++ b/_releases/release-53411.md
@@ -19,23 +19,23 @@ The release notes for this release can be found [here]({{ '/install/all_releases
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v5.34.11.source.tar.gz](https://root.cern.ch/download/root_v5.34.11.source.tar.gz) |  64M |
+| source | [root_v5.34.11.source.tar.gz](https://root.cern/download/root_v5.34.11.source.tar.gz) |  64M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| Linux slc5 gcc4.3 | [root_v5.34.11.Linux-slc5-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.34.11.Linux-slc5-gcc4.3.tar.gz) |  56M |
-| Linux slc5_amd64 gcc4.3 | [root_v5.34.11.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.34.11.Linux-slc5_amd64-gcc4.3.tar.gz) |  57M |
-| Scientific Linux Cern 6_amd64 gcc4.4 | [root_v5.34.11.Linux-slc6_amd64-gcc4.4.tar.gz](https://root.cern.ch/download/root_v5.34.11.Linux-slc6_amd64-gcc4.4.tar.gz) |  54M |
-| Scientific Linux Cern 6_amd64 gcc4.6 | [root_v5.34.11.Linux-slc6_amd64-gcc4.6.tar.gz](https://root.cern.ch/download/root_v5.34.11.Linux-slc6_amd64-gcc4.6.tar.gz) |  57M |
-| macosx106 i386 gcc 4.2 | [root_v5.34.11.macosx106-i386-gcc-4.2.tar.gz](https://root.cern.ch/download/root_v5.34.11.macosx106-i386-gcc-4.2.tar.gz) |  50M |
-| macosx106 gcc 4.2 | [root_v5.34.11.macosx106-x86_64-gcc-4.2.tar.gz](https://root.cern.ch/download/root_v5.34.11.macosx106-x86_64-gcc-4.2.tar.gz) |  52M |
-| Windows Visual Studio 10 (dbg) | [root_v5.34.11.win32.vc10.debug.tar.gz](https://root.cern.ch/download/root_v5.34.11.win32.vc10.debug.tar.gz) | 160M |
-| Windows Visual Studio 10 | [root_v5.34.11.win32.vc10.tar.gz](https://root.cern.ch/download/root_v5.34.11.win32.vc10.tar.gz) |  67M |
-| Windows Visual Studio 90 (dbg) | [root_v5.34.11.win32.vc90.debug.tar.gz](https://root.cern.ch/download/root_v5.34.11.win32.vc90.debug.tar.gz) | 153M |
-| Windows Visual Studio 90 | [root_v5.34.11.win32.vc90.tar.gz](https://root.cern.ch/download/root_v5.34.11.win32.vc90.tar.gz) |  65M |
+| Linux slc5 gcc4.3 | [root_v5.34.11.Linux-slc5-gcc4.3.tar.gz](https://root.cern/download/root_v5.34.11.Linux-slc5-gcc4.3.tar.gz) |  56M |
+| Linux slc5_amd64 gcc4.3 | [root_v5.34.11.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern/download/root_v5.34.11.Linux-slc5_amd64-gcc4.3.tar.gz) |  57M |
+| Scientific Linux Cern 6_amd64 gcc4.4 | [root_v5.34.11.Linux-slc6_amd64-gcc4.4.tar.gz](https://root.cern/download/root_v5.34.11.Linux-slc6_amd64-gcc4.4.tar.gz) |  54M |
+| Scientific Linux Cern 6_amd64 gcc4.6 | [root_v5.34.11.Linux-slc6_amd64-gcc4.6.tar.gz](https://root.cern/download/root_v5.34.11.Linux-slc6_amd64-gcc4.6.tar.gz) |  57M |
+| macosx106 i386 gcc 4.2 | [root_v5.34.11.macosx106-i386-gcc-4.2.tar.gz](https://root.cern/download/root_v5.34.11.macosx106-i386-gcc-4.2.tar.gz) |  50M |
+| macosx106 gcc 4.2 | [root_v5.34.11.macosx106-x86_64-gcc-4.2.tar.gz](https://root.cern/download/root_v5.34.11.macosx106-x86_64-gcc-4.2.tar.gz) |  52M |
+| Windows Visual Studio 10 (dbg) | [root_v5.34.11.win32.vc10.debug.tar.gz](https://root.cern/download/root_v5.34.11.win32.vc10.debug.tar.gz) | 160M |
+| Windows Visual Studio 10 | [root_v5.34.11.win32.vc10.tar.gz](https://root.cern/download/root_v5.34.11.win32.vc10.tar.gz) |  67M |
+| Windows Visual Studio 90 (dbg) | [root_v5.34.11.win32.vc90.debug.tar.gz](https://root.cern/download/root_v5.34.11.win32.vc90.debug.tar.gz) | 153M |
+| Windows Visual Studio 90 | [root_v5.34.11.win32.vc90.tar.gz](https://root.cern/download/root_v5.34.11.win32.vc90.tar.gz) |  65M |
 
 
 
@@ -72,7 +72,7 @@ To use ROOT directly from AFS:
 The entire ROOT source can be obtained from our public Git repository:
 
 ~~~
-git clone http://root.cern.ch/git/root.git
+git clone http://root.cern/git/root.git
 ~~~
 The release specific tag can be obtained using:
 ~~~

--- a/_releases/release-53412.md
+++ b/_releases/release-53412.md
@@ -19,23 +19,23 @@ The release notes for this release can be found [here]({{ '/install/all_releases
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v5.34.12.source.tar.gz](https://root.cern.ch/download/root_v5.34.12.source.tar.gz) |  65M |
+| source | [root_v5.34.12.source.tar.gz](https://root.cern/download/root_v5.34.12.source.tar.gz) |  65M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| Linux slc5 gcc4.3 | [root_v5.34.12.Linux-slc5-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.34.12.Linux-slc5-gcc4.3.tar.gz) |  56M |
-| Linux slc5_amd64 gcc4.3 | [root_v5.34.12.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.34.12.Linux-slc5_amd64-gcc4.3.tar.gz) |  57M |
-| Scientific Linux Cern 6_amd64 gcc4.4 | [root_v5.34.12.Linux-slc6_amd64-gcc4.4.tar.gz](https://root.cern.ch/download/root_v5.34.12.Linux-slc6_amd64-gcc4.4.tar.gz) |  54M |
-| Scientific Linux Cern 6_amd64 gcc4.6 | [root_v5.34.12.Linux-slc6_amd64-gcc4.6.tar.gz](https://root.cern.ch/download/root_v5.34.12.Linux-slc6_amd64-gcc4.6.tar.gz) |  57M |
-| macosx106 i386 gcc 4.2 | [root_v5.34.12.macosx106-i386-gcc-4.2.tar.gz](https://root.cern.ch/download/root_v5.34.12.macosx106-i386-gcc-4.2.tar.gz) |  50M |
-| macosx106 gcc 4.2 | [root_v5.34.12.macosx106-x86_64-gcc-4.2.tar.gz](https://root.cern.ch/download/root_v5.34.12.macosx106-x86_64-gcc-4.2.tar.gz) |  52M |
-| Windows Visual Studio 10 (dbg) | [root_v5.34.12.win32.vc10.debug.tar.gz](https://root.cern.ch/download/root_v5.34.12.win32.vc10.debug.tar.gz) | 164M |
-| Windows Visual Studio 10 | [root_v5.34.12.win32.vc10.tar.gz](https://root.cern.ch/download/root_v5.34.12.win32.vc10.tar.gz) |  68M |
-| Windows Visual Studio 90 (dbg) | [root_v5.34.12.win32.vc90.debug.tar.gz](https://root.cern.ch/download/root_v5.34.12.win32.vc90.debug.tar.gz) | 157M |
-| Windows Visual Studio 90 | [root_v5.34.12.win32.vc90.tar.gz](https://root.cern.ch/download/root_v5.34.12.win32.vc90.tar.gz) |  66M |
+| Linux slc5 gcc4.3 | [root_v5.34.12.Linux-slc5-gcc4.3.tar.gz](https://root.cern/download/root_v5.34.12.Linux-slc5-gcc4.3.tar.gz) |  56M |
+| Linux slc5_amd64 gcc4.3 | [root_v5.34.12.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern/download/root_v5.34.12.Linux-slc5_amd64-gcc4.3.tar.gz) |  57M |
+| Scientific Linux Cern 6_amd64 gcc4.4 | [root_v5.34.12.Linux-slc6_amd64-gcc4.4.tar.gz](https://root.cern/download/root_v5.34.12.Linux-slc6_amd64-gcc4.4.tar.gz) |  54M |
+| Scientific Linux Cern 6_amd64 gcc4.6 | [root_v5.34.12.Linux-slc6_amd64-gcc4.6.tar.gz](https://root.cern/download/root_v5.34.12.Linux-slc6_amd64-gcc4.6.tar.gz) |  57M |
+| macosx106 i386 gcc 4.2 | [root_v5.34.12.macosx106-i386-gcc-4.2.tar.gz](https://root.cern/download/root_v5.34.12.macosx106-i386-gcc-4.2.tar.gz) |  50M |
+| macosx106 gcc 4.2 | [root_v5.34.12.macosx106-x86_64-gcc-4.2.tar.gz](https://root.cern/download/root_v5.34.12.macosx106-x86_64-gcc-4.2.tar.gz) |  52M |
+| Windows Visual Studio 10 (dbg) | [root_v5.34.12.win32.vc10.debug.tar.gz](https://root.cern/download/root_v5.34.12.win32.vc10.debug.tar.gz) | 164M |
+| Windows Visual Studio 10 | [root_v5.34.12.win32.vc10.tar.gz](https://root.cern/download/root_v5.34.12.win32.vc10.tar.gz) |  68M |
+| Windows Visual Studio 90 (dbg) | [root_v5.34.12.win32.vc90.debug.tar.gz](https://root.cern/download/root_v5.34.12.win32.vc90.debug.tar.gz) | 157M |
+| Windows Visual Studio 90 | [root_v5.34.12.win32.vc90.tar.gz](https://root.cern/download/root_v5.34.12.win32.vc90.tar.gz) |  66M |
 
 
 
@@ -72,7 +72,7 @@ To use ROOT directly from AFS:
 The entire ROOT source can be obtained from our public Git repository:
 
 ~~~
-git clone http://root.cern.ch/git/root.git
+git clone http://root.cern/git/root.git
 ~~~
 The release specific tag can be obtained using:
 ~~~

--- a/_releases/release-53413.md
+++ b/_releases/release-53413.md
@@ -18,24 +18,24 @@ The release notes for this release can be found [here]({{ '/install/all_releases
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v5.34.13.source.tar.gz](https://root.cern.ch/download/root_v5.34.13.source.tar.gz) |  65M |
+| source | [root_v5.34.13.source.tar.gz](https://root.cern/download/root_v5.34.13.source.tar.gz) |  65M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| Linux slc5 gcc4.3 | [root_v5.34.13.Linux-slc5-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.34.13.Linux-slc5-gcc4.3.tar.gz) |  56M |
-| Linux slc5_amd64 gcc4.3 | [root_v5.34.13.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.34.13.Linux-slc5_amd64-gcc4.3.tar.gz) |  57M |
-| Scientific Linux Cern 6_amd64 gcc4.4 | [root_v5.34.13.Linux-slc6_amd64-gcc4.4.tar.gz](https://root.cern.ch/download/root_v5.34.13.Linux-slc6_amd64-gcc4.4.tar.gz) |  54M |
-| Scientific Linux Cern 6_amd64 gcc4.7 | [root_v5.34.13.Linux-slc6_amd64-gcc4.7.tar.gz](https://root.cern.ch/download/root_v5.34.13.Linux-slc6_amd64-gcc4.7.tar.gz) |  57M |
-| Scientific Linux Cern 6_amd64 gcc4.8 | [root_v5.34.13.Linux-slc6_amd64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v5.34.13.Linux-slc6_amd64-gcc4.8.tar.gz) |  57M |
-| macosx106 i386 gcc 4.2 | [root_v5.34.13.macosx106-i386-gcc-4.2.tar.gz](https://root.cern.ch/download/root_v5.34.13.macosx106-i386-gcc-4.2.tar.gz) |  50M |
-| macosx106 gcc 4.2 | [root_v5.34.13.macosx106-x86_64-gcc-4.2.tar.gz](https://root.cern.ch/download/root_v5.34.13.macosx106-x86_64-gcc-4.2.tar.gz) |  52M |
-| Windows Visual Studio 10 (dbg) | [root_v5.34.13.win32.vc10.debug.tar.gz](https://root.cern.ch/download/root_v5.34.13.win32.vc10.debug.tar.gz) | 164M |
-| Windows Visual Studio 10 | [root_v5.34.13.win32.vc10.tar.gz](https://root.cern.ch/download/root_v5.34.13.win32.vc10.tar.gz) |  68M |
-| Windows Visual Studio 90 (dbg) | [root_v5.34.13.win32.vc90.debug.tar.gz](https://root.cern.ch/download/root_v5.34.13.win32.vc90.debug.tar.gz) | 158M |
-| Windows Visual Studio 90 | [root_v5.34.13.win32.vc90.tar.gz](https://root.cern.ch/download/root_v5.34.13.win32.vc90.tar.gz) |  66M |
+| Linux slc5 gcc4.3 | [root_v5.34.13.Linux-slc5-gcc4.3.tar.gz](https://root.cern/download/root_v5.34.13.Linux-slc5-gcc4.3.tar.gz) |  56M |
+| Linux slc5_amd64 gcc4.3 | [root_v5.34.13.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern/download/root_v5.34.13.Linux-slc5_amd64-gcc4.3.tar.gz) |  57M |
+| Scientific Linux Cern 6_amd64 gcc4.4 | [root_v5.34.13.Linux-slc6_amd64-gcc4.4.tar.gz](https://root.cern/download/root_v5.34.13.Linux-slc6_amd64-gcc4.4.tar.gz) |  54M |
+| Scientific Linux Cern 6_amd64 gcc4.7 | [root_v5.34.13.Linux-slc6_amd64-gcc4.7.tar.gz](https://root.cern/download/root_v5.34.13.Linux-slc6_amd64-gcc4.7.tar.gz) |  57M |
+| Scientific Linux Cern 6_amd64 gcc4.8 | [root_v5.34.13.Linux-slc6_amd64-gcc4.8.tar.gz](https://root.cern/download/root_v5.34.13.Linux-slc6_amd64-gcc4.8.tar.gz) |  57M |
+| macosx106 i386 gcc 4.2 | [root_v5.34.13.macosx106-i386-gcc-4.2.tar.gz](https://root.cern/download/root_v5.34.13.macosx106-i386-gcc-4.2.tar.gz) |  50M |
+| macosx106 gcc 4.2 | [root_v5.34.13.macosx106-x86_64-gcc-4.2.tar.gz](https://root.cern/download/root_v5.34.13.macosx106-x86_64-gcc-4.2.tar.gz) |  52M |
+| Windows Visual Studio 10 (dbg) | [root_v5.34.13.win32.vc10.debug.tar.gz](https://root.cern/download/root_v5.34.13.win32.vc10.debug.tar.gz) | 164M |
+| Windows Visual Studio 10 | [root_v5.34.13.win32.vc10.tar.gz](https://root.cern/download/root_v5.34.13.win32.vc10.tar.gz) |  68M |
+| Windows Visual Studio 90 (dbg) | [root_v5.34.13.win32.vc90.debug.tar.gz](https://root.cern/download/root_v5.34.13.win32.vc90.debug.tar.gz) | 158M |
+| Windows Visual Studio 90 | [root_v5.34.13.win32.vc90.tar.gz](https://root.cern/download/root_v5.34.13.win32.vc90.tar.gz) |  66M |
 
 
 
@@ -74,7 +74,7 @@ To use ROOT directly from AFS:
 The entire ROOT source can be obtained from our public Git repository:
 
 ~~~
-git clone http://root.cern.ch/git/root.git
+git clone http://root.cern/git/root.git
 ~~~
 The release specific tag can be obtained using:
 ~~~

--- a/_releases/release-53414.md
+++ b/_releases/release-53414.md
@@ -19,26 +19,26 @@ The release notes for this release can be found [here]({{ '/install/all_releases
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v5.34.14.source.tar.gz](https://root.cern.ch/download/root_v5.34.14.source.tar.gz) |  64M |
+| source | [root_v5.34.14.source.tar.gz](https://root.cern/download/root_v5.34.14.source.tar.gz) |  64M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| Linux slc5 gcc4.3 | [root_v5.34.14.Linux-slc5-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.34.14.Linux-slc5-gcc4.3.tar.gz) |  56M |
-| Linux slc5_amd64 gcc4.3 | [root_v5.34.14.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.34.14.Linux-slc5_amd64-gcc4.3.tar.gz) |  57M |
-| Scientific Linux Cern 6_amd64 gcc4.4 | [root_v5.34.14.Linux-slc6_amd64-gcc4.4.tar.gz](https://root.cern.ch/download/root_v5.34.14.Linux-slc6_amd64-gcc4.4.tar.gz) |  54M |
-| Scientific Linux Cern 6_amd64 gcc4.7 | [root_v5.34.14.Linux-slc6_amd64-gcc4.7.tar.gz](https://root.cern.ch/download/root_v5.34.14.Linux-slc6_amd64-gcc4.7.tar.gz) |  57M |
-| Scientific Linux Cern 6_amd64 gcc4.8 | [root_v5.34.14.Linux-slc6_amd64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v5.34.14.Linux-slc6_amd64-gcc4.8.tar.gz) |  57M |
-| macosx106 i386 gcc 4.2 | [root_v5.34.14.macosx106-i386-gcc-4.2.tar.gz](https://root.cern.ch/download/root_v5.34.14.macosx106-i386-gcc-4.2.tar.gz) |  50M |
-| macosx106 gcc 4.2 | [root_v5.34.14.macosx106-x86_64-gcc-4.2.tar.gz](https://root.cern.ch/download/root_v5.34.14.macosx106-x86_64-gcc-4.2.tar.gz) |  52M |
-| Windows Visual Studio 10 (dbg) | [root_v5.34.14.win32.vc10.debug.tar.gz](https://root.cern.ch/download/root_v5.34.14.win32.vc10.debug.tar.gz) | 164M |
-| Windows Visual Studio 10 | [root_v5.34.14.win32.vc10.tar.gz](https://root.cern.ch/download/root_v5.34.14.win32.vc10.tar.gz) |  68M |
-| Windows Visual Studio 11 (dbg) | [root_v5.34.14.win32.vc11.debug.tar.gz](https://root.cern.ch/download/root_v5.34.14.win32.vc11.debug.tar.gz) | 160M |
-| Windows Visual Studio 11 | [root_v5.34.14.win32.vc11.tar.gz](https://root.cern.ch/download/root_v5.34.14.win32.vc11.tar.gz) |  71M |
-| Windows Visual Studio 90 (dbg) | [root_v5.34.14.win32.vc90.debug.tar.gz](https://root.cern.ch/download/root_v5.34.14.win32.vc90.debug.tar.gz) | 158M |
-| Windows Visual Studio 90 | [root_v5.34.14.win32.vc90.tar.gz](https://root.cern.ch/download/root_v5.34.14.win32.vc90.tar.gz) |  66M |
+| Linux slc5 gcc4.3 | [root_v5.34.14.Linux-slc5-gcc4.3.tar.gz](https://root.cern/download/root_v5.34.14.Linux-slc5-gcc4.3.tar.gz) |  56M |
+| Linux slc5_amd64 gcc4.3 | [root_v5.34.14.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern/download/root_v5.34.14.Linux-slc5_amd64-gcc4.3.tar.gz) |  57M |
+| Scientific Linux Cern 6_amd64 gcc4.4 | [root_v5.34.14.Linux-slc6_amd64-gcc4.4.tar.gz](https://root.cern/download/root_v5.34.14.Linux-slc6_amd64-gcc4.4.tar.gz) |  54M |
+| Scientific Linux Cern 6_amd64 gcc4.7 | [root_v5.34.14.Linux-slc6_amd64-gcc4.7.tar.gz](https://root.cern/download/root_v5.34.14.Linux-slc6_amd64-gcc4.7.tar.gz) |  57M |
+| Scientific Linux Cern 6_amd64 gcc4.8 | [root_v5.34.14.Linux-slc6_amd64-gcc4.8.tar.gz](https://root.cern/download/root_v5.34.14.Linux-slc6_amd64-gcc4.8.tar.gz) |  57M |
+| macosx106 i386 gcc 4.2 | [root_v5.34.14.macosx106-i386-gcc-4.2.tar.gz](https://root.cern/download/root_v5.34.14.macosx106-i386-gcc-4.2.tar.gz) |  50M |
+| macosx106 gcc 4.2 | [root_v5.34.14.macosx106-x86_64-gcc-4.2.tar.gz](https://root.cern/download/root_v5.34.14.macosx106-x86_64-gcc-4.2.tar.gz) |  52M |
+| Windows Visual Studio 10 (dbg) | [root_v5.34.14.win32.vc10.debug.tar.gz](https://root.cern/download/root_v5.34.14.win32.vc10.debug.tar.gz) | 164M |
+| Windows Visual Studio 10 | [root_v5.34.14.win32.vc10.tar.gz](https://root.cern/download/root_v5.34.14.win32.vc10.tar.gz) |  68M |
+| Windows Visual Studio 11 (dbg) | [root_v5.34.14.win32.vc11.debug.tar.gz](https://root.cern/download/root_v5.34.14.win32.vc11.debug.tar.gz) | 160M |
+| Windows Visual Studio 11 | [root_v5.34.14.win32.vc11.tar.gz](https://root.cern/download/root_v5.34.14.win32.vc11.tar.gz) |  71M |
+| Windows Visual Studio 90 (dbg) | [root_v5.34.14.win32.vc90.debug.tar.gz](https://root.cern/download/root_v5.34.14.win32.vc90.debug.tar.gz) | 158M |
+| Windows Visual Studio 90 | [root_v5.34.14.win32.vc90.tar.gz](https://root.cern/download/root_v5.34.14.win32.vc90.tar.gz) |  66M |
 
 
 
@@ -77,7 +77,7 @@ To use ROOT directly from AFS:
 The entire ROOT source can be obtained from our public Git repository:
 
 ~~~
-git clone http://root.cern.ch/git/root.git
+git clone http://root.cern/git/root.git
 ~~~
 The release specific tag can be obtained using:
 ~~~

--- a/_releases/release-53417.md
+++ b/_releases/release-53417.md
@@ -19,22 +19,22 @@ The release notes for this release can be found [here]({{ '/install/all_releases
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v5.34.17.source.tar.gz](https://root.cern.ch/download/root_v5.34.17.source.tar.gz) |  64M |
+| source | [root_v5.34.17.source.tar.gz](https://root.cern/download/root_v5.34.17.source.tar.gz) |  64M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| Linux slc5 gcc4.3 | [root_v5.34.17.Linux-slc5-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.34.17.Linux-slc5-gcc4.3.tar.gz) |  56M |
-| Linux slc5_amd64 gcc4.3 | [root_v5.34.17.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.34.17.Linux-slc5_amd64-gcc4.3.tar.gz) |  57M |
-| Scientific Linux Cern 6_amd64 gcc4.4 | [root_v5.34.17.Linux-slc6_amd64-gcc4.4.tar.gz](https://root.cern.ch/download/root_v5.34.17.Linux-slc6_amd64-gcc4.4.tar.gz) |  54M |
-| Scientific Linux Cern 6_amd64 gcc4.7 | [root_v5.34.17.Linux-slc6_amd64-gcc4.7.tar.gz](https://root.cern.ch/download/root_v5.34.17.Linux-slc6_amd64-gcc4.7.tar.gz) |  57M |
-| Scientific Linux Cern 6_amd64 gcc4.8 | [root_v5.34.17.Linux-slc6_amd64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v5.34.17.Linux-slc6_amd64-gcc4.8.tar.gz) |  57M |
-| Windows Visual Studio 10 (dbg) | [root_v5.34.17.win32.vc10.debug.tar.gz](https://root.cern.ch/download/root_v5.34.17.win32.vc10.debug.tar.gz) | 147M |
-| Windows Visual Studio 10 | [root_v5.34.17.win32.vc10.tar.gz](https://root.cern.ch/download/root_v5.34.17.win32.vc10.tar.gz) |  69M |
-| Windows Visual Studio 11 (dbg) | [root_v5.34.17.win32.vc11.debug.tar.gz](https://root.cern.ch/download/root_v5.34.17.win32.vc11.debug.tar.gz) | 161M |
-| Windows Visual Studio 11 | [root_v5.34.17.win32.vc11.tar.gz](https://root.cern.ch/download/root_v5.34.17.win32.vc11.tar.gz) |  71M |
+| Linux slc5 gcc4.3 | [root_v5.34.17.Linux-slc5-gcc4.3.tar.gz](https://root.cern/download/root_v5.34.17.Linux-slc5-gcc4.3.tar.gz) |  56M |
+| Linux slc5_amd64 gcc4.3 | [root_v5.34.17.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern/download/root_v5.34.17.Linux-slc5_amd64-gcc4.3.tar.gz) |  57M |
+| Scientific Linux Cern 6_amd64 gcc4.4 | [root_v5.34.17.Linux-slc6_amd64-gcc4.4.tar.gz](https://root.cern/download/root_v5.34.17.Linux-slc6_amd64-gcc4.4.tar.gz) |  54M |
+| Scientific Linux Cern 6_amd64 gcc4.7 | [root_v5.34.17.Linux-slc6_amd64-gcc4.7.tar.gz](https://root.cern/download/root_v5.34.17.Linux-slc6_amd64-gcc4.7.tar.gz) |  57M |
+| Scientific Linux Cern 6_amd64 gcc4.8 | [root_v5.34.17.Linux-slc6_amd64-gcc4.8.tar.gz](https://root.cern/download/root_v5.34.17.Linux-slc6_amd64-gcc4.8.tar.gz) |  57M |
+| Windows Visual Studio 10 (dbg) | [root_v5.34.17.win32.vc10.debug.tar.gz](https://root.cern/download/root_v5.34.17.win32.vc10.debug.tar.gz) | 147M |
+| Windows Visual Studio 10 | [root_v5.34.17.win32.vc10.tar.gz](https://root.cern/download/root_v5.34.17.win32.vc10.tar.gz) |  69M |
+| Windows Visual Studio 11 (dbg) | [root_v5.34.17.win32.vc11.debug.tar.gz](https://root.cern/download/root_v5.34.17.win32.vc11.debug.tar.gz) | 161M |
+| Windows Visual Studio 11 | [root_v5.34.17.win32.vc11.tar.gz](https://root.cern/download/root_v5.34.17.win32.vc11.tar.gz) |  71M |
 
 
 
@@ -71,7 +71,7 @@ To use ROOT directly from AFS:
 The entire ROOT source can be obtained from our public Git repository:
 
 ~~~
-git clone http://root.cern.ch/git/root.git
+git clone http://root.cern/git/root.git
 ~~~
 The release specific tag can be obtained using:
 ~~~

--- a/_releases/release-53418.md
+++ b/_releases/release-53418.md
@@ -19,23 +19,23 @@ The release notes for this release can be found [here]({{ '/install/all_releases
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v5.34.18.source.tar.gz](https://root.cern.ch/download/root_v5.34.18.source.tar.gz) |  71M |
+| source | [root_v5.34.18.source.tar.gz](https://root.cern/download/root_v5.34.18.source.tar.gz) |  71M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| Linux slc5 gcc4.3 | [root_v5.34.18.Linux-slc5-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.34.18.Linux-slc5-gcc4.3.tar.gz) |  56M |
-| Linux slc5_amd64 gcc4.3 | [root_v5.34.18.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.34.18.Linux-slc5_amd64-gcc4.3.tar.gz) |  57M |
-| Scientific Linux Cern 6_amd64 gcc4.4 | [root_v5.34.18.Linux-slc6_amd64-gcc4.4.tar.gz](https://root.cern.ch/download/root_v5.34.18.Linux-slc6_amd64-gcc4.4.tar.gz) |  54M |
-| Scientific Linux Cern 6_amd64 gcc4.7 | [root_v5.34.18.Linux-slc6_amd64-gcc4.7.tar.gz](https://root.cern.ch/download/root_v5.34.18.Linux-slc6_amd64-gcc4.7.tar.gz) |  57M |
-| Scientific Linux Cern 6_amd64 gcc4.8 | [root_v5.34.18.Linux-slc6_amd64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v5.34.18.Linux-slc6_amd64-gcc4.8.tar.gz) |  57M |
-| OsX 10.9 i386 | [root_v5.34.18.macosx64-10.9-i386.tar.gz](https://root.cern.ch/download/root_v5.34.18.macosx64-10.9-i386.tar.gz) |  54M |
-| Windows Visual Studio 10 (dbg) | [root_v5.34.18.win32.vc10.debug.tar.gz](https://root.cern.ch/download/root_v5.34.18.win32.vc10.debug.tar.gz) | 145M |
-| Windows Visual Studio 10 | [root_v5.34.18.win32.vc10.tar.gz](https://root.cern.ch/download/root_v5.34.18.win32.vc10.tar.gz) |  68M |
-| Windows Visual Studio 11 (dbg) | [root_v5.34.18.win32.vc11.debug.tar.gz](https://root.cern.ch/download/root_v5.34.18.win32.vc11.debug.tar.gz) | 160M |
-| Windows Visual Studio 11 | [root_v5.34.18.win32.vc11.tar.gz](https://root.cern.ch/download/root_v5.34.18.win32.vc11.tar.gz) |  71M |
+| Linux slc5 gcc4.3 | [root_v5.34.18.Linux-slc5-gcc4.3.tar.gz](https://root.cern/download/root_v5.34.18.Linux-slc5-gcc4.3.tar.gz) |  56M |
+| Linux slc5_amd64 gcc4.3 | [root_v5.34.18.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern/download/root_v5.34.18.Linux-slc5_amd64-gcc4.3.tar.gz) |  57M |
+| Scientific Linux Cern 6_amd64 gcc4.4 | [root_v5.34.18.Linux-slc6_amd64-gcc4.4.tar.gz](https://root.cern/download/root_v5.34.18.Linux-slc6_amd64-gcc4.4.tar.gz) |  54M |
+| Scientific Linux Cern 6_amd64 gcc4.7 | [root_v5.34.18.Linux-slc6_amd64-gcc4.7.tar.gz](https://root.cern/download/root_v5.34.18.Linux-slc6_amd64-gcc4.7.tar.gz) |  57M |
+| Scientific Linux Cern 6_amd64 gcc4.8 | [root_v5.34.18.Linux-slc6_amd64-gcc4.8.tar.gz](https://root.cern/download/root_v5.34.18.Linux-slc6_amd64-gcc4.8.tar.gz) |  57M |
+| OsX 10.9 i386 | [root_v5.34.18.macosx64-10.9-i386.tar.gz](https://root.cern/download/root_v5.34.18.macosx64-10.9-i386.tar.gz) |  54M |
+| Windows Visual Studio 10 (dbg) | [root_v5.34.18.win32.vc10.debug.tar.gz](https://root.cern/download/root_v5.34.18.win32.vc10.debug.tar.gz) | 145M |
+| Windows Visual Studio 10 | [root_v5.34.18.win32.vc10.tar.gz](https://root.cern/download/root_v5.34.18.win32.vc10.tar.gz) |  68M |
+| Windows Visual Studio 11 (dbg) | [root_v5.34.18.win32.vc11.debug.tar.gz](https://root.cern/download/root_v5.34.18.win32.vc11.debug.tar.gz) | 160M |
+| Windows Visual Studio 11 | [root_v5.34.18.win32.vc11.tar.gz](https://root.cern/download/root_v5.34.18.win32.vc11.tar.gz) |  71M |
 
 
 
@@ -71,7 +71,7 @@ To use ROOT directly from AFS:
 The entire ROOT source can be obtained from our public Git repository:
 
 ~~~
-git clone http://root.cern.ch/git/root.git
+git clone http://root.cern/git/root.git
 ~~~
 The release specific tag can be obtained using:
 ~~~

--- a/_releases/release-53419.md
+++ b/_releases/release-53419.md
@@ -19,23 +19,23 @@ The release notes for this release can be found [here]({{ '/install/all_releases
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v5.34.19.source.tar.gz](https://root.cern.ch/download/root_v5.34.19.source.tar.gz) |  72M |
+| source | [root_v5.34.19.source.tar.gz](https://root.cern/download/root_v5.34.19.source.tar.gz) |  72M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| Linux slc5 gcc4.3 | [root_v5.34.19.Linux-slc5-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.34.19.Linux-slc5-gcc4.3.tar.gz) |  57M |
-| Linux slc5_amd64 gcc4.3 | [root_v5.34.19.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.34.19.Linux-slc5_amd64-gcc4.3.tar.gz) |  58M |
-| Scientific Linux Cern 6_amd64 gcc4.4 | [root_v5.34.19.Linux-slc6_amd64-gcc4.4.tar.gz](https://root.cern.ch/download/root_v5.34.19.Linux-slc6_amd64-gcc4.4.tar.gz) |  55M |
-| Scientific Linux Cern 6_amd64 gcc4.7 | [root_v5.34.19.Linux-slc6_amd64-gcc4.7.tar.gz](https://root.cern.ch/download/root_v5.34.19.Linux-slc6_amd64-gcc4.7.tar.gz) |  58M |
-| Scientific Linux Cern 6_amd64 gcc4.8 | [root_v5.34.19.Linux-slc6_amd64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v5.34.19.Linux-slc6_amd64-gcc4.8.tar.gz) |  58M |
-| OsX 10.9 i386 | [root_v5.34.19.macosx64-10.9-i386.tar.gz](https://root.cern.ch/download/root_v5.34.19.macosx64-10.9-i386.tar.gz) |  51M |
-| Windows Visual Studio 10 (dbg) | [root_v5.34.19.win32.vc10.debug.tar.gz](https://root.cern.ch/download/root_v5.34.19.win32.vc10.debug.tar.gz) | 147M |
-| Windows Visual Studio 10 | [root_v5.34.19.win32.vc10.tar.gz](https://root.cern.ch/download/root_v5.34.19.win32.vc10.tar.gz) |  69M |
-| Windows Visual Studio 11 (dbg) | [root_v5.34.19.win32.vc11.debug.tar.gz](https://root.cern.ch/download/root_v5.34.19.win32.vc11.debug.tar.gz) | 162M |
-| Windows Visual Studio 11 | [root_v5.34.19.win32.vc11.tar.gz](https://root.cern.ch/download/root_v5.34.19.win32.vc11.tar.gz) |  72M |
+| Linux slc5 gcc4.3 | [root_v5.34.19.Linux-slc5-gcc4.3.tar.gz](https://root.cern/download/root_v5.34.19.Linux-slc5-gcc4.3.tar.gz) |  57M |
+| Linux slc5_amd64 gcc4.3 | [root_v5.34.19.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern/download/root_v5.34.19.Linux-slc5_amd64-gcc4.3.tar.gz) |  58M |
+| Scientific Linux Cern 6_amd64 gcc4.4 | [root_v5.34.19.Linux-slc6_amd64-gcc4.4.tar.gz](https://root.cern/download/root_v5.34.19.Linux-slc6_amd64-gcc4.4.tar.gz) |  55M |
+| Scientific Linux Cern 6_amd64 gcc4.7 | [root_v5.34.19.Linux-slc6_amd64-gcc4.7.tar.gz](https://root.cern/download/root_v5.34.19.Linux-slc6_amd64-gcc4.7.tar.gz) |  58M |
+| Scientific Linux Cern 6_amd64 gcc4.8 | [root_v5.34.19.Linux-slc6_amd64-gcc4.8.tar.gz](https://root.cern/download/root_v5.34.19.Linux-slc6_amd64-gcc4.8.tar.gz) |  58M |
+| OsX 10.9 i386 | [root_v5.34.19.macosx64-10.9-i386.tar.gz](https://root.cern/download/root_v5.34.19.macosx64-10.9-i386.tar.gz) |  51M |
+| Windows Visual Studio 10 (dbg) | [root_v5.34.19.win32.vc10.debug.tar.gz](https://root.cern/download/root_v5.34.19.win32.vc10.debug.tar.gz) | 147M |
+| Windows Visual Studio 10 | [root_v5.34.19.win32.vc10.tar.gz](https://root.cern/download/root_v5.34.19.win32.vc10.tar.gz) |  69M |
+| Windows Visual Studio 11 (dbg) | [root_v5.34.19.win32.vc11.debug.tar.gz](https://root.cern/download/root_v5.34.19.win32.vc11.debug.tar.gz) | 162M |
+| Windows Visual Studio 11 | [root_v5.34.19.win32.vc11.tar.gz](https://root.cern/download/root_v5.34.19.win32.vc11.tar.gz) |  72M |
 
 
 
@@ -72,7 +72,7 @@ To use ROOT directly from AFS:
 The entire ROOT source can be obtained from our public Git repository:
 
 ~~~
-git clone http://root.cern.ch/git/root.git
+git clone http://root.cern/git/root.git
 ~~~
 The release specific tag can be obtained using:
 ~~~

--- a/_releases/release-53420.md
+++ b/_releases/release-53420.md
@@ -19,23 +19,23 @@ The release notes for this release can be found [here]({{ '/install/all_releases
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v5.34.20.source.tar.gz](https://root.cern.ch/download/root_v5.34.20.source.tar.gz) |  72M |
+| source | [root_v5.34.20.source.tar.gz](https://root.cern/download/root_v5.34.20.source.tar.gz) |  72M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| Linux slc5 gcc4.3 | [root_v5.34.20.Linux-slc5-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.34.20.Linux-slc5-gcc4.3.tar.gz) |  60M |
-| Linux slc5_amd64 gcc4.3 | [root_v5.34.20.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.34.20.Linux-slc5_amd64-gcc4.3.tar.gz) |  60M |
-| Scientific Linux Cern 6_amd64 gcc4.4 | [root_v5.34.20.Linux-slc6_amd64-gcc4.4.tar.gz](https://root.cern.ch/download/root_v5.34.20.Linux-slc6_amd64-gcc4.4.tar.gz) |  61M |
-| Scientific Linux Cern 6_amd64 gcc4.7 | [root_v5.34.20.Linux-slc6_amd64-gcc4.7.tar.gz](https://root.cern.ch/download/root_v5.34.20.Linux-slc6_amd64-gcc4.7.tar.gz) |  61M |
-| Scientific Linux Cern 6_amd64 gcc4.8 | [root_v5.34.20.Linux-slc6_amd64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v5.34.20.Linux-slc6_amd64-gcc4.8.tar.gz) |  60M |
-| OsX 10.9 i386 | [root_v5.34.20.macosx64-10.9-i386.tar.gz](https://root.cern.ch/download/root_v5.34.20.macosx64-10.9-i386.tar.gz) |  53M |
-| Windows Visual Studio 10 (dbg) | [root_v5.34.20.win32.vc10.debug.tar.gz](https://root.cern.ch/download/root_v5.34.20.win32.vc10.debug.tar.gz) | 148M |
-| Windows Visual Studio 10 | [root_v5.34.20.win32.vc10.tar.gz](https://root.cern.ch/download/root_v5.34.20.win32.vc10.tar.gz) |  69M |
-| Windows Visual Studio 11 (dbg) | [root_v5.34.20.win32.vc11.debug.tar.gz](https://root.cern.ch/download/root_v5.34.20.win32.vc11.debug.tar.gz) | 163M |
-| Windows Visual Studio 11 | [root_v5.34.20.win32.vc11.tar.gz](https://root.cern.ch/download/root_v5.34.20.win32.vc11.tar.gz) |  72M |
+| Linux slc5 gcc4.3 | [root_v5.34.20.Linux-slc5-gcc4.3.tar.gz](https://root.cern/download/root_v5.34.20.Linux-slc5-gcc4.3.tar.gz) |  60M |
+| Linux slc5_amd64 gcc4.3 | [root_v5.34.20.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern/download/root_v5.34.20.Linux-slc5_amd64-gcc4.3.tar.gz) |  60M |
+| Scientific Linux Cern 6_amd64 gcc4.4 | [root_v5.34.20.Linux-slc6_amd64-gcc4.4.tar.gz](https://root.cern/download/root_v5.34.20.Linux-slc6_amd64-gcc4.4.tar.gz) |  61M |
+| Scientific Linux Cern 6_amd64 gcc4.7 | [root_v5.34.20.Linux-slc6_amd64-gcc4.7.tar.gz](https://root.cern/download/root_v5.34.20.Linux-slc6_amd64-gcc4.7.tar.gz) |  61M |
+| Scientific Linux Cern 6_amd64 gcc4.8 | [root_v5.34.20.Linux-slc6_amd64-gcc4.8.tar.gz](https://root.cern/download/root_v5.34.20.Linux-slc6_amd64-gcc4.8.tar.gz) |  60M |
+| OsX 10.9 i386 | [root_v5.34.20.macosx64-10.9-i386.tar.gz](https://root.cern/download/root_v5.34.20.macosx64-10.9-i386.tar.gz) |  53M |
+| Windows Visual Studio 10 (dbg) | [root_v5.34.20.win32.vc10.debug.tar.gz](https://root.cern/download/root_v5.34.20.win32.vc10.debug.tar.gz) | 148M |
+| Windows Visual Studio 10 | [root_v5.34.20.win32.vc10.tar.gz](https://root.cern/download/root_v5.34.20.win32.vc10.tar.gz) |  69M |
+| Windows Visual Studio 11 (dbg) | [root_v5.34.20.win32.vc11.debug.tar.gz](https://root.cern/download/root_v5.34.20.win32.vc11.debug.tar.gz) | 163M |
+| Windows Visual Studio 11 | [root_v5.34.20.win32.vc11.tar.gz](https://root.cern/download/root_v5.34.20.win32.vc11.tar.gz) |  72M |
 
 
 
@@ -64,7 +64,7 @@ To use ROOT directly from AFS:
 The entire ROOT source can be obtained from our public Git repository:
 
 ~~~
-git clone http://root.cern.ch/git/root.git
+git clone http://root.cern/git/root.git
 ~~~
 The release specific tag can be obtained using:
 ~~~

--- a/_releases/release-53421.md
+++ b/_releases/release-53421.md
@@ -19,27 +19,27 @@ The release notes for this release can be found [here]({{ '/install/all_releases
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v5.34.21.source.tar.gz](https://root.cern.ch/download/root_v5.34.21.source.tar.gz) |  72M |
+| source | [root_v5.34.21.source.tar.gz](https://root.cern/download/root_v5.34.21.source.tar.gz) |  72M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| Linux slc5 gcc4.3 | [root_v5.34.21.Linux-slc5-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.34.21.Linux-slc5-gcc4.3.tar.gz) |  64M |
-| Linux slc5_amd64 gcc4.3 | [root_v5.34.21.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.34.21.Linux-slc5_amd64-gcc4.3.tar.gz) |  69M |
-| Scientific Linux Cern 6_amd64 gcc4.4 | [root_v5.34.21.Linux-slc6_amd64-gcc4.4.tar.gz](https://root.cern.ch/download/root_v5.34.21.Linux-slc6_amd64-gcc4.4.tar.gz) |  69M |
-| Scientific Linux Cern 6_amd64 gcc4.7 | [root_v5.34.21.Linux-slc6_amd64-gcc4.7.tar.gz](https://root.cern.ch/download/root_v5.34.21.Linux-slc6_amd64-gcc4.7.tar.gz) |  70M |
-| Scientific Linux Cern 6_amd64 gcc4.8 | [root_v5.34.21.Linux-slc6_amd64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v5.34.21.Linux-slc6_amd64-gcc4.8.tar.gz) |  71M |
-| OsX 10.9 i386 | [root_v5.34.21.macosx64-10.9-i386.tar.gz](https://root.cern.ch/download/root_v5.34.21.macosx64-10.9-i386.tar.gz) |  55M |
-| Windows Visual Studio 10 (dbg) | [root_v5.34.21.win32.vc10.debug.exe](https://root.cern.ch/download/root_v5.34.21.win32.vc10.debug.exe) |  93M |
-| Windows Visual Studio 10 (dbg) | [root_v5.34.21.win32.vc10.debug.tar.gz](https://root.cern.ch/download/root_v5.34.21.win32.vc10.debug.tar.gz) | 138M |
-| Windows Visual Studio 10 | [root_v5.34.21.win32.vc10.exe](https://root.cern.ch/download/root_v5.34.21.win32.vc10.exe) |  47M |
-| Windows Visual Studio 10 | [root_v5.34.21.win32.vc10.tar.gz](https://root.cern.ch/download/root_v5.34.21.win32.vc10.tar.gz) |  61M |
-| Windows Visual Studio 11 (dbg) | [root_v5.34.21.win32.vc11.debug.exe](https://root.cern.ch/download/root_v5.34.21.win32.vc11.debug.exe) |  99M |
-| Windows Visual Studio 11 (dbg) | [root_v5.34.21.win32.vc11.debug.tar.gz](https://root.cern.ch/download/root_v5.34.21.win32.vc11.debug.tar.gz) | 149M |
-| Windows Visual Studio 11 | [root_v5.34.21.win32.vc11.exe](https://root.cern.ch/download/root_v5.34.21.win32.vc11.exe) |  48M |
-| Windows Visual Studio 11 | [root_v5.34.21.win32.vc11.tar.gz](https://root.cern.ch/download/root_v5.34.21.win32.vc11.tar.gz) |  62M |
+| Linux slc5 gcc4.3 | [root_v5.34.21.Linux-slc5-gcc4.3.tar.gz](https://root.cern/download/root_v5.34.21.Linux-slc5-gcc4.3.tar.gz) |  64M |
+| Linux slc5_amd64 gcc4.3 | [root_v5.34.21.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern/download/root_v5.34.21.Linux-slc5_amd64-gcc4.3.tar.gz) |  69M |
+| Scientific Linux Cern 6_amd64 gcc4.4 | [root_v5.34.21.Linux-slc6_amd64-gcc4.4.tar.gz](https://root.cern/download/root_v5.34.21.Linux-slc6_amd64-gcc4.4.tar.gz) |  69M |
+| Scientific Linux Cern 6_amd64 gcc4.7 | [root_v5.34.21.Linux-slc6_amd64-gcc4.7.tar.gz](https://root.cern/download/root_v5.34.21.Linux-slc6_amd64-gcc4.7.tar.gz) |  70M |
+| Scientific Linux Cern 6_amd64 gcc4.8 | [root_v5.34.21.Linux-slc6_amd64-gcc4.8.tar.gz](https://root.cern/download/root_v5.34.21.Linux-slc6_amd64-gcc4.8.tar.gz) |  71M |
+| OsX 10.9 i386 | [root_v5.34.21.macosx64-10.9-i386.tar.gz](https://root.cern/download/root_v5.34.21.macosx64-10.9-i386.tar.gz) |  55M |
+| Windows Visual Studio 10 (dbg) | [root_v5.34.21.win32.vc10.debug.exe](https://root.cern/download/root_v5.34.21.win32.vc10.debug.exe) |  93M |
+| Windows Visual Studio 10 (dbg) | [root_v5.34.21.win32.vc10.debug.tar.gz](https://root.cern/download/root_v5.34.21.win32.vc10.debug.tar.gz) | 138M |
+| Windows Visual Studio 10 | [root_v5.34.21.win32.vc10.exe](https://root.cern/download/root_v5.34.21.win32.vc10.exe) |  47M |
+| Windows Visual Studio 10 | [root_v5.34.21.win32.vc10.tar.gz](https://root.cern/download/root_v5.34.21.win32.vc10.tar.gz) |  61M |
+| Windows Visual Studio 11 (dbg) | [root_v5.34.21.win32.vc11.debug.exe](https://root.cern/download/root_v5.34.21.win32.vc11.debug.exe) |  99M |
+| Windows Visual Studio 11 (dbg) | [root_v5.34.21.win32.vc11.debug.tar.gz](https://root.cern/download/root_v5.34.21.win32.vc11.debug.tar.gz) | 149M |
+| Windows Visual Studio 11 | [root_v5.34.21.win32.vc11.exe](https://root.cern/download/root_v5.34.21.win32.vc11.exe) |  48M |
+| Windows Visual Studio 11 | [root_v5.34.21.win32.vc11.tar.gz](https://root.cern/download/root_v5.34.21.win32.vc11.tar.gz) |  62M |
 
 
 
@@ -68,7 +68,7 @@ To use ROOT directly from AFS:
 The entire ROOT source can be obtained from our public Git repository:
 
 ~~~
-git clone http://root.cern.ch/git/root.git
+git clone http://root.cern/git/root.git
 ~~~
 The release specific tag can be obtained using:
 ~~~

--- a/_releases/release-53422.md
+++ b/_releases/release-53422.md
@@ -19,32 +19,32 @@ The release notes for this release can be found [here]({{ '/install/all_releases
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v5.34.22.source.tar.gz](https://root.cern.ch/download/root_v5.34.22.source.tar.gz) |  72M |
+| source | [root_v5.34.22.source.tar.gz](https://root.cern/download/root_v5.34.22.source.tar.gz) |  72M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| Linux slc5 gcc4.3 | [root_v5.34.22.Linux-slc5-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.34.22.Linux-slc5-gcc4.3.tar.gz) |  68M |
-| Linux slc5 gcc4.7 | [root_v5.34.22.Linux-slc5-gcc4.7.tar.gz](https://root.cern.ch/download/root_v5.34.22.Linux-slc5-gcc4.7.tar.gz) |  70M |
-| Linux slc5_amd64 gcc4.3 | [root_v5.34.22.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.34.22.Linux-slc5_amd64-gcc4.3.tar.gz) |  69M |
-| Linux slc5_amd64 gcc4.7 | [root_v5.34.22.Linux-slc5_amd64-gcc4.7.tar.gz](https://root.cern.ch/download/root_v5.34.22.Linux-slc5_amd64-gcc4.7.tar.gz) |  70M |
-| Scientific Linux Cern 6 gcc4.7 | [root_v5.34.22.Linux-slc6-gcc4.7.tar.gz](https://root.cern.ch/download/root_v5.34.22.Linux-slc6-gcc4.7.tar.gz) |  61M |
-| Scientific Linux Cern 6 gcc4.8 | [root_v5.34.22.Linux-slc6-gcc4.8.tar.gz](https://root.cern.ch/download/root_v5.34.22.Linux-slc6-gcc4.8.tar.gz) |  60M |
-| Scientific Linux Cern 6_amd64 gcc4.4 | [root_v5.34.22.Linux-slc6_amd64-gcc4.4.tar.gz](https://root.cern.ch/download/root_v5.34.22.Linux-slc6_amd64-gcc4.4.tar.gz) |  69M |
-| Scientific Linux Cern 6_amd64 gcc4.7 | [root_v5.34.22.Linux-slc6_amd64-gcc4.7.tar.gz](https://root.cern.ch/download/root_v5.34.22.Linux-slc6_amd64-gcc4.7.tar.gz) |  70M |
-| Scientific Linux Cern 6_amd64 gcc4.8 | [root_v5.34.22.Linux-slc6_amd64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v5.34.22.Linux-slc6_amd64-gcc4.8.tar.gz) |  71M |
-| Scientific Linux Cern 6_amd64 gcc4.9 | [root_v5.34.22.Linux-slc6_amd64-gcc4.9.tar.gz](https://root.cern.ch/download/root_v5.34.22.Linux-slc6_amd64-gcc4.9.tar.gz) |  72M |
-| OsX 10.9 i386 | [root_v5.34.22.macosx64-10.9-i386.tar.gz](https://root.cern.ch/download/root_v5.34.22.macosx64-10.9-i386.tar.gz) |  57M |
-| Windows Visual Studio 10 (dbg) | [root_v5.34.22.win32.vc10.debug.exe](https://root.cern.ch/download/root_v5.34.22.win32.vc10.debug.exe) |  93M |
-| Windows Visual Studio 10 (dbg) | [root_v5.34.22.win32.vc10.debug.tar.gz](https://root.cern.ch/download/root_v5.34.22.win32.vc10.debug.tar.gz) | 138M |
-| Windows Visual Studio 10 | [root_v5.34.22.win32.vc10.exe](https://root.cern.ch/download/root_v5.34.22.win32.vc10.exe) |  47M |
-| Windows Visual Studio 10 | [root_v5.34.22.win32.vc10.tar.gz](https://root.cern.ch/download/root_v5.34.22.win32.vc10.tar.gz) |  61M |
-| Windows Visual Studio 11 (dbg) | [root_v5.34.22.win32.vc11.debug.exe](https://root.cern.ch/download/root_v5.34.22.win32.vc11.debug.exe) |  97M |
-| Windows Visual Studio 11 (dbg) | [root_v5.34.22.win32.vc11.debug.tar.gz](https://root.cern.ch/download/root_v5.34.22.win32.vc11.debug.tar.gz) | 147M |
-| Windows Visual Studio 11 | [root_v5.34.22.win32.vc11.exe](https://root.cern.ch/download/root_v5.34.22.win32.vc11.exe) |  47M |
-| Windows Visual Studio 11 | [root_v5.34.22.win32.vc11.tar.gz](https://root.cern.ch/download/root_v5.34.22.win32.vc11.tar.gz) |  61M |
+| Linux slc5 gcc4.3 | [root_v5.34.22.Linux-slc5-gcc4.3.tar.gz](https://root.cern/download/root_v5.34.22.Linux-slc5-gcc4.3.tar.gz) |  68M |
+| Linux slc5 gcc4.7 | [root_v5.34.22.Linux-slc5-gcc4.7.tar.gz](https://root.cern/download/root_v5.34.22.Linux-slc5-gcc4.7.tar.gz) |  70M |
+| Linux slc5_amd64 gcc4.3 | [root_v5.34.22.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern/download/root_v5.34.22.Linux-slc5_amd64-gcc4.3.tar.gz) |  69M |
+| Linux slc5_amd64 gcc4.7 | [root_v5.34.22.Linux-slc5_amd64-gcc4.7.tar.gz](https://root.cern/download/root_v5.34.22.Linux-slc5_amd64-gcc4.7.tar.gz) |  70M |
+| Scientific Linux Cern 6 gcc4.7 | [root_v5.34.22.Linux-slc6-gcc4.7.tar.gz](https://root.cern/download/root_v5.34.22.Linux-slc6-gcc4.7.tar.gz) |  61M |
+| Scientific Linux Cern 6 gcc4.8 | [root_v5.34.22.Linux-slc6-gcc4.8.tar.gz](https://root.cern/download/root_v5.34.22.Linux-slc6-gcc4.8.tar.gz) |  60M |
+| Scientific Linux Cern 6_amd64 gcc4.4 | [root_v5.34.22.Linux-slc6_amd64-gcc4.4.tar.gz](https://root.cern/download/root_v5.34.22.Linux-slc6_amd64-gcc4.4.tar.gz) |  69M |
+| Scientific Linux Cern 6_amd64 gcc4.7 | [root_v5.34.22.Linux-slc6_amd64-gcc4.7.tar.gz](https://root.cern/download/root_v5.34.22.Linux-slc6_amd64-gcc4.7.tar.gz) |  70M |
+| Scientific Linux Cern 6_amd64 gcc4.8 | [root_v5.34.22.Linux-slc6_amd64-gcc4.8.tar.gz](https://root.cern/download/root_v5.34.22.Linux-slc6_amd64-gcc4.8.tar.gz) |  71M |
+| Scientific Linux Cern 6_amd64 gcc4.9 | [root_v5.34.22.Linux-slc6_amd64-gcc4.9.tar.gz](https://root.cern/download/root_v5.34.22.Linux-slc6_amd64-gcc4.9.tar.gz) |  72M |
+| OsX 10.9 i386 | [root_v5.34.22.macosx64-10.9-i386.tar.gz](https://root.cern/download/root_v5.34.22.macosx64-10.9-i386.tar.gz) |  57M |
+| Windows Visual Studio 10 (dbg) | [root_v5.34.22.win32.vc10.debug.exe](https://root.cern/download/root_v5.34.22.win32.vc10.debug.exe) |  93M |
+| Windows Visual Studio 10 (dbg) | [root_v5.34.22.win32.vc10.debug.tar.gz](https://root.cern/download/root_v5.34.22.win32.vc10.debug.tar.gz) | 138M |
+| Windows Visual Studio 10 | [root_v5.34.22.win32.vc10.exe](https://root.cern/download/root_v5.34.22.win32.vc10.exe) |  47M |
+| Windows Visual Studio 10 | [root_v5.34.22.win32.vc10.tar.gz](https://root.cern/download/root_v5.34.22.win32.vc10.tar.gz) |  61M |
+| Windows Visual Studio 11 (dbg) | [root_v5.34.22.win32.vc11.debug.exe](https://root.cern/download/root_v5.34.22.win32.vc11.debug.exe) |  97M |
+| Windows Visual Studio 11 (dbg) | [root_v5.34.22.win32.vc11.debug.tar.gz](https://root.cern/download/root_v5.34.22.win32.vc11.debug.tar.gz) | 147M |
+| Windows Visual Studio 11 | [root_v5.34.22.win32.vc11.exe](https://root.cern/download/root_v5.34.22.win32.vc11.exe) |  47M |
+| Windows Visual Studio 11 | [root_v5.34.22.win32.vc11.tar.gz](https://root.cern/download/root_v5.34.22.win32.vc11.tar.gz) |  61M |
 
 
 
@@ -74,7 +74,7 @@ To use ROOT directly from AFS:
 The entire ROOT source can be obtained from our public Git repository:
 
 ~~~
-git clone http://root.cern.ch/git/root.git
+git clone http://root.cern/git/root.git
 ~~~
 The release specific tag can be obtained using:
 ~~~

--- a/_releases/release-53423.md
+++ b/_releases/release-53423.md
@@ -19,32 +19,32 @@ The release notes for this release can be found [here]({{ '/install/all_releases
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v5.34.23.source.tar.gz](https://root.cern.ch/download/root_v5.34.23.source.tar.gz) |  72M |
+| source | [root_v5.34.23.source.tar.gz](https://root.cern/download/root_v5.34.23.source.tar.gz) |  72M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| Linux slc5 gcc4.3 | [root_v5.34.23.Linux-slc5-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.34.23.Linux-slc5-gcc4.3.tar.gz) |  68M |
-| Linux slc5 gcc4.7 | [root_v5.34.23.Linux-slc5-gcc4.7.tar.gz](https://root.cern.ch/download/root_v5.34.23.Linux-slc5-gcc4.7.tar.gz) |  70M |
-| Linux slc5_amd64 gcc4.3 | [root_v5.34.23.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.34.23.Linux-slc5_amd64-gcc4.3.tar.gz) |  69M |
-| Linux slc5_amd64 gcc4.7 | [root_v5.34.23.Linux-slc5_amd64-gcc4.7.tar.gz](https://root.cern.ch/download/root_v5.34.23.Linux-slc5_amd64-gcc4.7.tar.gz) |  70M |
-| Scientific Linux Cern 6 gcc4.7 | [root_v5.34.23.Linux-slc6-gcc4.7.tar.gz](https://root.cern.ch/download/root_v5.34.23.Linux-slc6-gcc4.7.tar.gz) |  61M |
-| Scientific Linux Cern 6 gcc4.8 | [root_v5.34.23.Linux-slc6-gcc4.8.tar.gz](https://root.cern.ch/download/root_v5.34.23.Linux-slc6-gcc4.8.tar.gz) |  60M |
-| Scientific Linux Cern 6_amd64 gcc4.4 | [root_v5.34.23.Linux-slc6_amd64-gcc4.4.tar.gz](https://root.cern.ch/download/root_v5.34.23.Linux-slc6_amd64-gcc4.4.tar.gz) |  69M |
-| Scientific Linux Cern 6_amd64 gcc4.7 | [root_v5.34.23.Linux-slc6_amd64-gcc4.7.tar.gz](https://root.cern.ch/download/root_v5.34.23.Linux-slc6_amd64-gcc4.7.tar.gz) |  70M |
-| Scientific Linux Cern 6_amd64 gcc4.8 | [root_v5.34.23.Linux-slc6_amd64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v5.34.23.Linux-slc6_amd64-gcc4.8.tar.gz) |  71M |
-| Scientific Linux Cern 6_amd64 gcc4.9 | [root_v5.34.23.Linux-slc6_amd64-gcc4.9.tar.gz](https://root.cern.ch/download/root_v5.34.23.Linux-slc6_amd64-gcc4.9.tar.gz) |  72M |
-| OsX 10.9 i386 | [root_v5.34.23.macosx64-10.9-i386.tar.gz](https://root.cern.ch/download/root_v5.34.23.macosx64-10.9-i386.tar.gz) |  56M |
-| Windows Visual Studio 10 (dbg) | [root_v5.34.23.win32.vc10.debug.exe](https://root.cern.ch/download/root_v5.34.23.win32.vc10.debug.exe) |  93M |
-| Windows Visual Studio 10 (dbg) | [root_v5.34.23.win32.vc10.debug.tar.gz](https://root.cern.ch/download/root_v5.34.23.win32.vc10.debug.tar.gz) | 138M |
-| Windows Visual Studio 10 | [root_v5.34.23.win32.vc10.exe](https://root.cern.ch/download/root_v5.34.23.win32.vc10.exe) |  47M |
-| Windows Visual Studio 10 | [root_v5.34.23.win32.vc10.tar.gz](https://root.cern.ch/download/root_v5.34.23.win32.vc10.tar.gz) |  61M |
-| Windows Visual Studio 11 (dbg) | [root_v5.34.23.win32.vc11.debug.exe](https://root.cern.ch/download/root_v5.34.23.win32.vc11.debug.exe) |  99M |
-| Windows Visual Studio 11 (dbg) | [root_v5.34.23.win32.vc11.debug.tar.gz](https://root.cern.ch/download/root_v5.34.23.win32.vc11.debug.tar.gz) | 149M |
-| Windows Visual Studio 11 | [root_v5.34.23.win32.vc11.exe](https://root.cern.ch/download/root_v5.34.23.win32.vc11.exe) |  48M |
-| Windows Visual Studio 11 | [root_v5.34.23.win32.vc11.tar.gz](https://root.cern.ch/download/root_v5.34.23.win32.vc11.tar.gz) |  62M |
+| Linux slc5 gcc4.3 | [root_v5.34.23.Linux-slc5-gcc4.3.tar.gz](https://root.cern/download/root_v5.34.23.Linux-slc5-gcc4.3.tar.gz) |  68M |
+| Linux slc5 gcc4.7 | [root_v5.34.23.Linux-slc5-gcc4.7.tar.gz](https://root.cern/download/root_v5.34.23.Linux-slc5-gcc4.7.tar.gz) |  70M |
+| Linux slc5_amd64 gcc4.3 | [root_v5.34.23.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern/download/root_v5.34.23.Linux-slc5_amd64-gcc4.3.tar.gz) |  69M |
+| Linux slc5_amd64 gcc4.7 | [root_v5.34.23.Linux-slc5_amd64-gcc4.7.tar.gz](https://root.cern/download/root_v5.34.23.Linux-slc5_amd64-gcc4.7.tar.gz) |  70M |
+| Scientific Linux Cern 6 gcc4.7 | [root_v5.34.23.Linux-slc6-gcc4.7.tar.gz](https://root.cern/download/root_v5.34.23.Linux-slc6-gcc4.7.tar.gz) |  61M |
+| Scientific Linux Cern 6 gcc4.8 | [root_v5.34.23.Linux-slc6-gcc4.8.tar.gz](https://root.cern/download/root_v5.34.23.Linux-slc6-gcc4.8.tar.gz) |  60M |
+| Scientific Linux Cern 6_amd64 gcc4.4 | [root_v5.34.23.Linux-slc6_amd64-gcc4.4.tar.gz](https://root.cern/download/root_v5.34.23.Linux-slc6_amd64-gcc4.4.tar.gz) |  69M |
+| Scientific Linux Cern 6_amd64 gcc4.7 | [root_v5.34.23.Linux-slc6_amd64-gcc4.7.tar.gz](https://root.cern/download/root_v5.34.23.Linux-slc6_amd64-gcc4.7.tar.gz) |  70M |
+| Scientific Linux Cern 6_amd64 gcc4.8 | [root_v5.34.23.Linux-slc6_amd64-gcc4.8.tar.gz](https://root.cern/download/root_v5.34.23.Linux-slc6_amd64-gcc4.8.tar.gz) |  71M |
+| Scientific Linux Cern 6_amd64 gcc4.9 | [root_v5.34.23.Linux-slc6_amd64-gcc4.9.tar.gz](https://root.cern/download/root_v5.34.23.Linux-slc6_amd64-gcc4.9.tar.gz) |  72M |
+| OsX 10.9 i386 | [root_v5.34.23.macosx64-10.9-i386.tar.gz](https://root.cern/download/root_v5.34.23.macosx64-10.9-i386.tar.gz) |  56M |
+| Windows Visual Studio 10 (dbg) | [root_v5.34.23.win32.vc10.debug.exe](https://root.cern/download/root_v5.34.23.win32.vc10.debug.exe) |  93M |
+| Windows Visual Studio 10 (dbg) | [root_v5.34.23.win32.vc10.debug.tar.gz](https://root.cern/download/root_v5.34.23.win32.vc10.debug.tar.gz) | 138M |
+| Windows Visual Studio 10 | [root_v5.34.23.win32.vc10.exe](https://root.cern/download/root_v5.34.23.win32.vc10.exe) |  47M |
+| Windows Visual Studio 10 | [root_v5.34.23.win32.vc10.tar.gz](https://root.cern/download/root_v5.34.23.win32.vc10.tar.gz) |  61M |
+| Windows Visual Studio 11 (dbg) | [root_v5.34.23.win32.vc11.debug.exe](https://root.cern/download/root_v5.34.23.win32.vc11.debug.exe) |  99M |
+| Windows Visual Studio 11 (dbg) | [root_v5.34.23.win32.vc11.debug.tar.gz](https://root.cern/download/root_v5.34.23.win32.vc11.debug.tar.gz) | 149M |
+| Windows Visual Studio 11 | [root_v5.34.23.win32.vc11.exe](https://root.cern/download/root_v5.34.23.win32.vc11.exe) |  48M |
+| Windows Visual Studio 11 | [root_v5.34.23.win32.vc11.tar.gz](https://root.cern/download/root_v5.34.23.win32.vc11.tar.gz) |  62M |
 
 
 
@@ -74,7 +74,7 @@ To use ROOT directly from AFS:
 The entire ROOT source can be obtained from our public Git repository:
 
 ~~~
-git clone http://root.cern.ch/git/root.git
+git clone http://root.cern/git/root.git
 ~~~
 The release specific tag can be obtained using:
 ~~~

--- a/_releases/release-53424.md
+++ b/_releases/release-53424.md
@@ -19,33 +19,33 @@ The release notes for this release can be found [here]({{ '/install/all_releases
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v5.34.24.source.tar.gz](https://root.cern.ch/download/root_v5.34.24.source.tar.gz) |  72M |
+| source | [root_v5.34.24.source.tar.gz](https://root.cern/download/root_v5.34.24.source.tar.gz) |  72M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| Linux slc5 gcc4.3 | [root_v5.34.24.Linux-slc5-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.34.24.Linux-slc5-gcc4.3.tar.gz) |  68M |
-| Linux slc5 gcc4.7 | [root_v5.34.24.Linux-slc5-gcc4.7.tar.gz](https://root.cern.ch/download/root_v5.34.24.Linux-slc5-gcc4.7.tar.gz) |  70M |
-| Linux slc5_amd64 gcc4.3 | [root_v5.34.24.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.34.24.Linux-slc5_amd64-gcc4.3.tar.gz) |  69M |
-| Linux slc5_amd64 gcc4.7 | [root_v5.34.24.Linux-slc5_amd64-gcc4.7.tar.gz](https://root.cern.ch/download/root_v5.34.24.Linux-slc5_amd64-gcc4.7.tar.gz) |  70M |
-| Scientific Linux Cern 6 gcc4.7 | [root_v5.34.24.Linux-slc6-gcc4.7.tar.gz](https://root.cern.ch/download/root_v5.34.24.Linux-slc6-gcc4.7.tar.gz) |  61M |
-| Scientific Linux Cern 6 gcc4.8 | [root_v5.34.24.Linux-slc6-gcc4.8.tar.gz](https://root.cern.ch/download/root_v5.34.24.Linux-slc6-gcc4.8.tar.gz) |  60M |
-| Scientific Linux Cern 6_amd64 gcc4.4 | [root_v5.34.24.Linux-slc6_amd64-gcc4.4.tar.gz](https://root.cern.ch/download/root_v5.34.24.Linux-slc6_amd64-gcc4.4.tar.gz) |  69M |
-| Scientific Linux Cern 6_amd64 gcc4.7 | [root_v5.34.24.Linux-slc6_amd64-gcc4.7.tar.gz](https://root.cern.ch/download/root_v5.34.24.Linux-slc6_amd64-gcc4.7.tar.gz) |  70M |
-| Scientific Linux Cern 6_amd64 gcc4.8 | [root_v5.34.24.Linux-slc6_amd64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v5.34.24.Linux-slc6_amd64-gcc4.8.tar.gz) |  71M |
-| Scientific Linux Cern 6_amd64 gcc4.9 | [root_v5.34.24.Linux-slc6_amd64-gcc4.9.tar.gz](https://root.cern.ch/download/root_v5.34.24.Linux-slc6_amd64-gcc4.9.tar.gz) |  72M |
-| OsX 10.9 i386 | [root_v5.34.24.macosx64-10.9-i386.tar.gz](https://root.cern.ch/download/root_v5.34.24.macosx64-10.9-i386.tar.gz) |  56M |
-| OsX 10.10 i386 | [root_v5.34.24.macosx64-10.10-i386.tar.gz](https://root.cern.ch/download/root_v5.34.24.macosx64-10.10-i386.tar.gz) |  56M |
-| Windows Visual Studio 10 (dbg) | [root_v5.34.24.win32.vc10.debug.exe](https://root.cern.ch/download/root_v5.34.24.win32.vc10.debug.exe) |  93M |
-| Windows Visual Studio 10 (dbg) | [root_v5.34.24.win32.vc10.debug.tar.gz](https://root.cern.ch/download/root_v5.34.24.win32.vc10.debug.tar.gz) | 138M |
-| Windows Visual Studio 10 | [root_v5.34.24.win32.vc10.exe](https://root.cern.ch/download/root_v5.34.24.win32.vc10.exe) |  47M |
-| Windows Visual Studio 10 | [root_v5.34.24.win32.vc10.tar.gz](https://root.cern.ch/download/root_v5.34.24.win32.vc10.tar.gz) |  61M |
-| Windows Visual Studio 11 (dbg) | [root_v5.34.24.win32.vc11.debug.exe](https://root.cern.ch/download/root_v5.34.24.win32.vc11.debug.exe) |  99M |
-| Windows Visual Studio 11 (dbg) | [root_v5.34.24.win32.vc11.debug.tar.gz](https://root.cern.ch/download/root_v5.34.24.win32.vc11.debug.tar.gz) | 149M |
-| Windows Visual Studio 11 | [root_v5.34.24.win32.vc11.exe](https://root.cern.ch/download/root_v5.34.24.win32.vc11.exe) |  48M |
-| Windows Visual Studio 11 | [root_v5.34.24.win32.vc11.tar.gz](https://root.cern.ch/download/root_v5.34.24.win32.vc11.tar.gz) |  62M |
+| Linux slc5 gcc4.3 | [root_v5.34.24.Linux-slc5-gcc4.3.tar.gz](https://root.cern/download/root_v5.34.24.Linux-slc5-gcc4.3.tar.gz) |  68M |
+| Linux slc5 gcc4.7 | [root_v5.34.24.Linux-slc5-gcc4.7.tar.gz](https://root.cern/download/root_v5.34.24.Linux-slc5-gcc4.7.tar.gz) |  70M |
+| Linux slc5_amd64 gcc4.3 | [root_v5.34.24.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern/download/root_v5.34.24.Linux-slc5_amd64-gcc4.3.tar.gz) |  69M |
+| Linux slc5_amd64 gcc4.7 | [root_v5.34.24.Linux-slc5_amd64-gcc4.7.tar.gz](https://root.cern/download/root_v5.34.24.Linux-slc5_amd64-gcc4.7.tar.gz) |  70M |
+| Scientific Linux Cern 6 gcc4.7 | [root_v5.34.24.Linux-slc6-gcc4.7.tar.gz](https://root.cern/download/root_v5.34.24.Linux-slc6-gcc4.7.tar.gz) |  61M |
+| Scientific Linux Cern 6 gcc4.8 | [root_v5.34.24.Linux-slc6-gcc4.8.tar.gz](https://root.cern/download/root_v5.34.24.Linux-slc6-gcc4.8.tar.gz) |  60M |
+| Scientific Linux Cern 6_amd64 gcc4.4 | [root_v5.34.24.Linux-slc6_amd64-gcc4.4.tar.gz](https://root.cern/download/root_v5.34.24.Linux-slc6_amd64-gcc4.4.tar.gz) |  69M |
+| Scientific Linux Cern 6_amd64 gcc4.7 | [root_v5.34.24.Linux-slc6_amd64-gcc4.7.tar.gz](https://root.cern/download/root_v5.34.24.Linux-slc6_amd64-gcc4.7.tar.gz) |  70M |
+| Scientific Linux Cern 6_amd64 gcc4.8 | [root_v5.34.24.Linux-slc6_amd64-gcc4.8.tar.gz](https://root.cern/download/root_v5.34.24.Linux-slc6_amd64-gcc4.8.tar.gz) |  71M |
+| Scientific Linux Cern 6_amd64 gcc4.9 | [root_v5.34.24.Linux-slc6_amd64-gcc4.9.tar.gz](https://root.cern/download/root_v5.34.24.Linux-slc6_amd64-gcc4.9.tar.gz) |  72M |
+| OsX 10.9 i386 | [root_v5.34.24.macosx64-10.9-i386.tar.gz](https://root.cern/download/root_v5.34.24.macosx64-10.9-i386.tar.gz) |  56M |
+| OsX 10.10 i386 | [root_v5.34.24.macosx64-10.10-i386.tar.gz](https://root.cern/download/root_v5.34.24.macosx64-10.10-i386.tar.gz) |  56M |
+| Windows Visual Studio 10 (dbg) | [root_v5.34.24.win32.vc10.debug.exe](https://root.cern/download/root_v5.34.24.win32.vc10.debug.exe) |  93M |
+| Windows Visual Studio 10 (dbg) | [root_v5.34.24.win32.vc10.debug.tar.gz](https://root.cern/download/root_v5.34.24.win32.vc10.debug.tar.gz) | 138M |
+| Windows Visual Studio 10 | [root_v5.34.24.win32.vc10.exe](https://root.cern/download/root_v5.34.24.win32.vc10.exe) |  47M |
+| Windows Visual Studio 10 | [root_v5.34.24.win32.vc10.tar.gz](https://root.cern/download/root_v5.34.24.win32.vc10.tar.gz) |  61M |
+| Windows Visual Studio 11 (dbg) | [root_v5.34.24.win32.vc11.debug.exe](https://root.cern/download/root_v5.34.24.win32.vc11.debug.exe) |  99M |
+| Windows Visual Studio 11 (dbg) | [root_v5.34.24.win32.vc11.debug.tar.gz](https://root.cern/download/root_v5.34.24.win32.vc11.debug.tar.gz) | 149M |
+| Windows Visual Studio 11 | [root_v5.34.24.win32.vc11.exe](https://root.cern/download/root_v5.34.24.win32.vc11.exe) |  48M |
+| Windows Visual Studio 11 | [root_v5.34.24.win32.vc11.tar.gz](https://root.cern/download/root_v5.34.24.win32.vc11.tar.gz) |  62M |
 
 
 
@@ -75,7 +75,7 @@ To use ROOT directly from AFS:
 The entire ROOT source can be obtained from our public Git repository:
 
 ~~~
-git clone http://root.cern.ch/git/root.git
+git clone http://root.cern/git/root.git
 ~~~
 The release specific tag can be obtained using:
 ~~~

--- a/_releases/release-53425.md
+++ b/_releases/release-53425.md
@@ -18,37 +18,37 @@ The release notes for this release can be found [here]({{ '/install/all_releases
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v5.34.25.source.tar.gz](https://root.cern.ch/download/root_v5.34.25.source.tar.gz) |  72M |
+| source | [root_v5.34.25.source.tar.gz](https://root.cern/download/root_v5.34.25.source.tar.gz) |  72M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| Linux slc5 gcc4.3 | [root_v5.34.25.Linux-slc5-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.34.25.Linux-slc5-gcc4.3.tar.gz) |  68M |
-| Linux slc5 gcc4.7 | [root_v5.34.25.Linux-slc5-gcc4.7.tar.gz](https://root.cern.ch/download/root_v5.34.25.Linux-slc5-gcc4.7.tar.gz) |  70M |
-| Linux slc5_amd64 gcc4.3 | [root_v5.34.25.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.34.25.Linux-slc5_amd64-gcc4.3.tar.gz) |  69M |
-| Linux slc5_amd64 gcc4.7 | [root_v5.34.25.Linux-slc5_amd64-gcc4.7.tar.gz](https://root.cern.ch/download/root_v5.34.25.Linux-slc5_amd64-gcc4.7.tar.gz) |  70M |
-| Scientific Linux Cern 6 gcc4.7 | [root_v5.34.25.Linux-slc6-gcc4.7.tar.gz](https://root.cern.ch/download/root_v5.34.25.Linux-slc6-gcc4.7.tar.gz) |  61M |
-| Scientific Linux Cern 6 gcc4.8 | [root_v5.34.25.Linux-slc6-gcc4.8.tar.gz](https://root.cern.ch/download/root_v5.34.25.Linux-slc6-gcc4.8.tar.gz) |  60M |
-| Scientific Linux Cern 6_amd64 gcc4.4 | [root_v5.34.25.Linux-slc6_amd64-gcc4.4.tar.gz](https://root.cern.ch/download/root_v5.34.25.Linux-slc6_amd64-gcc4.4.tar.gz) |  69M |
-| Scientific Linux Cern 6_amd64 gcc4.7 | [root_v5.34.25.Linux-slc6_amd64-gcc4.7.tar.gz](https://root.cern.ch/download/root_v5.34.25.Linux-slc6_amd64-gcc4.7.tar.gz) |  70M |
-| Scientific Linux Cern 6_amd64 gcc4.8 | [root_v5.34.25.Linux-slc6_amd64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v5.34.25.Linux-slc6_amd64-gcc4.8.tar.gz) |  71M |
-| Scientific Linux Cern 6_amd64 gcc4.9 | [root_v5.34.25.Linux-slc6_amd64-gcc4.9.tar.gz](https://root.cern.ch/download/root_v5.34.25.Linux-slc6_amd64-gcc4.9.tar.gz) |  72M |
-| OsX 10.9 i386 | [root_v5.34.25.macosx64-10.9-i386.tar.gz](https://root.cern.ch/download/root_v5.34.25.macosx64-10.9-i386.tar.gz) |  56M |
-| OsX 10.10 i386 | [root_v5.34.25.macosx64-10.10-i386.tar.gz](https://root.cern.ch/download/root_v5.34.25.macosx64-10.10-i386.tar.gz) |  56M |
-| Windows Visual Studio 10 (dbg) | [root_v5.34.25.win32.vc10.debug.exe](https://root.cern.ch/download/root_v5.34.25.win32.vc10.debug.exe) |  93M |
-| Windows Visual Studio 10 (dbg) | [root_v5.34.25.win32.vc10.debug.tar.gz](https://root.cern.ch/download/root_v5.34.25.win32.vc10.debug.tar.gz) | 138M |
-| Windows Visual Studio 10 | [root_v5.34.25.win32.vc10.exe](https://root.cern.ch/download/root_v5.34.25.win32.vc10.exe) |  47M |
-| Windows Visual Studio 10 | [root_v5.34.25.win32.vc10.tar.gz](https://root.cern.ch/download/root_v5.34.25.win32.vc10.tar.gz) |  61M |
-| Windows Visual Studio 11 (dbg) | [root_v5.34.25.win32.vc11.debug.exe](https://root.cern.ch/download/root_v5.34.25.win32.vc11.debug.exe) |  99M |
-| Windows Visual Studio 11 (dbg) | [root_v5.34.25.win32.vc11.debug.tar.gz](https://root.cern.ch/download/root_v5.34.25.win32.vc11.debug.tar.gz) | 149M |
-| Windows Visual Studio 11 | [root_v5.34.25.win32.vc11.exe](https://root.cern.ch/download/root_v5.34.25.win32.vc11.exe) |  48M |
-| Windows Visual Studio 11 | [root_v5.34.25.win32.vc11.tar.gz](https://root.cern.ch/download/root_v5.34.25.win32.vc11.tar.gz) |  62M |
-| Windows Visual Studio 12 (dbg) | [root_v5.34.25.win32.vc12.debug.exe](https://root.cern.ch/download/root_v5.34.25.win32.vc12.debug.exe) | 100M |
-| Windows Visual Studio 12 (dbg) | [root_v5.34.25.win32.vc12.debug.tar.gz](https://root.cern.ch/download/root_v5.34.25.win32.vc12.debug.tar.gz) | 151M |
-| Windows Visual Studio 12 | [root_v5.34.25.win32.vc12.exe](https://root.cern.ch/download/root_v5.34.25.win32.vc12.exe) |  48M |
-| Windows Visual Studio 12 | [root_v5.34.25.win32.vc12.tar.gz](https://root.cern.ch/download/root_v5.34.25.win32.vc12.tar.gz) |  62M |
+| Linux slc5 gcc4.3 | [root_v5.34.25.Linux-slc5-gcc4.3.tar.gz](https://root.cern/download/root_v5.34.25.Linux-slc5-gcc4.3.tar.gz) |  68M |
+| Linux slc5 gcc4.7 | [root_v5.34.25.Linux-slc5-gcc4.7.tar.gz](https://root.cern/download/root_v5.34.25.Linux-slc5-gcc4.7.tar.gz) |  70M |
+| Linux slc5_amd64 gcc4.3 | [root_v5.34.25.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern/download/root_v5.34.25.Linux-slc5_amd64-gcc4.3.tar.gz) |  69M |
+| Linux slc5_amd64 gcc4.7 | [root_v5.34.25.Linux-slc5_amd64-gcc4.7.tar.gz](https://root.cern/download/root_v5.34.25.Linux-slc5_amd64-gcc4.7.tar.gz) |  70M |
+| Scientific Linux Cern 6 gcc4.7 | [root_v5.34.25.Linux-slc6-gcc4.7.tar.gz](https://root.cern/download/root_v5.34.25.Linux-slc6-gcc4.7.tar.gz) |  61M |
+| Scientific Linux Cern 6 gcc4.8 | [root_v5.34.25.Linux-slc6-gcc4.8.tar.gz](https://root.cern/download/root_v5.34.25.Linux-slc6-gcc4.8.tar.gz) |  60M |
+| Scientific Linux Cern 6_amd64 gcc4.4 | [root_v5.34.25.Linux-slc6_amd64-gcc4.4.tar.gz](https://root.cern/download/root_v5.34.25.Linux-slc6_amd64-gcc4.4.tar.gz) |  69M |
+| Scientific Linux Cern 6_amd64 gcc4.7 | [root_v5.34.25.Linux-slc6_amd64-gcc4.7.tar.gz](https://root.cern/download/root_v5.34.25.Linux-slc6_amd64-gcc4.7.tar.gz) |  70M |
+| Scientific Linux Cern 6_amd64 gcc4.8 | [root_v5.34.25.Linux-slc6_amd64-gcc4.8.tar.gz](https://root.cern/download/root_v5.34.25.Linux-slc6_amd64-gcc4.8.tar.gz) |  71M |
+| Scientific Linux Cern 6_amd64 gcc4.9 | [root_v5.34.25.Linux-slc6_amd64-gcc4.9.tar.gz](https://root.cern/download/root_v5.34.25.Linux-slc6_amd64-gcc4.9.tar.gz) |  72M |
+| OsX 10.9 i386 | [root_v5.34.25.macosx64-10.9-i386.tar.gz](https://root.cern/download/root_v5.34.25.macosx64-10.9-i386.tar.gz) |  56M |
+| OsX 10.10 i386 | [root_v5.34.25.macosx64-10.10-i386.tar.gz](https://root.cern/download/root_v5.34.25.macosx64-10.10-i386.tar.gz) |  56M |
+| Windows Visual Studio 10 (dbg) | [root_v5.34.25.win32.vc10.debug.exe](https://root.cern/download/root_v5.34.25.win32.vc10.debug.exe) |  93M |
+| Windows Visual Studio 10 (dbg) | [root_v5.34.25.win32.vc10.debug.tar.gz](https://root.cern/download/root_v5.34.25.win32.vc10.debug.tar.gz) | 138M |
+| Windows Visual Studio 10 | [root_v5.34.25.win32.vc10.exe](https://root.cern/download/root_v5.34.25.win32.vc10.exe) |  47M |
+| Windows Visual Studio 10 | [root_v5.34.25.win32.vc10.tar.gz](https://root.cern/download/root_v5.34.25.win32.vc10.tar.gz) |  61M |
+| Windows Visual Studio 11 (dbg) | [root_v5.34.25.win32.vc11.debug.exe](https://root.cern/download/root_v5.34.25.win32.vc11.debug.exe) |  99M |
+| Windows Visual Studio 11 (dbg) | [root_v5.34.25.win32.vc11.debug.tar.gz](https://root.cern/download/root_v5.34.25.win32.vc11.debug.tar.gz) | 149M |
+| Windows Visual Studio 11 | [root_v5.34.25.win32.vc11.exe](https://root.cern/download/root_v5.34.25.win32.vc11.exe) |  48M |
+| Windows Visual Studio 11 | [root_v5.34.25.win32.vc11.tar.gz](https://root.cern/download/root_v5.34.25.win32.vc11.tar.gz) |  62M |
+| Windows Visual Studio 12 (dbg) | [root_v5.34.25.win32.vc12.debug.exe](https://root.cern/download/root_v5.34.25.win32.vc12.debug.exe) | 100M |
+| Windows Visual Studio 12 (dbg) | [root_v5.34.25.win32.vc12.debug.tar.gz](https://root.cern/download/root_v5.34.25.win32.vc12.debug.tar.gz) | 151M |
+| Windows Visual Studio 12 | [root_v5.34.25.win32.vc12.exe](https://root.cern/download/root_v5.34.25.win32.vc12.exe) |  48M |
+| Windows Visual Studio 12 | [root_v5.34.25.win32.vc12.tar.gz](https://root.cern/download/root_v5.34.25.win32.vc12.tar.gz) |  62M |
 
 
 
@@ -78,7 +78,7 @@ To use ROOT directly from AFS:
 The entire ROOT source can be obtained from our public Git repository:
 
 ~~~
-git clone http://root.cern.ch/git/root.git
+git clone http://root.cern/git/root.git
 ~~~
 The release specific tag can be obtained using:
 ~~~

--- a/_releases/release-53426.md
+++ b/_releases/release-53426.md
@@ -19,37 +19,37 @@ The release notes for this release can be found [here]({{ '/install/all_releases
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v5.34.26.source.tar.gz](https://root.cern.ch/download/root_v5.34.26.source.tar.gz) |  72M |
+| source | [root_v5.34.26.source.tar.gz](https://root.cern/download/root_v5.34.26.source.tar.gz) |  72M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| Linux slc5 gcc4.3 | [root_v5.34.26.Linux-slc5-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.34.26.Linux-slc5-gcc4.3.tar.gz) |  68M |
-| Linux slc5 gcc4.7 | [root_v5.34.26.Linux-slc5-gcc4.7.tar.gz](https://root.cern.ch/download/root_v5.34.26.Linux-slc5-gcc4.7.tar.gz) |  70M |
-| Linux slc5_amd64 gcc4.3 | [root_v5.34.26.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern.ch/download/root_v5.34.26.Linux-slc5_amd64-gcc4.3.tar.gz) |  69M |
-| Linux slc5_amd64 gcc4.7 | [root_v5.34.26.Linux-slc5_amd64-gcc4.7.tar.gz](https://root.cern.ch/download/root_v5.34.26.Linux-slc5_amd64-gcc4.7.tar.gz) |  70M |
-| Scientific Linux Cern 6 gcc4.7 | [root_v5.34.26.Linux-slc6-gcc4.7.tar.gz](https://root.cern.ch/download/root_v5.34.26.Linux-slc6-gcc4.7.tar.gz) |  61M |
-| Scientific Linux Cern 6 gcc4.8 | [root_v5.34.26.Linux-slc6-gcc4.8.tar.gz](https://root.cern.ch/download/root_v5.34.26.Linux-slc6-gcc4.8.tar.gz) |  60M |
-| Scientific Linux Cern 6_amd64 gcc4.4 | [root_v5.34.26.Linux-slc6_amd64-gcc4.4.tar.gz](https://root.cern.ch/download/root_v5.34.26.Linux-slc6_amd64-gcc4.4.tar.gz) |  69M |
-| Scientific Linux Cern 6_amd64 gcc4.7 | [root_v5.34.26.Linux-slc6_amd64-gcc4.7.tar.gz](https://root.cern.ch/download/root_v5.34.26.Linux-slc6_amd64-gcc4.7.tar.gz) |  70M |
-| Scientific Linux Cern 6_amd64 gcc4.8 | [root_v5.34.26.Linux-slc6_amd64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v5.34.26.Linux-slc6_amd64-gcc4.8.tar.gz) |  71M |
-| Scientific Linux Cern 6_amd64 gcc4.9 | [root_v5.34.26.Linux-slc6_amd64-gcc4.9.tar.gz](https://root.cern.ch/download/root_v5.34.26.Linux-slc6_amd64-gcc4.9.tar.gz) |  72M |
-| OsX 10.9 i386 | [root_v5.34.26.macosx64-10.9-i386.tar.gz](https://root.cern.ch/download/root_v5.34.26.macosx64-10.9-i386.tar.gz) |  56M |
-| OsX 10.10 i386 | [root_v5.34.26.macosx64-10.10-i386.tar.gz](https://root.cern.ch/download/root_v5.34.26.macosx64-10.10-i386.tar.gz) |  56M |
-| Windows Visual Studio 10 (dbg) | [root_v5.34.26.win32.vc10.debug.exe](https://root.cern.ch/download/root_v5.34.26.win32.vc10.debug.exe) |  93M |
-| Windows Visual Studio 10 (dbg) | [root_v5.34.26.win32.vc10.debug.tar.gz](https://root.cern.ch/download/root_v5.34.26.win32.vc10.debug.tar.gz) | 139M |
-| Windows Visual Studio 10 | [root_v5.34.26.win32.vc10.exe](https://root.cern.ch/download/root_v5.34.26.win32.vc10.exe) |  47M |
-| Windows Visual Studio 10 | [root_v5.34.26.win32.vc10.tar.gz](https://root.cern.ch/download/root_v5.34.26.win32.vc10.tar.gz) |  61M |
-| Windows Visual Studio 11 (dbg) | [root_v5.34.26.win32.vc11.debug.exe](https://root.cern.ch/download/root_v5.34.26.win32.vc11.debug.exe) |  99M |
-| Windows Visual Studio 11 (dbg) | [root_v5.34.26.win32.vc11.debug.tar.gz](https://root.cern.ch/download/root_v5.34.26.win32.vc11.debug.tar.gz) | 150M |
-| Windows Visual Studio 11 | [root_v5.34.26.win32.vc11.exe](https://root.cern.ch/download/root_v5.34.26.win32.vc11.exe) |  48M |
-| Windows Visual Studio 11 | [root_v5.34.26.win32.vc11.tar.gz](https://root.cern.ch/download/root_v5.34.26.win32.vc11.tar.gz) |  63M |
-| Windows Visual Studio 12 (dbg) | [root_v5.34.26.win32.vc12.debug.exe](https://root.cern.ch/download/root_v5.34.26.win32.vc12.debug.exe) | 100M |
-| Windows Visual Studio 12 (dbg) | [root_v5.34.26.win32.vc12.debug.tar.gz](https://root.cern.ch/download/root_v5.34.26.win32.vc12.debug.tar.gz) | 150M |
-| Windows Visual Studio 12 | [root_v5.34.26.win32.vc12.exe](https://root.cern.ch/download/root_v5.34.26.win32.vc12.exe) |  48M |
-| Windows Visual Studio 12 | [root_v5.34.26.win32.vc12.tar.gz](https://root.cern.ch/download/root_v5.34.26.win32.vc12.tar.gz) |  62M |
+| Linux slc5 gcc4.3 | [root_v5.34.26.Linux-slc5-gcc4.3.tar.gz](https://root.cern/download/root_v5.34.26.Linux-slc5-gcc4.3.tar.gz) |  68M |
+| Linux slc5 gcc4.7 | [root_v5.34.26.Linux-slc5-gcc4.7.tar.gz](https://root.cern/download/root_v5.34.26.Linux-slc5-gcc4.7.tar.gz) |  70M |
+| Linux slc5_amd64 gcc4.3 | [root_v5.34.26.Linux-slc5_amd64-gcc4.3.tar.gz](https://root.cern/download/root_v5.34.26.Linux-slc5_amd64-gcc4.3.tar.gz) |  69M |
+| Linux slc5_amd64 gcc4.7 | [root_v5.34.26.Linux-slc5_amd64-gcc4.7.tar.gz](https://root.cern/download/root_v5.34.26.Linux-slc5_amd64-gcc4.7.tar.gz) |  70M |
+| Scientific Linux Cern 6 gcc4.7 | [root_v5.34.26.Linux-slc6-gcc4.7.tar.gz](https://root.cern/download/root_v5.34.26.Linux-slc6-gcc4.7.tar.gz) |  61M |
+| Scientific Linux Cern 6 gcc4.8 | [root_v5.34.26.Linux-slc6-gcc4.8.tar.gz](https://root.cern/download/root_v5.34.26.Linux-slc6-gcc4.8.tar.gz) |  60M |
+| Scientific Linux Cern 6_amd64 gcc4.4 | [root_v5.34.26.Linux-slc6_amd64-gcc4.4.tar.gz](https://root.cern/download/root_v5.34.26.Linux-slc6_amd64-gcc4.4.tar.gz) |  69M |
+| Scientific Linux Cern 6_amd64 gcc4.7 | [root_v5.34.26.Linux-slc6_amd64-gcc4.7.tar.gz](https://root.cern/download/root_v5.34.26.Linux-slc6_amd64-gcc4.7.tar.gz) |  70M |
+| Scientific Linux Cern 6_amd64 gcc4.8 | [root_v5.34.26.Linux-slc6_amd64-gcc4.8.tar.gz](https://root.cern/download/root_v5.34.26.Linux-slc6_amd64-gcc4.8.tar.gz) |  71M |
+| Scientific Linux Cern 6_amd64 gcc4.9 | [root_v5.34.26.Linux-slc6_amd64-gcc4.9.tar.gz](https://root.cern/download/root_v5.34.26.Linux-slc6_amd64-gcc4.9.tar.gz) |  72M |
+| OsX 10.9 i386 | [root_v5.34.26.macosx64-10.9-i386.tar.gz](https://root.cern/download/root_v5.34.26.macosx64-10.9-i386.tar.gz) |  56M |
+| OsX 10.10 i386 | [root_v5.34.26.macosx64-10.10-i386.tar.gz](https://root.cern/download/root_v5.34.26.macosx64-10.10-i386.tar.gz) |  56M |
+| Windows Visual Studio 10 (dbg) | [root_v5.34.26.win32.vc10.debug.exe](https://root.cern/download/root_v5.34.26.win32.vc10.debug.exe) |  93M |
+| Windows Visual Studio 10 (dbg) | [root_v5.34.26.win32.vc10.debug.tar.gz](https://root.cern/download/root_v5.34.26.win32.vc10.debug.tar.gz) | 139M |
+| Windows Visual Studio 10 | [root_v5.34.26.win32.vc10.exe](https://root.cern/download/root_v5.34.26.win32.vc10.exe) |  47M |
+| Windows Visual Studio 10 | [root_v5.34.26.win32.vc10.tar.gz](https://root.cern/download/root_v5.34.26.win32.vc10.tar.gz) |  61M |
+| Windows Visual Studio 11 (dbg) | [root_v5.34.26.win32.vc11.debug.exe](https://root.cern/download/root_v5.34.26.win32.vc11.debug.exe) |  99M |
+| Windows Visual Studio 11 (dbg) | [root_v5.34.26.win32.vc11.debug.tar.gz](https://root.cern/download/root_v5.34.26.win32.vc11.debug.tar.gz) | 150M |
+| Windows Visual Studio 11 | [root_v5.34.26.win32.vc11.exe](https://root.cern/download/root_v5.34.26.win32.vc11.exe) |  48M |
+| Windows Visual Studio 11 | [root_v5.34.26.win32.vc11.tar.gz](https://root.cern/download/root_v5.34.26.win32.vc11.tar.gz) |  63M |
+| Windows Visual Studio 12 (dbg) | [root_v5.34.26.win32.vc12.debug.exe](https://root.cern/download/root_v5.34.26.win32.vc12.debug.exe) | 100M |
+| Windows Visual Studio 12 (dbg) | [root_v5.34.26.win32.vc12.debug.tar.gz](https://root.cern/download/root_v5.34.26.win32.vc12.debug.tar.gz) | 150M |
+| Windows Visual Studio 12 | [root_v5.34.26.win32.vc12.exe](https://root.cern/download/root_v5.34.26.win32.vc12.exe) |  48M |
+| Windows Visual Studio 12 | [root_v5.34.26.win32.vc12.tar.gz](https://root.cern/download/root_v5.34.26.win32.vc12.tar.gz) |  62M |
 
 
 
@@ -81,7 +81,7 @@ To use ROOT directly from AFS:
 The entire ROOT source can be obtained from our public Git repository:
 
 ~~~
-git clone http://root.cern.ch/git/root.git
+git clone http://root.cern/git/root.git
 ~~~
 The release specific tag can be obtained using:
 ~~~

--- a/_releases/release-53428.md
+++ b/_releases/release-53428.md
@@ -19,40 +19,40 @@ The release notes for this release can be found [here]({{ '/install/all_releases
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v5.34.28.source.tar.gz](https://root.cern.ch/download/root_v5.34.28.source.tar.gz) |  72M |
+| source | [root_v5.34.28.source.tar.gz](https://root.cern/download/root_v5.34.28.source.tar.gz) |  72M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| CentOS Cern 7 gcc4.8 | [root_v5.34.28.Linux-cc7-x86_64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v5.34.28.Linux-cc7-x86_64-gcc4.8.tar.gz) |  71M |
-| CentOS Cern 7 gcc4.9 | [root_v5.34.28.Linux-cc7-x86_64-gcc4.9.tar.gz](https://root.cern.ch/download/root_v5.34.28.Linux-cc7-x86_64-gcc4.9.tar.gz) |  72M |
-| Linux fedora20 gcc4.8 | [root_v5.34.28.Linux-fedora20-x86_64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v5.34.28.Linux-fedora20-x86_64-gcc4.8.tar.gz) |  57M |
-| Scientific Linux Cern 6 gcc4.4 | [root_v5.34.28.Linux-slc6-x86_64-gcc4.4.tar.gz](https://root.cern.ch/download/root_v5.34.28.Linux-slc6-x86_64-gcc4.4.tar.gz) |  69M |
-| Scientific Linux Cern 6 gcc4.7 | [root_v5.34.28.Linux-slc6-x86_64-gcc4.7.tar.gz](https://root.cern.ch/download/root_v5.34.28.Linux-slc6-x86_64-gcc4.7.tar.gz) |  71M |
-| Scientific Linux Cern 6 gcc4.8 | [root_v5.34.28.Linux-slc6-x86_64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v5.34.28.Linux-slc6-x86_64-gcc4.8.tar.gz) |  71M |
-| Scientific Linux Cern 6 gcc4.9 | [root_v5.34.28.Linux-slc6-x86_64-gcc4.9.tar.gz](https://root.cern.ch/download/root_v5.34.28.Linux-slc6-x86_64-gcc4.9.tar.gz) |  72M |
-| Ubuntu 12 gcc4.6 | [root_v5.34.28.Linux-ubuntu12-x86_64-gcc4.6.tar.gz](https://root.cern.ch/download/root_v5.34.28.Linux-ubuntu12-x86_64-gcc4.6.tar.gz) |  57M |
-| Ubuntu 14 gcc4.8 | [root_v5.34.28.Linux-ubuntu14-x86_64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v5.34.28.Linux-ubuntu14-x86_64-gcc4.8.tar.gz) |  61M |
-| OsX 10.8 clang51 | [root_v5.34.28.macosx64-10.8-clang51.dmg](https://root.cern.ch/download/root_v5.34.28.macosx64-10.8-clang51.dmg) |  58M |
-| OsX 10.8 clang51 | [root_v5.34.28.macosx64-10.8-clang51.tar.gz](https://root.cern.ch/download/root_v5.34.28.macosx64-10.8-clang51.tar.gz) |  57M |
-| OsX 10.9 clang60 | [root_v5.34.28.macosx64-10.9-clang60.dmg](https://root.cern.ch/download/root_v5.34.28.macosx64-10.9-clang60.dmg) |  56M |
-| OsX 10.9 clang60 | [root_v5.34.28.macosx64-10.9-clang60.tar.gz](https://root.cern.ch/download/root_v5.34.28.macosx64-10.9-clang60.tar.gz) |  56M |
-| OsX 10.10 clang60 | [root_v5.34.28.macosx64-10.10-clang60.dmg](https://root.cern.ch/download/root_v5.34.28.macosx64-10.10-clang60.dmg) |  57M |
-| OsX 10.10 clang60 | [root_v5.34.28.macosx64-10.10-clang60.tar.gz](https://root.cern.ch/download/root_v5.34.28.macosx64-10.10-clang60.tar.gz) |  56M |
-| Windows Visual Studio 10 (dbg) | [root_v5.34.28.win32.vc10.debug.exe](https://root.cern.ch/download/root_v5.34.28.win32.vc10.debug.exe) |  92M |
-| Windows Visual Studio 10 (dbg) | [root_v5.34.28.win32.vc10.debug.zip](https://root.cern.ch/download/root_v5.34.28.win32.vc10.debug.zip) | 140M |
-| Windows Visual Studio 10 | [root_v5.34.28.win32.vc10.exe](https://root.cern.ch/download/root_v5.34.28.win32.vc10.exe) |  46M |
-| Windows Visual Studio 10 | [root_v5.34.28.win32.vc10.zip](https://root.cern.ch/download/root_v5.34.28.win32.vc10.zip) |  63M |
-| Windows Visual Studio 11 (dbg) | [root_v5.34.28.win32.vc11.debug.exe](https://root.cern.ch/download/root_v5.34.28.win32.vc11.debug.exe) |  98M |
-| Windows Visual Studio 11 (dbg) | [root_v5.34.28.win32.vc11.debug.zip](https://root.cern.ch/download/root_v5.34.28.win32.vc11.debug.zip) | 151M |
-| Windows Visual Studio 11 | [root_v5.34.28.win32.vc11.exe](https://root.cern.ch/download/root_v5.34.28.win32.vc11.exe) |  47M |
-| Windows Visual Studio 11 | [root_v5.34.28.win32.vc11.zip](https://root.cern.ch/download/root_v5.34.28.win32.vc11.zip) |  64M |
-| Windows Visual Studio 12 (dbg) | [root_v5.34.28.win32.vc12.debug.exe](https://root.cern.ch/download/root_v5.34.28.win32.vc12.debug.exe) |  99M |
-| Windows Visual Studio 12 (dbg) | [root_v5.34.28.win32.vc12.debug.zip](https://root.cern.ch/download/root_v5.34.28.win32.vc12.debug.zip) | 152M |
-| Windows Visual Studio 12 | [root_v5.34.28.win32.vc12.exe](https://root.cern.ch/download/root_v5.34.28.win32.vc12.exe) |  47M |
-| Windows Visual Studio 12 | [root_v5.34.28.win32.vc12.zip](https://root.cern.ch/download/root_v5.34.28.win32.vc12.zip) |  64M |
+| CentOS Cern 7 gcc4.8 | [root_v5.34.28.Linux-cc7-x86_64-gcc4.8.tar.gz](https://root.cern/download/root_v5.34.28.Linux-cc7-x86_64-gcc4.8.tar.gz) |  71M |
+| CentOS Cern 7 gcc4.9 | [root_v5.34.28.Linux-cc7-x86_64-gcc4.9.tar.gz](https://root.cern/download/root_v5.34.28.Linux-cc7-x86_64-gcc4.9.tar.gz) |  72M |
+| Linux fedora20 gcc4.8 | [root_v5.34.28.Linux-fedora20-x86_64-gcc4.8.tar.gz](https://root.cern/download/root_v5.34.28.Linux-fedora20-x86_64-gcc4.8.tar.gz) |  57M |
+| Scientific Linux Cern 6 gcc4.4 | [root_v5.34.28.Linux-slc6-x86_64-gcc4.4.tar.gz](https://root.cern/download/root_v5.34.28.Linux-slc6-x86_64-gcc4.4.tar.gz) |  69M |
+| Scientific Linux Cern 6 gcc4.7 | [root_v5.34.28.Linux-slc6-x86_64-gcc4.7.tar.gz](https://root.cern/download/root_v5.34.28.Linux-slc6-x86_64-gcc4.7.tar.gz) |  71M |
+| Scientific Linux Cern 6 gcc4.8 | [root_v5.34.28.Linux-slc6-x86_64-gcc4.8.tar.gz](https://root.cern/download/root_v5.34.28.Linux-slc6-x86_64-gcc4.8.tar.gz) |  71M |
+| Scientific Linux Cern 6 gcc4.9 | [root_v5.34.28.Linux-slc6-x86_64-gcc4.9.tar.gz](https://root.cern/download/root_v5.34.28.Linux-slc6-x86_64-gcc4.9.tar.gz) |  72M |
+| Ubuntu 12 gcc4.6 | [root_v5.34.28.Linux-ubuntu12-x86_64-gcc4.6.tar.gz](https://root.cern/download/root_v5.34.28.Linux-ubuntu12-x86_64-gcc4.6.tar.gz) |  57M |
+| Ubuntu 14 gcc4.8 | [root_v5.34.28.Linux-ubuntu14-x86_64-gcc4.8.tar.gz](https://root.cern/download/root_v5.34.28.Linux-ubuntu14-x86_64-gcc4.8.tar.gz) |  61M |
+| OsX 10.8 clang51 | [root_v5.34.28.macosx64-10.8-clang51.dmg](https://root.cern/download/root_v5.34.28.macosx64-10.8-clang51.dmg) |  58M |
+| OsX 10.8 clang51 | [root_v5.34.28.macosx64-10.8-clang51.tar.gz](https://root.cern/download/root_v5.34.28.macosx64-10.8-clang51.tar.gz) |  57M |
+| OsX 10.9 clang60 | [root_v5.34.28.macosx64-10.9-clang60.dmg](https://root.cern/download/root_v5.34.28.macosx64-10.9-clang60.dmg) |  56M |
+| OsX 10.9 clang60 | [root_v5.34.28.macosx64-10.9-clang60.tar.gz](https://root.cern/download/root_v5.34.28.macosx64-10.9-clang60.tar.gz) |  56M |
+| OsX 10.10 clang60 | [root_v5.34.28.macosx64-10.10-clang60.dmg](https://root.cern/download/root_v5.34.28.macosx64-10.10-clang60.dmg) |  57M |
+| OsX 10.10 clang60 | [root_v5.34.28.macosx64-10.10-clang60.tar.gz](https://root.cern/download/root_v5.34.28.macosx64-10.10-clang60.tar.gz) |  56M |
+| Windows Visual Studio 10 (dbg) | [root_v5.34.28.win32.vc10.debug.exe](https://root.cern/download/root_v5.34.28.win32.vc10.debug.exe) |  92M |
+| Windows Visual Studio 10 (dbg) | [root_v5.34.28.win32.vc10.debug.zip](https://root.cern/download/root_v5.34.28.win32.vc10.debug.zip) | 140M |
+| Windows Visual Studio 10 | [root_v5.34.28.win32.vc10.exe](https://root.cern/download/root_v5.34.28.win32.vc10.exe) |  46M |
+| Windows Visual Studio 10 | [root_v5.34.28.win32.vc10.zip](https://root.cern/download/root_v5.34.28.win32.vc10.zip) |  63M |
+| Windows Visual Studio 11 (dbg) | [root_v5.34.28.win32.vc11.debug.exe](https://root.cern/download/root_v5.34.28.win32.vc11.debug.exe) |  98M |
+| Windows Visual Studio 11 (dbg) | [root_v5.34.28.win32.vc11.debug.zip](https://root.cern/download/root_v5.34.28.win32.vc11.debug.zip) | 151M |
+| Windows Visual Studio 11 | [root_v5.34.28.win32.vc11.exe](https://root.cern/download/root_v5.34.28.win32.vc11.exe) |  47M |
+| Windows Visual Studio 11 | [root_v5.34.28.win32.vc11.zip](https://root.cern/download/root_v5.34.28.win32.vc11.zip) |  64M |
+| Windows Visual Studio 12 (dbg) | [root_v5.34.28.win32.vc12.debug.exe](https://root.cern/download/root_v5.34.28.win32.vc12.debug.exe) |  99M |
+| Windows Visual Studio 12 (dbg) | [root_v5.34.28.win32.vc12.debug.zip](https://root.cern/download/root_v5.34.28.win32.vc12.debug.zip) | 152M |
+| Windows Visual Studio 12 | [root_v5.34.28.win32.vc12.exe](https://root.cern/download/root_v5.34.28.win32.vc12.exe) |  47M |
+| Windows Visual Studio 12 | [root_v5.34.28.win32.vc12.zip](https://root.cern/download/root_v5.34.28.win32.vc12.zip) |  64M |
 
 
 
@@ -81,7 +81,7 @@ To use ROOT directly from AFS:
 The entire ROOT source can be obtained from our public Git repository:
 
 ~~~
-git clone http://root.cern.ch/git/root.git
+git clone http://root.cern/git/root.git
 ~~~
 The release specific tag can be obtained using:
 ~~~

--- a/_releases/release-53430.md
+++ b/_releases/release-53430.md
@@ -19,40 +19,40 @@ The release notes for this release can be found [here]({{ '/install/all_releases
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v5.34.30.source.tar.gz](https://root.cern.ch/download/root_v5.34.30.source.tar.gz) |  72M |
+| source | [root_v5.34.30.source.tar.gz](https://root.cern/download/root_v5.34.30.source.tar.gz) |  72M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| CentOS Cern 7 gcc4.8 | [root_v5.34.30.Linux-cc7-x86_64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v5.34.30.Linux-cc7-x86_64-gcc4.8.tar.gz) |  71M |
-| CentOS Cern 7 gcc4.9 | [root_v5.34.30.Linux-cc7-x86_64-gcc4.9.tar.gz](https://root.cern.ch/download/root_v5.34.30.Linux-cc7-x86_64-gcc4.9.tar.gz) |  72M |
-| Linux fedora20 gcc4.8 | [root_v5.34.30.Linux-fedora20-x86_64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v5.34.30.Linux-fedora20-x86_64-gcc4.8.tar.gz) |  57M |
-| Scientific Linux Cern 6 gcc4.4 | [root_v5.34.30.Linux-slc6-x86_64-gcc4.4.tar.gz](https://root.cern.ch/download/root_v5.34.30.Linux-slc6-x86_64-gcc4.4.tar.gz) |  69M |
-| Scientific Linux Cern 6 gcc4.7 | [root_v5.34.30.Linux-slc6-x86_64-gcc4.7.tar.gz](https://root.cern.ch/download/root_v5.34.30.Linux-slc6-x86_64-gcc4.7.tar.gz) |  71M |
-| Scientific Linux Cern 6 gcc4.8 | [root_v5.34.30.Linux-slc6-x86_64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v5.34.30.Linux-slc6-x86_64-gcc4.8.tar.gz) |  71M |
-| Scientific Linux Cern 6 gcc4.9 | [root_v5.34.30.Linux-slc6-x86_64-gcc4.9.tar.gz](https://root.cern.ch/download/root_v5.34.30.Linux-slc6-x86_64-gcc4.9.tar.gz) |  72M |
-| Ubuntu 12 gcc4.6 | [root_v5.34.30.Linux-ubuntu12-x86_64-gcc4.6.tar.gz](https://root.cern.ch/download/root_v5.34.30.Linux-ubuntu12-x86_64-gcc4.6.tar.gz) |  57M |
-| Ubuntu 14 gcc4.8 | [root_v5.34.30.Linux-ubuntu14-x86_64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v5.34.30.Linux-ubuntu14-x86_64-gcc4.8.tar.gz) |  57M |
-| OsX 10.8 clang51 | [root_v5.34.30.macosx64-10.8-clang51.dmg](https://root.cern.ch/download/root_v5.34.30.macosx64-10.8-clang51.dmg) |  58M |
-| OsX 10.8 clang51 | [root_v5.34.30.macosx64-10.8-clang51.tar.gz](https://root.cern.ch/download/root_v5.34.30.macosx64-10.8-clang51.tar.gz) |  57M |
-| OsX 10.9 clang60 | [root_v5.34.30.macosx64-10.9-clang60.dmg](https://root.cern.ch/download/root_v5.34.30.macosx64-10.9-clang60.dmg) |  56M |
-| OsX 10.9 clang60 | [root_v5.34.30.macosx64-10.9-clang60.tar.gz](https://root.cern.ch/download/root_v5.34.30.macosx64-10.9-clang60.tar.gz) |  56M |
-| OsX 10.10 clang61 | [root_v5.34.30.macosx64-10.10-clang61.dmg](https://root.cern.ch/download/root_v5.34.30.macosx64-10.10-clang61.dmg) |  57M |
-| OsX 10.10 clang61 | [root_v5.34.30.macosx64-10.10-clang61.tar.gz](https://root.cern.ch/download/root_v5.34.30.macosx64-10.10-clang61.tar.gz) |  56M |
-| Windows Visual Studio 10 (dbg) | [root_v5.34.30.win32.vc10.debug.exe](https://root.cern.ch/download/root_v5.34.30.win32.vc10.debug.exe) |  92M |
-| Windows Visual Studio 10 (dbg) | [root_v5.34.30.win32.vc10.debug.zip](https://root.cern.ch/download/root_v5.34.30.win32.vc10.debug.zip) | 139M |
-| Windows Visual Studio 10 | [root_v5.34.30.win32.vc10.exe](https://root.cern.ch/download/root_v5.34.30.win32.vc10.exe) |  46M |
-| Windows Visual Studio 10 | [root_v5.34.30.win32.vc10.zip](https://root.cern.ch/download/root_v5.34.30.win32.vc10.zip) |  63M |
-| Windows Visual Studio 11 (dbg) | [root_v5.34.30.win32.vc11.debug.exe](https://root.cern.ch/download/root_v5.34.30.win32.vc11.debug.exe) |  98M |
-| Windows Visual Studio 11 (dbg) | [root_v5.34.30.win32.vc11.debug.zip](https://root.cern.ch/download/root_v5.34.30.win32.vc11.debug.zip) | 150M |
-| Windows Visual Studio 11 | [root_v5.34.30.win32.vc11.exe](https://root.cern.ch/download/root_v5.34.30.win32.vc11.exe) |  47M |
-| Windows Visual Studio 11 | [root_v5.34.30.win32.vc11.zip](https://root.cern.ch/download/root_v5.34.30.win32.vc11.zip) |  64M |
-| Windows Visual Studio 12 (dbg) | [root_v5.34.30.win32.vc12.debug.exe](https://root.cern.ch/download/root_v5.34.30.win32.vc12.debug.exe) |  99M |
-| Windows Visual Studio 12 (dbg) | [root_v5.34.30.win32.vc12.debug.zip](https://root.cern.ch/download/root_v5.34.30.win32.vc12.debug.zip) | 151M |
-| Windows Visual Studio 12 | [root_v5.34.30.win32.vc12.exe](https://root.cern.ch/download/root_v5.34.30.win32.vc12.exe) |  47M |
-| Windows Visual Studio 12 | [root_v5.34.30.win32.vc12.zip](https://root.cern.ch/download/root_v5.34.30.win32.vc12.zip) |  64M |
+| CentOS Cern 7 gcc4.8 | [root_v5.34.30.Linux-cc7-x86_64-gcc4.8.tar.gz](https://root.cern/download/root_v5.34.30.Linux-cc7-x86_64-gcc4.8.tar.gz) |  71M |
+| CentOS Cern 7 gcc4.9 | [root_v5.34.30.Linux-cc7-x86_64-gcc4.9.tar.gz](https://root.cern/download/root_v5.34.30.Linux-cc7-x86_64-gcc4.9.tar.gz) |  72M |
+| Linux fedora20 gcc4.8 | [root_v5.34.30.Linux-fedora20-x86_64-gcc4.8.tar.gz](https://root.cern/download/root_v5.34.30.Linux-fedora20-x86_64-gcc4.8.tar.gz) |  57M |
+| Scientific Linux Cern 6 gcc4.4 | [root_v5.34.30.Linux-slc6-x86_64-gcc4.4.tar.gz](https://root.cern/download/root_v5.34.30.Linux-slc6-x86_64-gcc4.4.tar.gz) |  69M |
+| Scientific Linux Cern 6 gcc4.7 | [root_v5.34.30.Linux-slc6-x86_64-gcc4.7.tar.gz](https://root.cern/download/root_v5.34.30.Linux-slc6-x86_64-gcc4.7.tar.gz) |  71M |
+| Scientific Linux Cern 6 gcc4.8 | [root_v5.34.30.Linux-slc6-x86_64-gcc4.8.tar.gz](https://root.cern/download/root_v5.34.30.Linux-slc6-x86_64-gcc4.8.tar.gz) |  71M |
+| Scientific Linux Cern 6 gcc4.9 | [root_v5.34.30.Linux-slc6-x86_64-gcc4.9.tar.gz](https://root.cern/download/root_v5.34.30.Linux-slc6-x86_64-gcc4.9.tar.gz) |  72M |
+| Ubuntu 12 gcc4.6 | [root_v5.34.30.Linux-ubuntu12-x86_64-gcc4.6.tar.gz](https://root.cern/download/root_v5.34.30.Linux-ubuntu12-x86_64-gcc4.6.tar.gz) |  57M |
+| Ubuntu 14 gcc4.8 | [root_v5.34.30.Linux-ubuntu14-x86_64-gcc4.8.tar.gz](https://root.cern/download/root_v5.34.30.Linux-ubuntu14-x86_64-gcc4.8.tar.gz) |  57M |
+| OsX 10.8 clang51 | [root_v5.34.30.macosx64-10.8-clang51.dmg](https://root.cern/download/root_v5.34.30.macosx64-10.8-clang51.dmg) |  58M |
+| OsX 10.8 clang51 | [root_v5.34.30.macosx64-10.8-clang51.tar.gz](https://root.cern/download/root_v5.34.30.macosx64-10.8-clang51.tar.gz) |  57M |
+| OsX 10.9 clang60 | [root_v5.34.30.macosx64-10.9-clang60.dmg](https://root.cern/download/root_v5.34.30.macosx64-10.9-clang60.dmg) |  56M |
+| OsX 10.9 clang60 | [root_v5.34.30.macosx64-10.9-clang60.tar.gz](https://root.cern/download/root_v5.34.30.macosx64-10.9-clang60.tar.gz) |  56M |
+| OsX 10.10 clang61 | [root_v5.34.30.macosx64-10.10-clang61.dmg](https://root.cern/download/root_v5.34.30.macosx64-10.10-clang61.dmg) |  57M |
+| OsX 10.10 clang61 | [root_v5.34.30.macosx64-10.10-clang61.tar.gz](https://root.cern/download/root_v5.34.30.macosx64-10.10-clang61.tar.gz) |  56M |
+| Windows Visual Studio 10 (dbg) | [root_v5.34.30.win32.vc10.debug.exe](https://root.cern/download/root_v5.34.30.win32.vc10.debug.exe) |  92M |
+| Windows Visual Studio 10 (dbg) | [root_v5.34.30.win32.vc10.debug.zip](https://root.cern/download/root_v5.34.30.win32.vc10.debug.zip) | 139M |
+| Windows Visual Studio 10 | [root_v5.34.30.win32.vc10.exe](https://root.cern/download/root_v5.34.30.win32.vc10.exe) |  46M |
+| Windows Visual Studio 10 | [root_v5.34.30.win32.vc10.zip](https://root.cern/download/root_v5.34.30.win32.vc10.zip) |  63M |
+| Windows Visual Studio 11 (dbg) | [root_v5.34.30.win32.vc11.debug.exe](https://root.cern/download/root_v5.34.30.win32.vc11.debug.exe) |  98M |
+| Windows Visual Studio 11 (dbg) | [root_v5.34.30.win32.vc11.debug.zip](https://root.cern/download/root_v5.34.30.win32.vc11.debug.zip) | 150M |
+| Windows Visual Studio 11 | [root_v5.34.30.win32.vc11.exe](https://root.cern/download/root_v5.34.30.win32.vc11.exe) |  47M |
+| Windows Visual Studio 11 | [root_v5.34.30.win32.vc11.zip](https://root.cern/download/root_v5.34.30.win32.vc11.zip) |  64M |
+| Windows Visual Studio 12 (dbg) | [root_v5.34.30.win32.vc12.debug.exe](https://root.cern/download/root_v5.34.30.win32.vc12.debug.exe) |  99M |
+| Windows Visual Studio 12 (dbg) | [root_v5.34.30.win32.vc12.debug.zip](https://root.cern/download/root_v5.34.30.win32.vc12.debug.zip) | 151M |
+| Windows Visual Studio 12 | [root_v5.34.30.win32.vc12.exe](https://root.cern/download/root_v5.34.30.win32.vc12.exe) |  47M |
+| Windows Visual Studio 12 | [root_v5.34.30.win32.vc12.zip](https://root.cern/download/root_v5.34.30.win32.vc12.zip) |  64M |
 
 
 
@@ -85,7 +85,7 @@ To use ROOT directly from AFS:
 The entire ROOT source can be obtained from our public Git repository:
 
 ~~~
-git clone http://root.cern.ch/git/root.git
+git clone http://root.cern/git/root.git
 ~~~
 The release specific tag can be obtained using:
 ~~~

--- a/_releases/release-53432.md
+++ b/_releases/release-53432.md
@@ -19,40 +19,40 @@ The release notes for this release can be found [here]({{ '/install/all_releases
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v5.34.32.source.tar.gz](https://root.cern.ch/download/root_v5.34.32.source.tar.gz) |  72M |
+| source | [root_v5.34.32.source.tar.gz](https://root.cern/download/root_v5.34.32.source.tar.gz) |  72M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| CentOS Cern 7 gcc4.8 | [root_v5.34.32.Linux-cc7-x86_64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v5.34.32.Linux-cc7-x86_64-gcc4.8.tar.gz) |  71M |
-| CentOS Cern 7 gcc4.9 | [root_v5.34.32.Linux-cc7-x86_64-gcc4.9.tar.gz](https://root.cern.ch/download/root_v5.34.32.Linux-cc7-x86_64-gcc4.9.tar.gz) |  72M |
-| Linux fedora20 gcc4.8 | [root_v5.34.32.Linux-fedora20-x86_64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v5.34.32.Linux-fedora20-x86_64-gcc4.8.tar.gz) |  57M |
-| Scientific Linux Cern 6 gcc4.4 | [root_v5.34.32.Linux-slc6-x86_64-gcc4.4.tar.gz](https://root.cern.ch/download/root_v5.34.32.Linux-slc6-x86_64-gcc4.4.tar.gz) |  69M |
-| Scientific Linux Cern 6 gcc4.7 | [root_v5.34.32.Linux-slc6-x86_64-gcc4.7.tar.gz](https://root.cern.ch/download/root_v5.34.32.Linux-slc6-x86_64-gcc4.7.tar.gz) |  71M |
-| Scientific Linux Cern 6 gcc4.8 | [root_v5.34.32.Linux-slc6-x86_64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v5.34.32.Linux-slc6-x86_64-gcc4.8.tar.gz) |  71M |
-| Scientific Linux Cern 6 gcc4.9 | [root_v5.34.32.Linux-slc6-x86_64-gcc4.9.tar.gz](https://root.cern.ch/download/root_v5.34.32.Linux-slc6-x86_64-gcc4.9.tar.gz) |  72M |
-| Ubuntu 12 gcc4.6 | [root_v5.34.32.Linux-ubuntu12-x86_64-gcc4.6.tar.gz](https://root.cern.ch/download/root_v5.34.32.Linux-ubuntu12-x86_64-gcc4.6.tar.gz) |  57M |
-| Ubuntu 14 gcc4.8 | [root_v5.34.32.Linux-ubuntu14-x86_64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v5.34.32.Linux-ubuntu14-x86_64-gcc4.8.tar.gz) |  62M |
-| OsX 10.8 clang51 | [root_v5.34.32.macosx64-10.8-clang51.dmg](https://root.cern.ch/download/root_v5.34.32.macosx64-10.8-clang51.dmg) |  58M |
-| OsX 10.8 clang51 | [root_v5.34.32.macosx64-10.8-clang51.tar.gz](https://root.cern.ch/download/root_v5.34.32.macosx64-10.8-clang51.tar.gz) |  58M |
-| OsX 10.9 clang60 | [root_v5.34.32.macosx64-10.9-clang60.dmg](https://root.cern.ch/download/root_v5.34.32.macosx64-10.9-clang60.dmg) |  56M |
-| OsX 10.9 clang60 | [root_v5.34.32.macosx64-10.9-clang60.tar.gz](https://root.cern.ch/download/root_v5.34.32.macosx64-10.9-clang60.tar.gz) |  56M |
-| OsX 10.10 clang61 | [root_v5.34.32.macosx64-10.10-clang61.dmg](https://root.cern.ch/download/root_v5.34.32.macosx64-10.10-clang61.dmg) |  58M |
-| OsX 10.10 clang61 | [root_v5.34.32.macosx64-10.10-clang61.tar.gz](https://root.cern.ch/download/root_v5.34.32.macosx64-10.10-clang61.tar.gz) |  56M |
-| Windows Visual Studio 10 (dbg) | [root_v5.34.32.win32.vc10.debug.exe](https://root.cern.ch/download/root_v5.34.32.win32.vc10.debug.exe) |  92M |
-| Windows Visual Studio 10 (dbg) | [root_v5.34.32.win32.vc10.debug.zip](https://root.cern.ch/download/root_v5.34.32.win32.vc10.debug.zip) | 139M |
-| Windows Visual Studio 10 | [root_v5.34.32.win32.vc10.exe](https://root.cern.ch/download/root_v5.34.32.win32.vc10.exe) |  46M |
-| Windows Visual Studio 10 | [root_v5.34.32.win32.vc10.zip](https://root.cern.ch/download/root_v5.34.32.win32.vc10.zip) |  63M |
-| Windows Visual Studio 11 (dbg) | [root_v5.34.32.win32.vc11.debug.exe](https://root.cern.ch/download/root_v5.34.32.win32.vc11.debug.exe) |  98M |
-| Windows Visual Studio 11 (dbg) | [root_v5.34.32.win32.vc11.debug.zip](https://root.cern.ch/download/root_v5.34.32.win32.vc11.debug.zip) | 150M |
-| Windows Visual Studio 11 | [root_v5.34.32.win32.vc11.exe](https://root.cern.ch/download/root_v5.34.32.win32.vc11.exe) |  47M |
-| Windows Visual Studio 11 | [root_v5.34.32.win32.vc11.zip](https://root.cern.ch/download/root_v5.34.32.win32.vc11.zip) |  64M |
-| Windows Visual Studio 12 (dbg) | [root_v5.34.32.win32.vc12.debug.exe](https://root.cern.ch/download/root_v5.34.32.win32.vc12.debug.exe) |  99M |
-| Windows Visual Studio 12 (dbg) | [root_v5.34.32.win32.vc12.debug.zip](https://root.cern.ch/download/root_v5.34.32.win32.vc12.debug.zip) | 151M |
-| Windows Visual Studio 12 | [root_v5.34.32.win32.vc12.exe](https://root.cern.ch/download/root_v5.34.32.win32.vc12.exe) |  47M |
-| Windows Visual Studio 12 | [root_v5.34.32.win32.vc12.zip](https://root.cern.ch/download/root_v5.34.32.win32.vc12.zip) |  64M |
+| CentOS Cern 7 gcc4.8 | [root_v5.34.32.Linux-cc7-x86_64-gcc4.8.tar.gz](https://root.cern/download/root_v5.34.32.Linux-cc7-x86_64-gcc4.8.tar.gz) |  71M |
+| CentOS Cern 7 gcc4.9 | [root_v5.34.32.Linux-cc7-x86_64-gcc4.9.tar.gz](https://root.cern/download/root_v5.34.32.Linux-cc7-x86_64-gcc4.9.tar.gz) |  72M |
+| Linux fedora20 gcc4.8 | [root_v5.34.32.Linux-fedora20-x86_64-gcc4.8.tar.gz](https://root.cern/download/root_v5.34.32.Linux-fedora20-x86_64-gcc4.8.tar.gz) |  57M |
+| Scientific Linux Cern 6 gcc4.4 | [root_v5.34.32.Linux-slc6-x86_64-gcc4.4.tar.gz](https://root.cern/download/root_v5.34.32.Linux-slc6-x86_64-gcc4.4.tar.gz) |  69M |
+| Scientific Linux Cern 6 gcc4.7 | [root_v5.34.32.Linux-slc6-x86_64-gcc4.7.tar.gz](https://root.cern/download/root_v5.34.32.Linux-slc6-x86_64-gcc4.7.tar.gz) |  71M |
+| Scientific Linux Cern 6 gcc4.8 | [root_v5.34.32.Linux-slc6-x86_64-gcc4.8.tar.gz](https://root.cern/download/root_v5.34.32.Linux-slc6-x86_64-gcc4.8.tar.gz) |  71M |
+| Scientific Linux Cern 6 gcc4.9 | [root_v5.34.32.Linux-slc6-x86_64-gcc4.9.tar.gz](https://root.cern/download/root_v5.34.32.Linux-slc6-x86_64-gcc4.9.tar.gz) |  72M |
+| Ubuntu 12 gcc4.6 | [root_v5.34.32.Linux-ubuntu12-x86_64-gcc4.6.tar.gz](https://root.cern/download/root_v5.34.32.Linux-ubuntu12-x86_64-gcc4.6.tar.gz) |  57M |
+| Ubuntu 14 gcc4.8 | [root_v5.34.32.Linux-ubuntu14-x86_64-gcc4.8.tar.gz](https://root.cern/download/root_v5.34.32.Linux-ubuntu14-x86_64-gcc4.8.tar.gz) |  62M |
+| OsX 10.8 clang51 | [root_v5.34.32.macosx64-10.8-clang51.dmg](https://root.cern/download/root_v5.34.32.macosx64-10.8-clang51.dmg) |  58M |
+| OsX 10.8 clang51 | [root_v5.34.32.macosx64-10.8-clang51.tar.gz](https://root.cern/download/root_v5.34.32.macosx64-10.8-clang51.tar.gz) |  58M |
+| OsX 10.9 clang60 | [root_v5.34.32.macosx64-10.9-clang60.dmg](https://root.cern/download/root_v5.34.32.macosx64-10.9-clang60.dmg) |  56M |
+| OsX 10.9 clang60 | [root_v5.34.32.macosx64-10.9-clang60.tar.gz](https://root.cern/download/root_v5.34.32.macosx64-10.9-clang60.tar.gz) |  56M |
+| OsX 10.10 clang61 | [root_v5.34.32.macosx64-10.10-clang61.dmg](https://root.cern/download/root_v5.34.32.macosx64-10.10-clang61.dmg) |  58M |
+| OsX 10.10 clang61 | [root_v5.34.32.macosx64-10.10-clang61.tar.gz](https://root.cern/download/root_v5.34.32.macosx64-10.10-clang61.tar.gz) |  56M |
+| Windows Visual Studio 10 (dbg) | [root_v5.34.32.win32.vc10.debug.exe](https://root.cern/download/root_v5.34.32.win32.vc10.debug.exe) |  92M |
+| Windows Visual Studio 10 (dbg) | [root_v5.34.32.win32.vc10.debug.zip](https://root.cern/download/root_v5.34.32.win32.vc10.debug.zip) | 139M |
+| Windows Visual Studio 10 | [root_v5.34.32.win32.vc10.exe](https://root.cern/download/root_v5.34.32.win32.vc10.exe) |  46M |
+| Windows Visual Studio 10 | [root_v5.34.32.win32.vc10.zip](https://root.cern/download/root_v5.34.32.win32.vc10.zip) |  63M |
+| Windows Visual Studio 11 (dbg) | [root_v5.34.32.win32.vc11.debug.exe](https://root.cern/download/root_v5.34.32.win32.vc11.debug.exe) |  98M |
+| Windows Visual Studio 11 (dbg) | [root_v5.34.32.win32.vc11.debug.zip](https://root.cern/download/root_v5.34.32.win32.vc11.debug.zip) | 150M |
+| Windows Visual Studio 11 | [root_v5.34.32.win32.vc11.exe](https://root.cern/download/root_v5.34.32.win32.vc11.exe) |  47M |
+| Windows Visual Studio 11 | [root_v5.34.32.win32.vc11.zip](https://root.cern/download/root_v5.34.32.win32.vc11.zip) |  64M |
+| Windows Visual Studio 12 (dbg) | [root_v5.34.32.win32.vc12.debug.exe](https://root.cern/download/root_v5.34.32.win32.vc12.debug.exe) |  99M |
+| Windows Visual Studio 12 (dbg) | [root_v5.34.32.win32.vc12.debug.zip](https://root.cern/download/root_v5.34.32.win32.vc12.debug.zip) | 151M |
+| Windows Visual Studio 12 | [root_v5.34.32.win32.vc12.exe](https://root.cern/download/root_v5.34.32.win32.vc12.exe) |  47M |
+| Windows Visual Studio 12 | [root_v5.34.32.win32.vc12.zip](https://root.cern/download/root_v5.34.32.win32.vc12.zip) |  64M |
 
 
 
@@ -82,7 +82,7 @@ To use ROOT directly from AFS:
 The entire ROOT source can be obtained from our public Git repository:
 
 ~~~
-git clone http://root.cern.ch/git/root.git
+git clone http://root.cern/git/root.git
 ~~~
 The release specific tag can be obtained using:
 ~~~

--- a/_releases/release-53434.md
+++ b/_releases/release-53434.md
@@ -19,40 +19,40 @@ The release notes for this release can be found [here]({{ '/install/all_releases
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v5.34.34.source.tar.gz](https://root.cern.ch/download/root_v5.34.34.source.tar.gz) |  72M |
+| source | [root_v5.34.34.source.tar.gz](https://root.cern/download/root_v5.34.34.source.tar.gz) |  72M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| CentOS Cern 7 gcc4.8 | [root_v5.34.34.Linux-cc7-x86_64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v5.34.34.Linux-cc7-x86_64-gcc4.8.tar.gz) |  72M |
-| CentOS Cern 7 gcc4.9 | [root_v5.34.34.Linux-cc7-x86_64-gcc4.9.tar.gz](https://root.cern.ch/download/root_v5.34.34.Linux-cc7-x86_64-gcc4.9.tar.gz) |  73M |
-| Linux fedora20 gcc4.8 | [root_v5.34.34.Linux-fedora20-x86_64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v5.34.34.Linux-fedora20-x86_64-gcc4.8.tar.gz) |  57M |
-| Scientific Linux Cern 6 gcc4.4 | [root_v5.34.34.Linux-slc6-x86_64-gcc4.4.tar.gz](https://root.cern.ch/download/root_v5.34.34.Linux-slc6-x86_64-gcc4.4.tar.gz) |  69M |
-| Scientific Linux Cern 6 gcc4.7 | [root_v5.34.34.Linux-slc6-x86_64-gcc4.7.tar.gz](https://root.cern.ch/download/root_v5.34.34.Linux-slc6-x86_64-gcc4.7.tar.gz) |  71M |
-| Scientific Linux Cern 6 gcc4.8 | [root_v5.34.34.Linux-slc6-x86_64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v5.34.34.Linux-slc6-x86_64-gcc4.8.tar.gz) |  71M |
-| Scientific Linux Cern 6 gcc4.9 | [root_v5.34.34.Linux-slc6-x86_64-gcc4.9.tar.gz](https://root.cern.ch/download/root_v5.34.34.Linux-slc6-x86_64-gcc4.9.tar.gz) |  73M |
-| Ubuntu 12 gcc4.6 | [root_v5.34.34.Linux-ubuntu12-x86_64-gcc4.6.tar.gz](https://root.cern.ch/download/root_v5.34.34.Linux-ubuntu12-x86_64-gcc4.6.tar.gz) |  58M |
-| Ubuntu 14 gcc4.8 | [root_v5.34.34.Linux-ubuntu14-x86_64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v5.34.34.Linux-ubuntu14-x86_64-gcc4.8.tar.gz) |  62M |
-| OsX 10.8 clang51 | [root_v5.34.34.macosx64-10.8-clang51.dmg](https://root.cern.ch/download/root_v5.34.34.macosx64-10.8-clang51.dmg) |  58M |
-| OsX 10.8 clang51 | [root_v5.34.34.macosx64-10.8-clang51.tar.gz](https://root.cern.ch/download/root_v5.34.34.macosx64-10.8-clang51.tar.gz) |  58M |
-| OsX 10.9 clang60 | [root_v5.34.34.macosx64-10.9-clang60.dmg](https://root.cern.ch/download/root_v5.34.34.macosx64-10.9-clang60.dmg) |  56M |
-| OsX 10.9 clang60 | [root_v5.34.34.macosx64-10.9-clang60.tar.gz](https://root.cern.ch/download/root_v5.34.34.macosx64-10.9-clang60.tar.gz) |  56M |
-| OsX 10.10 clang61 | [root_v5.34.34.macosx64-10.10-clang61.dmg](https://root.cern.ch/download/root_v5.34.34.macosx64-10.10-clang61.dmg) |  58M |
-| OsX 10.10 clang61 | [root_v5.34.34.macosx64-10.10-clang61.tar.gz](https://root.cern.ch/download/root_v5.34.34.macosx64-10.10-clang61.tar.gz) |  56M |
-| Windows Visual Studio 10 (dbg) | [root_v5.34.34.win32.vc10.debug.exe](https://root.cern.ch/download/root_v5.34.34.win32.vc10.debug.exe) |  92M |
-| Windows Visual Studio 10 (dbg) | [root_v5.34.34.win32.vc10.debug.zip](https://root.cern.ch/download/root_v5.34.34.win32.vc10.debug.zip) | 139M |
-| Windows Visual Studio 10 | [root_v5.34.34.win32.vc10.exe](https://root.cern.ch/download/root_v5.34.34.win32.vc10.exe) |  46M |
-| Windows Visual Studio 10 | [root_v5.34.34.win32.vc10.zip](https://root.cern.ch/download/root_v5.34.34.win32.vc10.zip) |  63M |
-| Windows Visual Studio 11 (dbg) | [root_v5.34.34.win32.vc11.debug.exe](https://root.cern.ch/download/root_v5.34.34.win32.vc11.debug.exe) |  98M |
-| Windows Visual Studio 11 (dbg) | [root_v5.34.34.win32.vc11.debug.zip](https://root.cern.ch/download/root_v5.34.34.win32.vc11.debug.zip) | 150M |
-| Windows Visual Studio 11 | [root_v5.34.34.win32.vc11.exe](https://root.cern.ch/download/root_v5.34.34.win32.vc11.exe) |  47M |
-| Windows Visual Studio 11 | [root_v5.34.34.win32.vc11.zip](https://root.cern.ch/download/root_v5.34.34.win32.vc11.zip) |  64M |
-| Windows Visual Studio 12 (dbg) | [root_v5.34.34.win32.vc12.debug.exe](https://root.cern.ch/download/root_v5.34.34.win32.vc12.debug.exe) |  99M |
-| Windows Visual Studio 12 (dbg) | [root_v5.34.34.win32.vc12.debug.zip](https://root.cern.ch/download/root_v5.34.34.win32.vc12.debug.zip) | 151M |
-| Windows Visual Studio 12 | [root_v5.34.34.win32.vc12.exe](https://root.cern.ch/download/root_v5.34.34.win32.vc12.exe) |  47M |
-| Windows Visual Studio 12 | [root_v5.34.34.win32.vc12.zip](https://root.cern.ch/download/root_v5.34.34.win32.vc12.zip) |  64M |
+| CentOS Cern 7 gcc4.8 | [root_v5.34.34.Linux-cc7-x86_64-gcc4.8.tar.gz](https://root.cern/download/root_v5.34.34.Linux-cc7-x86_64-gcc4.8.tar.gz) |  72M |
+| CentOS Cern 7 gcc4.9 | [root_v5.34.34.Linux-cc7-x86_64-gcc4.9.tar.gz](https://root.cern/download/root_v5.34.34.Linux-cc7-x86_64-gcc4.9.tar.gz) |  73M |
+| Linux fedora20 gcc4.8 | [root_v5.34.34.Linux-fedora20-x86_64-gcc4.8.tar.gz](https://root.cern/download/root_v5.34.34.Linux-fedora20-x86_64-gcc4.8.tar.gz) |  57M |
+| Scientific Linux Cern 6 gcc4.4 | [root_v5.34.34.Linux-slc6-x86_64-gcc4.4.tar.gz](https://root.cern/download/root_v5.34.34.Linux-slc6-x86_64-gcc4.4.tar.gz) |  69M |
+| Scientific Linux Cern 6 gcc4.7 | [root_v5.34.34.Linux-slc6-x86_64-gcc4.7.tar.gz](https://root.cern/download/root_v5.34.34.Linux-slc6-x86_64-gcc4.7.tar.gz) |  71M |
+| Scientific Linux Cern 6 gcc4.8 | [root_v5.34.34.Linux-slc6-x86_64-gcc4.8.tar.gz](https://root.cern/download/root_v5.34.34.Linux-slc6-x86_64-gcc4.8.tar.gz) |  71M |
+| Scientific Linux Cern 6 gcc4.9 | [root_v5.34.34.Linux-slc6-x86_64-gcc4.9.tar.gz](https://root.cern/download/root_v5.34.34.Linux-slc6-x86_64-gcc4.9.tar.gz) |  73M |
+| Ubuntu 12 gcc4.6 | [root_v5.34.34.Linux-ubuntu12-x86_64-gcc4.6.tar.gz](https://root.cern/download/root_v5.34.34.Linux-ubuntu12-x86_64-gcc4.6.tar.gz) |  58M |
+| Ubuntu 14 gcc4.8 | [root_v5.34.34.Linux-ubuntu14-x86_64-gcc4.8.tar.gz](https://root.cern/download/root_v5.34.34.Linux-ubuntu14-x86_64-gcc4.8.tar.gz) |  62M |
+| OsX 10.8 clang51 | [root_v5.34.34.macosx64-10.8-clang51.dmg](https://root.cern/download/root_v5.34.34.macosx64-10.8-clang51.dmg) |  58M |
+| OsX 10.8 clang51 | [root_v5.34.34.macosx64-10.8-clang51.tar.gz](https://root.cern/download/root_v5.34.34.macosx64-10.8-clang51.tar.gz) |  58M |
+| OsX 10.9 clang60 | [root_v5.34.34.macosx64-10.9-clang60.dmg](https://root.cern/download/root_v5.34.34.macosx64-10.9-clang60.dmg) |  56M |
+| OsX 10.9 clang60 | [root_v5.34.34.macosx64-10.9-clang60.tar.gz](https://root.cern/download/root_v5.34.34.macosx64-10.9-clang60.tar.gz) |  56M |
+| OsX 10.10 clang61 | [root_v5.34.34.macosx64-10.10-clang61.dmg](https://root.cern/download/root_v5.34.34.macosx64-10.10-clang61.dmg) |  58M |
+| OsX 10.10 clang61 | [root_v5.34.34.macosx64-10.10-clang61.tar.gz](https://root.cern/download/root_v5.34.34.macosx64-10.10-clang61.tar.gz) |  56M |
+| Windows Visual Studio 10 (dbg) | [root_v5.34.34.win32.vc10.debug.exe](https://root.cern/download/root_v5.34.34.win32.vc10.debug.exe) |  92M |
+| Windows Visual Studio 10 (dbg) | [root_v5.34.34.win32.vc10.debug.zip](https://root.cern/download/root_v5.34.34.win32.vc10.debug.zip) | 139M |
+| Windows Visual Studio 10 | [root_v5.34.34.win32.vc10.exe](https://root.cern/download/root_v5.34.34.win32.vc10.exe) |  46M |
+| Windows Visual Studio 10 | [root_v5.34.34.win32.vc10.zip](https://root.cern/download/root_v5.34.34.win32.vc10.zip) |  63M |
+| Windows Visual Studio 11 (dbg) | [root_v5.34.34.win32.vc11.debug.exe](https://root.cern/download/root_v5.34.34.win32.vc11.debug.exe) |  98M |
+| Windows Visual Studio 11 (dbg) | [root_v5.34.34.win32.vc11.debug.zip](https://root.cern/download/root_v5.34.34.win32.vc11.debug.zip) | 150M |
+| Windows Visual Studio 11 | [root_v5.34.34.win32.vc11.exe](https://root.cern/download/root_v5.34.34.win32.vc11.exe) |  47M |
+| Windows Visual Studio 11 | [root_v5.34.34.win32.vc11.zip](https://root.cern/download/root_v5.34.34.win32.vc11.zip) |  64M |
+| Windows Visual Studio 12 (dbg) | [root_v5.34.34.win32.vc12.debug.exe](https://root.cern/download/root_v5.34.34.win32.vc12.debug.exe) |  99M |
+| Windows Visual Studio 12 (dbg) | [root_v5.34.34.win32.vc12.debug.zip](https://root.cern/download/root_v5.34.34.win32.vc12.debug.zip) | 151M |
+| Windows Visual Studio 12 | [root_v5.34.34.win32.vc12.exe](https://root.cern/download/root_v5.34.34.win32.vc12.exe) |  47M |
+| Windows Visual Studio 12 | [root_v5.34.34.win32.vc12.zip](https://root.cern/download/root_v5.34.34.win32.vc12.zip) |  64M |
 
 
 
@@ -82,7 +82,7 @@ To use ROOT directly from AFS:
 The entire ROOT source can be obtained from our public Git repository:
 
 ~~~
-git clone http://root.cern.ch/git/root.git
+git clone http://root.cern/git/root.git
 ~~~
 The release specific tag can be obtained using:
 ~~~

--- a/_releases/release-53436.md
+++ b/_releases/release-53436.md
@@ -46,41 +46,41 @@ The fixed/completed list of JIRA tickets are:
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v5.34.36.source.tar.gz](https://root.cern.ch/download/root_v5.34.36.source.tar.gz) |  72M |
+| source | [root_v5.34.36.source.tar.gz](https://root.cern/download/root_v5.34.36.source.tar.gz) |  72M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| CentOS Cern 7 gcc4.8 | [root_v5.34.36.Linux-centos7-x86_64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v5.34.36.Linux-centos7-x86_64-gcc4.8.tar.gz) |  72M |
-| CentOS Cern 7 gcc4.9 | [root_v5.34.36.Linux-centos7-x86_64-gcc4.9.tar.gz](https://root.cern.ch/download/root_v5.34.36.Linux-centos7-x86_64-gcc4.9.tar.gz) |  73M |
-| Linux fedora20 gcc4.8 | [root_v5.34.36.Linux-fedora20-x86_64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v5.34.36.Linux-fedora20-x86_64-gcc4.8.tar.gz) |  58M |
-| Scientific Linux Cern 6 gcc4.4 | [root_v5.34.36.Linux-slc6-x86_64-gcc4.4.tar.gz](https://root.cern.ch/download/root_v5.34.36.Linux-slc6-x86_64-gcc4.4.tar.gz) |  70M |
-| Scientific Linux Cern 6 gcc4.7 | [root_v5.34.36.Linux-slc6-x86_64-gcc4.7.tar.gz](https://root.cern.ch/download/root_v5.34.36.Linux-slc6-x86_64-gcc4.7.tar.gz) |  71M |
-| Scientific Linux Cern 6 gcc4.8 | [root_v5.34.36.Linux-slc6-x86_64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v5.34.36.Linux-slc6-x86_64-gcc4.8.tar.gz) |  71M |
-| Scientific Linux Cern 6 gcc4.9 | [root_v5.34.36.Linux-slc6-x86_64-gcc4.9.tar.gz](https://root.cern.ch/download/root_v5.34.36.Linux-slc6-x86_64-gcc4.9.tar.gz) |  73M |
-| Scientific Linux Cern 6 gcc5.1 | [root_v5.34.36.Linux-slc6-x86_64-gcc5.1.tar.gz](https://root.cern.ch/download/root_v5.34.36.Linux-slc6-x86_64-gcc5.1.tar.gz) |  73M |
-| Ubuntu 12 gcc4.6 | [root_v5.34.36.Linux-ubuntu12-x86_64-gcc4.6.tar.gz](https://root.cern.ch/download/root_v5.34.36.Linux-ubuntu12-x86_64-gcc4.6.tar.gz) |  58M |
-| Ubuntu 14 gcc4.8 | [root_v5.34.36.Linux-ubuntu14-x86_64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v5.34.36.Linux-ubuntu14-x86_64-gcc4.8.tar.gz) |  62M |
-| OsX 10.9 clang60 | [root_v5.34.36.macosx64-10.9-clang60.dmg](https://root.cern.ch/download/root_v5.34.36.macosx64-10.9-clang60.dmg) |  56M |
-| OsX 10.9 clang60 | [root_v5.34.36.macosx64-10.9-clang60.tar.gz](https://root.cern.ch/download/root_v5.34.36.macosx64-10.9-clang60.tar.gz) |  56M |
-| OsX 10.10 clang70 | [root_v5.34.36.macosx64-10.10-clang70.dmg](https://root.cern.ch/download/root_v5.34.36.macosx64-10.10-clang70.dmg) |  57M |
-| OsX 10.10 clang70 | [root_v5.34.36.macosx64-10.10-clang70.tar.gz](https://root.cern.ch/download/root_v5.34.36.macosx64-10.10-clang70.tar.gz) |  56M |
-| OsX 10.11 clang70 | [root_v5.34.36.macosx64-10.11-clang70.dmg](https://root.cern.ch/download/root_v5.34.36.macosx64-10.11-clang70.dmg) |  58M |
-| OsX 10.11 clang70 | [root_v5.34.36.macosx64-10.11-clang70.tar.gz](https://root.cern.ch/download/root_v5.34.36.macosx64-10.11-clang70.tar.gz) |  58M |
-| Windows Visual Studio 2010 (dbg) | [root_v5.34.36.win32.vc10.debug.exe](https://root.cern.ch/download/root_v5.34.36.win32.vc10.debug.exe) |  92M |
-| Windows Visual Studio 2010 (dbg) | [root_v5.34.36.win32.vc10.debug.zip](https://root.cern.ch/download/root_v5.34.36.win32.vc10.debug.zip) | 140M |
-| Windows Visual Studio 2010 | [root_v5.34.36.win32.vc10.exe](https://root.cern.ch/download/root_v5.34.36.win32.vc10.exe) |  46M |
-| Windows Visual Studio 2010 | [root_v5.34.36.win32.vc10.zip](https://root.cern.ch/download/root_v5.34.36.win32.vc10.zip) |  63M |
-| Windows Visual Studio 2012 (dbg) | [root_v5.34.36.win32.vc11.debug.exe](https://root.cern.ch/download/root_v5.34.36.win32.vc11.debug.exe) |  98M |
-| Windows Visual Studio 2012 (dbg) | [root_v5.34.36.win32.vc11.debug.zip](https://root.cern.ch/download/root_v5.34.36.win32.vc11.debug.zip) | 151M |
-| Windows Visual Studio 2012 | [root_v5.34.36.win32.vc11.exe](https://root.cern.ch/download/root_v5.34.36.win32.vc11.exe) |  47M |
-| Windows Visual Studio 2012 | [root_v5.34.36.win32.vc11.zip](https://root.cern.ch/download/root_v5.34.36.win32.vc11.zip) |  64M |
-| Windows Visual Studio 2013 (dbg) | [root_v5.34.36.win32.vc12.debug.exe](https://root.cern.ch/download/root_v5.34.36.win32.vc12.debug.exe) |  99M |
-| Windows Visual Studio 2013 (dbg) | [root_v5.34.36.win32.vc12.debug.zip](https://root.cern.ch/download/root_v5.34.36.win32.vc12.debug.zip) | 152M |
-| Windows Visual Studio 2013 | [root_v5.34.36.win32.vc12.exe](https://root.cern.ch/download/root_v5.34.36.win32.vc12.exe) |  47M |
-| Windows Visual Studio 2013 | [root_v5.34.36.win32.vc12.zip](https://root.cern.ch/download/root_v5.34.36.win32.vc12.zip) |  64M |
+| CentOS Cern 7 gcc4.8 | [root_v5.34.36.Linux-centos7-x86_64-gcc4.8.tar.gz](https://root.cern/download/root_v5.34.36.Linux-centos7-x86_64-gcc4.8.tar.gz) |  72M |
+| CentOS Cern 7 gcc4.9 | [root_v5.34.36.Linux-centos7-x86_64-gcc4.9.tar.gz](https://root.cern/download/root_v5.34.36.Linux-centos7-x86_64-gcc4.9.tar.gz) |  73M |
+| Linux fedora20 gcc4.8 | [root_v5.34.36.Linux-fedora20-x86_64-gcc4.8.tar.gz](https://root.cern/download/root_v5.34.36.Linux-fedora20-x86_64-gcc4.8.tar.gz) |  58M |
+| Scientific Linux Cern 6 gcc4.4 | [root_v5.34.36.Linux-slc6-x86_64-gcc4.4.tar.gz](https://root.cern/download/root_v5.34.36.Linux-slc6-x86_64-gcc4.4.tar.gz) |  70M |
+| Scientific Linux Cern 6 gcc4.7 | [root_v5.34.36.Linux-slc6-x86_64-gcc4.7.tar.gz](https://root.cern/download/root_v5.34.36.Linux-slc6-x86_64-gcc4.7.tar.gz) |  71M |
+| Scientific Linux Cern 6 gcc4.8 | [root_v5.34.36.Linux-slc6-x86_64-gcc4.8.tar.gz](https://root.cern/download/root_v5.34.36.Linux-slc6-x86_64-gcc4.8.tar.gz) |  71M |
+| Scientific Linux Cern 6 gcc4.9 | [root_v5.34.36.Linux-slc6-x86_64-gcc4.9.tar.gz](https://root.cern/download/root_v5.34.36.Linux-slc6-x86_64-gcc4.9.tar.gz) |  73M |
+| Scientific Linux Cern 6 gcc5.1 | [root_v5.34.36.Linux-slc6-x86_64-gcc5.1.tar.gz](https://root.cern/download/root_v5.34.36.Linux-slc6-x86_64-gcc5.1.tar.gz) |  73M |
+| Ubuntu 12 gcc4.6 | [root_v5.34.36.Linux-ubuntu12-x86_64-gcc4.6.tar.gz](https://root.cern/download/root_v5.34.36.Linux-ubuntu12-x86_64-gcc4.6.tar.gz) |  58M |
+| Ubuntu 14 gcc4.8 | [root_v5.34.36.Linux-ubuntu14-x86_64-gcc4.8.tar.gz](https://root.cern/download/root_v5.34.36.Linux-ubuntu14-x86_64-gcc4.8.tar.gz) |  62M |
+| OsX 10.9 clang60 | [root_v5.34.36.macosx64-10.9-clang60.dmg](https://root.cern/download/root_v5.34.36.macosx64-10.9-clang60.dmg) |  56M |
+| OsX 10.9 clang60 | [root_v5.34.36.macosx64-10.9-clang60.tar.gz](https://root.cern/download/root_v5.34.36.macosx64-10.9-clang60.tar.gz) |  56M |
+| OsX 10.10 clang70 | [root_v5.34.36.macosx64-10.10-clang70.dmg](https://root.cern/download/root_v5.34.36.macosx64-10.10-clang70.dmg) |  57M |
+| OsX 10.10 clang70 | [root_v5.34.36.macosx64-10.10-clang70.tar.gz](https://root.cern/download/root_v5.34.36.macosx64-10.10-clang70.tar.gz) |  56M |
+| OsX 10.11 clang70 | [root_v5.34.36.macosx64-10.11-clang70.dmg](https://root.cern/download/root_v5.34.36.macosx64-10.11-clang70.dmg) |  58M |
+| OsX 10.11 clang70 | [root_v5.34.36.macosx64-10.11-clang70.tar.gz](https://root.cern/download/root_v5.34.36.macosx64-10.11-clang70.tar.gz) |  58M |
+| Windows Visual Studio 2010 (dbg) | [root_v5.34.36.win32.vc10.debug.exe](https://root.cern/download/root_v5.34.36.win32.vc10.debug.exe) |  92M |
+| Windows Visual Studio 2010 (dbg) | [root_v5.34.36.win32.vc10.debug.zip](https://root.cern/download/root_v5.34.36.win32.vc10.debug.zip) | 140M |
+| Windows Visual Studio 2010 | [root_v5.34.36.win32.vc10.exe](https://root.cern/download/root_v5.34.36.win32.vc10.exe) |  46M |
+| Windows Visual Studio 2010 | [root_v5.34.36.win32.vc10.zip](https://root.cern/download/root_v5.34.36.win32.vc10.zip) |  63M |
+| Windows Visual Studio 2012 (dbg) | [root_v5.34.36.win32.vc11.debug.exe](https://root.cern/download/root_v5.34.36.win32.vc11.debug.exe) |  98M |
+| Windows Visual Studio 2012 (dbg) | [root_v5.34.36.win32.vc11.debug.zip](https://root.cern/download/root_v5.34.36.win32.vc11.debug.zip) | 151M |
+| Windows Visual Studio 2012 | [root_v5.34.36.win32.vc11.exe](https://root.cern/download/root_v5.34.36.win32.vc11.exe) |  47M |
+| Windows Visual Studio 2012 | [root_v5.34.36.win32.vc11.zip](https://root.cern/download/root_v5.34.36.win32.vc11.zip) |  64M |
+| Windows Visual Studio 2013 (dbg) | [root_v5.34.36.win32.vc12.debug.exe](https://root.cern/download/root_v5.34.36.win32.vc12.debug.exe) |  99M |
+| Windows Visual Studio 2013 (dbg) | [root_v5.34.36.win32.vc12.debug.zip](https://root.cern/download/root_v5.34.36.win32.vc12.debug.zip) | 152M |
+| Windows Visual Studio 2013 | [root_v5.34.36.win32.vc12.exe](https://root.cern/download/root_v5.34.36.win32.vc12.exe) |  47M |
+| Windows Visual Studio 2013 | [root_v5.34.36.win32.vc12.zip](https://root.cern/download/root_v5.34.36.win32.vc12.zip) |  64M |
 
 
 
@@ -107,7 +107,7 @@ Standalone installations with minimal external dependencies are available at:
 The entire ROOT source can be obtained from our public Git repository:
 
 ~~~
-git clone http://root.cern.ch/git/root.git
+git clone http://root.cern/git/root.git
 ~~~
 The release specific tag can be obtained using:
 ~~~

--- a/_releases/release-53438.md
+++ b/_releases/release-53438.md
@@ -18,24 +18,24 @@ The release notes for this release can be found [here]({{ '/install/all_releases
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v5.34.38.source.tar.gz](https://root.cern.ch/download/root_v5.34.38.source.tar.gz) |  72M |
+| source | [root_v5.34.38.source.tar.gz](https://root.cern/download/root_v5.34.38.source.tar.gz) |  72M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| Ubuntu 14 gcc4.8 | [root_v5.34.38.Linux-ubuntu14-x86_64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v5.34.38.Linux-ubuntu14-x86_64-gcc4.8.tar.gz) |  62M |
-| OsX 10.11 clang80 | [root_v5.34.38.macosx64-10.11-clang80.dmg](https://root.cern.ch/download/root_v5.34.38.macosx64-10.11-clang80.dmg) |  59M |
-| OsX 10.11 clang80 | [root_v5.34.38.macosx64-10.11-clang80.tar.gz](https://root.cern.ch/download/root_v5.34.38.macosx64-10.11-clang80.tar.gz) |  58M |
-| Windows Visual Studio 2012 (dbg) | [root_v5.34.38.win32.vc11.debug.exe](https://root.cern.ch/download/root_v5.34.38.win32.vc11.debug.exe) |  98M |
-| Windows Visual Studio 2012 (dbg) | [root_v5.34.38.win32.vc11.debug.zip](https://root.cern.ch/download/root_v5.34.38.win32.vc11.debug.zip) | 151M |
-| Windows Visual Studio 2012 | [root_v5.34.38.win32.vc11.exe](https://root.cern.ch/download/root_v5.34.38.win32.vc11.exe) |  47M |
-| Windows Visual Studio 2012 | [root_v5.34.38.win32.vc11.zip](https://root.cern.ch/download/root_v5.34.38.win32.vc11.zip) |  65M |
-| Windows Visual Studio 2013 (dbg) | [root_v5.34.38.win32.vc12.debug.exe](https://root.cern.ch/download/root_v5.34.38.win32.vc12.debug.exe) |  99M |
-| Windows Visual Studio 2013 (dbg) | [root_v5.34.38.win32.vc12.debug.zip](https://root.cern.ch/download/root_v5.34.38.win32.vc12.debug.zip) | 151M |
-| Windows Visual Studio 2013 | [root_v5.34.38.win32.vc12.exe](https://root.cern.ch/download/root_v5.34.38.win32.vc12.exe) |  47M |
-| Windows Visual Studio 2013 | [root_v5.34.38.win32.vc12.zip](https://root.cern.ch/download/root_v5.34.38.win32.vc12.zip) |  64M |
+| Ubuntu 14 gcc4.8 | [root_v5.34.38.Linux-ubuntu14-x86_64-gcc4.8.tar.gz](https://root.cern/download/root_v5.34.38.Linux-ubuntu14-x86_64-gcc4.8.tar.gz) |  62M |
+| OsX 10.11 clang80 | [root_v5.34.38.macosx64-10.11-clang80.dmg](https://root.cern/download/root_v5.34.38.macosx64-10.11-clang80.dmg) |  59M |
+| OsX 10.11 clang80 | [root_v5.34.38.macosx64-10.11-clang80.tar.gz](https://root.cern/download/root_v5.34.38.macosx64-10.11-clang80.tar.gz) |  58M |
+| Windows Visual Studio 2012 (dbg) | [root_v5.34.38.win32.vc11.debug.exe](https://root.cern/download/root_v5.34.38.win32.vc11.debug.exe) |  98M |
+| Windows Visual Studio 2012 (dbg) | [root_v5.34.38.win32.vc11.debug.zip](https://root.cern/download/root_v5.34.38.win32.vc11.debug.zip) | 151M |
+| Windows Visual Studio 2012 | [root_v5.34.38.win32.vc11.exe](https://root.cern/download/root_v5.34.38.win32.vc11.exe) |  47M |
+| Windows Visual Studio 2012 | [root_v5.34.38.win32.vc11.zip](https://root.cern/download/root_v5.34.38.win32.vc11.zip) |  65M |
+| Windows Visual Studio 2013 (dbg) | [root_v5.34.38.win32.vc12.debug.exe](https://root.cern/download/root_v5.34.38.win32.vc12.debug.exe) |  99M |
+| Windows Visual Studio 2013 (dbg) | [root_v5.34.38.win32.vc12.debug.zip](https://root.cern/download/root_v5.34.38.win32.vc12.debug.zip) | 151M |
+| Windows Visual Studio 2013 | [root_v5.34.38.win32.vc12.exe](https://root.cern/download/root_v5.34.38.win32.vc12.exe) |  47M |
+| Windows Visual Studio 2013 | [root_v5.34.38.win32.vc12.zip](https://root.cern/download/root_v5.34.38.win32.vc12.zip) |  64M |
 
 
 ## Git

--- a/_releases/release-60000.md
+++ b/_releases/release-60000.md
@@ -13,21 +13,21 @@ sidebar:
 
 ## Release Notes
 
-The release notes for this release can be found [here](https://root.cern.ch/root/html600/notes/release-notes.html)
+The release notes for this release can be found [here](https://root.cern/root/html600/notes/release-notes.html)
 
 ## Source distribution
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v6.00.00.source.tar.gz](https://root.cern.ch/download/root_v6.00.00.source.tar.gz) |  94M |
+| source | [root_v6.00.00.source.tar.gz](https://root.cern/download/root_v6.00.00.source.tar.gz) |  94M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| Scientific Linux Cern 6_amd64 gcc4.8 | [root_v6.00.00.Linux-slc6_amd64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v6.00.00.Linux-slc6_amd64-gcc4.8.tar.gz) | 105M |
-| OsX 10.9 i386 | [root_v6.00.00.macosx64-10.9-i386.tar.gz](https://root.cern.ch/download/root_v6.00.00.macosx64-10.9-i386.tar.gz) | 104M |
+| Scientific Linux Cern 6_amd64 gcc4.8 | [root_v6.00.00.Linux-slc6_amd64-gcc4.8.tar.gz](https://root.cern/download/root_v6.00.00.Linux-slc6_amd64-gcc4.8.tar.gz) | 105M |
+| OsX 10.9 i386 | [root_v6.00.00.macosx64-10.9-i386.tar.gz](https://root.cern/download/root_v6.00.00.macosx64-10.9-i386.tar.gz) | 104M |
 
 
 
@@ -52,7 +52,7 @@ To use ROOT directly from AFS:
 The entire ROOT source can be obtained from our public Git repository:
 
 ~~~
-git clone http://root.cern.ch/git/root.git
+git clone http://root.cern/git/root.git
 ~~~
 The release specific tag can be obtained using:
 ~~~

--- a/_releases/release-60001.md
+++ b/_releases/release-60001.md
@@ -13,22 +13,22 @@ sidebar:
 
 ## Release Notes
 
-The release notes for this release can be found [here](https://root.cern.ch/root/html600/notes/release-notes.html)
+The release notes for this release can be found [here](https://root.cern/root/html600/notes/release-notes.html)
 
 ## Source distribution
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v6.00.01.source.tar.gz](https://root.cern.ch/download/root_v6.00.01.source.tar.gz) |  93M |
+| source | [root_v6.00.01.source.tar.gz](https://root.cern/download/root_v6.00.01.source.tar.gz) |  93M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| Scientific Linux Cern 6 gcc4.8 | [root_v6.00.01.Linux-slc6-gcc4.8.tar.gz](https://root.cern.ch/download/root_v6.00.01.Linux-slc6-gcc4.8.tar.gz) | 101M |
-| Scientific Linux Cern 6_amd64 gcc4.8 | [root_v6.00.01.Linux-slc6_amd64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v6.00.01.Linux-slc6_amd64-gcc4.8.tar.gz) | 105M |
-| OsX 10.9 i386 | [root_v6.00.01.macosx64-10.9-i386.tar.gz](https://root.cern.ch/download/root_v6.00.01.macosx64-10.9-i386.tar.gz) |  97M |
+| Scientific Linux Cern 6 gcc4.8 | [root_v6.00.01.Linux-slc6-gcc4.8.tar.gz](https://root.cern/download/root_v6.00.01.Linux-slc6-gcc4.8.tar.gz) | 101M |
+| Scientific Linux Cern 6_amd64 gcc4.8 | [root_v6.00.01.Linux-slc6_amd64-gcc4.8.tar.gz](https://root.cern/download/root_v6.00.01.Linux-slc6_amd64-gcc4.8.tar.gz) | 105M |
+| OsX 10.9 i386 | [root_v6.00.01.macosx64-10.9-i386.tar.gz](https://root.cern/download/root_v6.00.01.macosx64-10.9-i386.tar.gz) |  97M |
 
 
 
@@ -53,7 +53,7 @@ To use ROOT directly from AFS:
 The entire ROOT source can be obtained from our public Git repository:
 
 ~~~
-git clone http://root.cern.ch/git/root.git
+git clone http://root.cern/git/root.git
 ~~~
 The release specific tag can be obtained using:
 ~~~

--- a/_releases/release-60002.md
+++ b/_releases/release-60002.md
@@ -13,23 +13,23 @@ sidebar:
 
 ## Release Notes
 
-The release notes for this release can be found [here](https://root.cern.ch/root/html600/notes/release-notes.html)
+The release notes for this release can be found [here](https://root.cern/root/html600/notes/release-notes.html)
 
 ## Source distribution
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v6.00.02.source.tar.gz](https://root.cern.ch/download/root_v6.00.02.source.tar.gz) |  93M |
+| source | [root_v6.00.02.source.tar.gz](https://root.cern/download/root_v6.00.02.source.tar.gz) |  93M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| Scientific Linux Cern 6 gcc4.8 | [root_v6.00.02.Linux-slc6-gcc4.8.tar.gz](https://root.cern.ch/download/root_v6.00.02.Linux-slc6-gcc4.8.tar.gz) | 101M |
-| Scientific Linux Cern 6_amd64 gcc4.8 | [root_v6.00.02.Linux-slc6_amd64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v6.00.02.Linux-slc6_amd64-gcc4.8.tar.gz) | 105M |
-| OsX 10.9 i386 | [root_v6.00.02.macosx64-10.9-i386.tar.gz](https://root.cern.ch/download/root_v6.00.02.macosx64-10.9-i386.tar.gz) |  97M |
-| win32gcc gcc 4.8 | [root_v6.00.02.win32gcc-gcc-4.8.tar.gz](https://root.cern.ch/download/root_v6.00.02.win32gcc-gcc-4.8.tar.gz) |  96M |
+| Scientific Linux Cern 6 gcc4.8 | [root_v6.00.02.Linux-slc6-gcc4.8.tar.gz](https://root.cern/download/root_v6.00.02.Linux-slc6-gcc4.8.tar.gz) | 101M |
+| Scientific Linux Cern 6_amd64 gcc4.8 | [root_v6.00.02.Linux-slc6_amd64-gcc4.8.tar.gz](https://root.cern/download/root_v6.00.02.Linux-slc6_amd64-gcc4.8.tar.gz) | 105M |
+| OsX 10.9 i386 | [root_v6.00.02.macosx64-10.9-i386.tar.gz](https://root.cern/download/root_v6.00.02.macosx64-10.9-i386.tar.gz) |  97M |
+| win32gcc gcc 4.8 | [root_v6.00.02.win32gcc-gcc-4.8.tar.gz](https://root.cern/download/root_v6.00.02.win32gcc-gcc-4.8.tar.gz) |  96M |
 
 
 
@@ -54,7 +54,7 @@ To use ROOT directly from AFS:
 The entire ROOT source can be obtained from our public Git repository:
 
 ~~~
-git clone http://root.cern.ch/git/root.git
+git clone http://root.cern/git/root.git
 ~~~
 The release specific tag can be obtained using:
 ~~~

--- a/_releases/release-60200.md
+++ b/_releases/release-60200.md
@@ -19,15 +19,15 @@ The release notes for this release can be found [here]({{ '/install/all_releases
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v6.02.00.source.tar.gz](https://root.cern.ch/download/root_v6.02.00.source.tar.gz) |  95M |
+| source | [root_v6.02.00.source.tar.gz](https://root.cern/download/root_v6.02.00.source.tar.gz) |  95M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| Scientific Linux Cern 6_amd64 gcc4.8 | [root_v6.02.00.Linux-slc6_amd64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v6.02.00.Linux-slc6_amd64-gcc4.8.tar.gz) | 140M |
-| OsX 10.9 i386 | [root_v6.02.00.macosx64-10.9-i386.tar.gz](https://root.cern.ch/download/root_v6.02.00.macosx64-10.9-i386.tar.gz) | 127M |
+| Scientific Linux Cern 6_amd64 gcc4.8 | [root_v6.02.00.Linux-slc6_amd64-gcc4.8.tar.gz](https://root.cern/download/root_v6.02.00.Linux-slc6_amd64-gcc4.8.tar.gz) | 140M |
+| OsX 10.9 i386 | [root_v6.02.00.macosx64-10.9-i386.tar.gz](https://root.cern/download/root_v6.02.00.macosx64-10.9-i386.tar.gz) | 127M |
 
 
 
@@ -53,7 +53,7 @@ To use ROOT directly from AFS:
 The entire ROOT source can be obtained from our public Git repository:
 
 ~~~
-git clone http://root.cern.ch/git/root.git
+git clone http://root.cern/git/root.git
 ~~~
 The release specific tag can be obtained using:
 ~~~

--- a/_releases/release-60201.md
+++ b/_releases/release-60201.md
@@ -13,21 +13,21 @@ sidebar:
 
 ## Release Notes
 
-The release notes for this release can be found [here](https://root.cern.ch/root-version-v6-02-00-patch-release-notes)
+The release notes for this release can be found [here](https://root.cern/root-version-v6-02-00-patch-release-notes)
 
 ## Source distribution
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v6.02.01.source.tar.gz](https://root.cern.ch/download/root_v6.02.01.source.tar.gz) |  94M |
+| source | [root_v6.02.01.source.tar.gz](https://root.cern/download/root_v6.02.01.source.tar.gz) |  94M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| Scientific Linux Cern 6_amd64 gcc4.8 | [root_v6.02.01.Linux-slc6_amd64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v6.02.01.Linux-slc6_amd64-gcc4.8.tar.gz) | 140M |
-| OsX 10.9 i386 | [root_v6.02.01.macosx64-10.9-i386.tar.gz](https://root.cern.ch/download/root_v6.02.01.macosx64-10.9-i386.tar.gz) | 127M |
+| Scientific Linux Cern 6_amd64 gcc4.8 | [root_v6.02.01.Linux-slc6_amd64-gcc4.8.tar.gz](https://root.cern/download/root_v6.02.01.Linux-slc6_amd64-gcc4.8.tar.gz) | 140M |
+| OsX 10.9 i386 | [root_v6.02.01.macosx64-10.9-i386.tar.gz](https://root.cern/download/root_v6.02.01.macosx64-10.9-i386.tar.gz) | 127M |
 
 
 
@@ -53,7 +53,7 @@ To use ROOT directly from AFS:
 The entire ROOT source can be obtained from our public Git repository:
 
 ~~~
-git clone http://root.cern.ch/git/root.git
+git clone http://root.cern/git/root.git
 ~~~
 The release specific tag can be obtained using:
 ~~~

--- a/_releases/release-60202.md
+++ b/_releases/release-60202.md
@@ -13,22 +13,22 @@ sidebar:
 
 ## Release Notes
 
-The release notes for this release can be found [here](https://root.cern.ch/root-version-v6-02-00-patch-release-notes)
+The release notes for this release can be found [here](https://root.cern/root-version-v6-02-00-patch-release-notes)
 
 ## Source distribution
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v6.02.02.source.tar.gz](https://root.cern.ch/download/root_v6.02.02.source.tar.gz) |  95M |
+| source | [root_v6.02.02.source.tar.gz](https://root.cern/download/root_v6.02.02.source.tar.gz) |  95M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| Scientific Linux Cern 6_amd64 gcc4.8 | [root_v6.02.02.Linux-slc6_amd64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v6.02.02.Linux-slc6_amd64-gcc4.8.tar.gz) | 144M |
-| OsX 10.9 i386 | [root_v6.02.02.macosx64-10.9-i386.tar.gz](https://root.cern.ch/download/root_v6.02.02.macosx64-10.9-i386.tar.gz) | 130M |
-| OsX 10.10 i386 | [root_v6.02.02.macosx64-10.10-i386.tar.gz](https://root.cern.ch/download/root_v6.02.02.macosx64-10.10-i386.tar.gz) | 130M |
+| Scientific Linux Cern 6_amd64 gcc4.8 | [root_v6.02.02.Linux-slc6_amd64-gcc4.8.tar.gz](https://root.cern/download/root_v6.02.02.Linux-slc6_amd64-gcc4.8.tar.gz) | 144M |
+| OsX 10.9 i386 | [root_v6.02.02.macosx64-10.9-i386.tar.gz](https://root.cern/download/root_v6.02.02.macosx64-10.9-i386.tar.gz) | 130M |
+| OsX 10.10 i386 | [root_v6.02.02.macosx64-10.10-i386.tar.gz](https://root.cern/download/root_v6.02.02.macosx64-10.10-i386.tar.gz) | 130M |
 
 
 
@@ -54,7 +54,7 @@ To use ROOT directly from AFS:
 The entire ROOT source can be obtained from our public Git repository:
 
 ~~~
-git clone http://root.cern.ch/git/root.git
+git clone http://root.cern/git/root.git
 ~~~
 The release specific tag can be obtained using:
 ~~~

--- a/_releases/release-60203.md
+++ b/_releases/release-60203.md
@@ -13,22 +13,22 @@ sidebar:
 
 ## Release Notes
 
-The release notes for this release can be found [here](https://root.cern.ch/root-version-v6-02-00-patch-release-notes)
+The release notes for this release can be found [here](https://root.cern/root-version-v6-02-00-patch-release-notes)
 
 ## Source distribution
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v6.02.03.source.tar.gz](https://root.cern.ch/download/root_v6.02.03.source.tar.gz) |  95M |
+| source | [root_v6.02.03.source.tar.gz](https://root.cern/download/root_v6.02.03.source.tar.gz) |  95M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| Scientific Linux Cern 6_amd64 gcc4.8 | [root_v6.02.03.Linux-slc6_amd64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v6.02.03.Linux-slc6_amd64-gcc4.8.tar.gz) | 146M |
-| OsX 10.9 i386 | [root_v6.02.03.macosx64-10.9-i386.tar.gz](https://root.cern.ch/download/root_v6.02.03.macosx64-10.9-i386.tar.gz) | 131M |
-| OsX 10.10 i386 | [root_v6.02.03.macosx64-10.10-i386.tar.gz](https://root.cern.ch/download/root_v6.02.03.macosx64-10.10-i386.tar.gz) | 132M |
+| Scientific Linux Cern 6_amd64 gcc4.8 | [root_v6.02.03.Linux-slc6_amd64-gcc4.8.tar.gz](https://root.cern/download/root_v6.02.03.Linux-slc6_amd64-gcc4.8.tar.gz) | 146M |
+| OsX 10.9 i386 | [root_v6.02.03.macosx64-10.9-i386.tar.gz](https://root.cern/download/root_v6.02.03.macosx64-10.9-i386.tar.gz) | 131M |
+| OsX 10.10 i386 | [root_v6.02.03.macosx64-10.10-i386.tar.gz](https://root.cern/download/root_v6.02.03.macosx64-10.10-i386.tar.gz) | 132M |
 
 
 
@@ -54,7 +54,7 @@ To use ROOT directly from AFS:
 The entire ROOT source can be obtained from our public Git repository:
 
 ~~~
-git clone http://root.cern.ch/git/root.git
+git clone http://root.cern/git/root.git
 ~~~
 The release specific tag can be obtained using:
 ~~~

--- a/_releases/release-60204.md
+++ b/_releases/release-60204.md
@@ -13,22 +13,22 @@ sidebar:
 
 ## Release Notes
 
-The release notes for this release can be found [here](https://root.cern.ch/root-version-v6-02-00-patch-release-notes)
+The release notes for this release can be found [here](https://root.cern/root-version-v6-02-00-patch-release-notes)
 
 ## Source distribution
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v6.02.04.source.tar.gz](https://root.cern.ch/download/root_v6.02.04.source.tar.gz) |  95M |
+| source | [root_v6.02.04.source.tar.gz](https://root.cern/download/root_v6.02.04.source.tar.gz) |  95M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| Scientific Linux Cern 6_amd64 gcc4.8 | [root_v6.02.04.Linux-slc6_amd64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v6.02.04.Linux-slc6_amd64-gcc4.8.tar.gz) | 146M |
-| OsX 10.9 i386 | [root_v6.02.04.macosx64-10.9-i386.tar.gz](https://root.cern.ch/download/root_v6.02.04.macosx64-10.9-i386.tar.gz) | 131M |
-| OsX 10.10 i386 | [root_v6.02.04.macosx64-10.10-i386.tar.gz](https://root.cern.ch/download/root_v6.02.04.macosx64-10.10-i386.tar.gz) | 132M |
+| Scientific Linux Cern 6_amd64 gcc4.8 | [root_v6.02.04.Linux-slc6_amd64-gcc4.8.tar.gz](https://root.cern/download/root_v6.02.04.Linux-slc6_amd64-gcc4.8.tar.gz) | 146M |
+| OsX 10.9 i386 | [root_v6.02.04.macosx64-10.9-i386.tar.gz](https://root.cern/download/root_v6.02.04.macosx64-10.9-i386.tar.gz) | 131M |
+| OsX 10.10 i386 | [root_v6.02.04.macosx64-10.10-i386.tar.gz](https://root.cern/download/root_v6.02.04.macosx64-10.10-i386.tar.gz) | 132M |
 
 
 
@@ -55,7 +55,7 @@ To use ROOT directly from AFS:
 The entire ROOT source can be obtained from our public Git repository:
 
 ~~~
-git clone http://root.cern.ch/git/root.git
+git clone http://root.cern/git/root.git
 ~~~
 The release specific tag can be obtained using:
 ~~~

--- a/_releases/release-60205.md
+++ b/_releases/release-60205.md
@@ -13,22 +13,22 @@ sidebar:
 
 ## Release Notes
 
-The release notes for this release can be found [here](https://root.cern.ch/root-version-v6-02-00-patch-release-notes)
+The release notes for this release can be found [here](https://root.cern/root-version-v6-02-00-patch-release-notes)
 
 ## Source distribution
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v6.02.05.source.tar.gz](https://root.cern.ch/download/root_v6.02.05.source.tar.gz) |  95M |
+| source | [root_v6.02.05.source.tar.gz](https://root.cern/download/root_v6.02.05.source.tar.gz) |  95M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| Scientific Linux Cern 6_amd64 gcc4.8 | [root_v6.02.05.Linux-slc6_amd64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v6.02.05.Linux-slc6_amd64-gcc4.8.tar.gz) | 146M |
-| OsX 10.9 i386 | [root_v6.02.05.macosx64-10.9-i386.tar.gz](https://root.cern.ch/download/root_v6.02.05.macosx64-10.9-i386.tar.gz) | 131M |
-| OsX 10.10 i386 | [root_v6.02.05.macosx64-10.10-i386.tar.gz](https://root.cern.ch/download/root_v6.02.05.macosx64-10.10-i386.tar.gz) | 132M |
+| Scientific Linux Cern 6_amd64 gcc4.8 | [root_v6.02.05.Linux-slc6_amd64-gcc4.8.tar.gz](https://root.cern/download/root_v6.02.05.Linux-slc6_amd64-gcc4.8.tar.gz) | 146M |
+| OsX 10.9 i386 | [root_v6.02.05.macosx64-10.9-i386.tar.gz](https://root.cern/download/root_v6.02.05.macosx64-10.9-i386.tar.gz) | 131M |
+| OsX 10.10 i386 | [root_v6.02.05.macosx64-10.10-i386.tar.gz](https://root.cern/download/root_v6.02.05.macosx64-10.10-i386.tar.gz) | 132M |
 
 
 
@@ -55,7 +55,7 @@ To use ROOT directly from AFS:
 The entire ROOT source can be obtained from our public Git repository:
 
 ~~~
-git clone http://root.cern.ch/git/root.git
+git clone http://root.cern/git/root.git
 ~~~
 The release specific tag can be obtained using:
 ~~~

--- a/_releases/release-60208.md
+++ b/_releases/release-60208.md
@@ -13,27 +13,27 @@ sidebar:
 
 ## Release Notes
 
-The release notes for this release can be found [here](https://root.cern.ch/root-version-v6-02-00-patch-release-notes)
+The release notes for this release can be found [here](https://root.cern/root-version-v6-02-00-patch-release-notes)
 
 ## Source distribution
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v6.02.08.source.tar.gz](https://root.cern.ch/download/root_v6.02.08.source.tar.gz) |  95M |
+| source | [root_v6.02.08.source.tar.gz](https://root.cern/download/root_v6.02.08.source.tar.gz) |  95M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| Linux fedora20 gcc4.8 | [root_v6.02.08.Linux-fedora20-x86_64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v6.02.08.Linux-fedora20-x86_64-gcc4.8.tar.gz) | 132M |
-| Scientific Linux Cern 6 gcc4.8 | [root_v6.02.08.Linux-slc6-x86_64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v6.02.08.Linux-slc6-x86_64-gcc4.8.tar.gz) | 147M |
-| Scientific Linux Cern 6 gcc4.9 | [root_v6.02.08.Linux-slc6-x86_64-gcc4.9.tar.gz](https://root.cern.ch/download/root_v6.02.08.Linux-slc6-x86_64-gcc4.9.tar.gz) | 152M |
-| Ubuntu 14 gcc4.8 | [root_v6.02.08.Linux-ubuntu14-x86_64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v6.02.08.Linux-ubuntu14-x86_64-gcc4.8.tar.gz) | 138M |
-| OsX 10.9 clang60 | [root_v6.02.08.macosx64-10.9-clang60.dmg](https://root.cern.ch/download/root_v6.02.08.macosx64-10.9-clang60.dmg) | 131M |
-| OsX 10.9 clang60 | [root_v6.02.08.macosx64-10.9-clang60.tar.gz](https://root.cern.ch/download/root_v6.02.08.macosx64-10.9-clang60.tar.gz) | 132M |
-| OsX 10.10 clang60 | [root_v6.02.08.macosx64-10.10-clang60.dmg](https://root.cern.ch/download/root_v6.02.08.macosx64-10.10-clang60.dmg) | 132M |
-| OsX 10.10 clang60 | [root_v6.02.08.macosx64-10.10-clang60.tar.gz](https://root.cern.ch/download/root_v6.02.08.macosx64-10.10-clang60.tar.gz) | 132M |
+| Linux fedora20 gcc4.8 | [root_v6.02.08.Linux-fedora20-x86_64-gcc4.8.tar.gz](https://root.cern/download/root_v6.02.08.Linux-fedora20-x86_64-gcc4.8.tar.gz) | 132M |
+| Scientific Linux Cern 6 gcc4.8 | [root_v6.02.08.Linux-slc6-x86_64-gcc4.8.tar.gz](https://root.cern/download/root_v6.02.08.Linux-slc6-x86_64-gcc4.8.tar.gz) | 147M |
+| Scientific Linux Cern 6 gcc4.9 | [root_v6.02.08.Linux-slc6-x86_64-gcc4.9.tar.gz](https://root.cern/download/root_v6.02.08.Linux-slc6-x86_64-gcc4.9.tar.gz) | 152M |
+| Ubuntu 14 gcc4.8 | [root_v6.02.08.Linux-ubuntu14-x86_64-gcc4.8.tar.gz](https://root.cern/download/root_v6.02.08.Linux-ubuntu14-x86_64-gcc4.8.tar.gz) | 138M |
+| OsX 10.9 clang60 | [root_v6.02.08.macosx64-10.9-clang60.dmg](https://root.cern/download/root_v6.02.08.macosx64-10.9-clang60.dmg) | 131M |
+| OsX 10.9 clang60 | [root_v6.02.08.macosx64-10.9-clang60.tar.gz](https://root.cern/download/root_v6.02.08.macosx64-10.9-clang60.tar.gz) | 132M |
+| OsX 10.10 clang60 | [root_v6.02.08.macosx64-10.10-clang60.dmg](https://root.cern/download/root_v6.02.08.macosx64-10.10-clang60.dmg) | 132M |
+| OsX 10.10 clang60 | [root_v6.02.08.macosx64-10.10-clang60.tar.gz](https://root.cern/download/root_v6.02.08.macosx64-10.10-clang60.tar.gz) | 132M |
 
 
 
@@ -62,7 +62,7 @@ To use ROOT directly from AFS:
 The entire ROOT source can be obtained from our public Git repository:
 
 ~~~
-git clone http://root.cern.ch/git/root.git
+git clone http://root.cern/git/root.git
 ~~~
 The release specific tag can be obtained using:
 ~~~

--- a/_releases/release-60210.md
+++ b/_releases/release-60210.md
@@ -13,33 +13,33 @@ sidebar:
 
 ## Release Note
 
-The release notes for this release can be found [here](https://root.cern.ch/root-version-v6-02-00-patch-release-notes)
+The release notes for this release can be found [here](https://root.cern/root-version-v6-02-00-patch-release-notes)
 
 ## Source distribution
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v6.02.10.source.tar.gz](https://root.cern.ch/download/root_v6.02.10.source.tar.gz) |  95M |
+| source | [root_v6.02.10.source.tar.gz](https://root.cern/download/root_v6.02.10.source.tar.gz) |  95M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| CentOS Cern 7 gcc4.8 | [root_v6.02.10.Linux-cc7-x86_64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v6.02.10.Linux-cc7-x86_64-gcc4.8.tar.gz) | 148M |
-| CentOS Cern 7 gcc4.9 | [root_v6.02.10.Linux-cc7-x86_64-gcc4.9.tar.gz](https://root.cern.ch/download/root_v6.02.10.Linux-cc7-x86_64-gcc4.9.tar.gz) | 153M |
-| Linux fedora20 gcc4.8 | [root_v6.02.10.Linux-fedora20-x86_64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v6.02.10.Linux-fedora20-x86_64-gcc4.8.tar.gz) | 132M |
-| Scientific Linux Cern 6 gcc4.8 | [root_v6.02.10.Linux-slc6-x86_64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v6.02.10.Linux-slc6-x86_64-gcc4.8.tar.gz) | 147M |
-| Scientific Linux Cern 6 gcc4.9 | [root_v6.02.10.Linux-slc6-x86_64-gcc4.9.tar.gz](https://root.cern.ch/download/root_v6.02.10.Linux-slc6-x86_64-gcc4.9.tar.gz) | 152M |
-| Ubuntu 14 gcc4.8 | [root_v6.02.10.Linux-ubuntu14-x86_64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v6.02.10.Linux-ubuntu14-x86_64-gcc4.8.tar.gz) | 138M |
-| OsX 10.8 clang51 | [root_v6.02.10.macosx64-10.8-clang51.dmg](https://root.cern.ch/download/root_v6.02.10.macosx64-10.8-clang51.dmg) | 133M |
-| OsX 10.8 clang51 | [root_v6.02.10.macosx64-10.8-clang51.tar.gz](https://root.cern.ch/download/root_v6.02.10.macosx64-10.8-clang51.tar.gz) | 133M |
-| OsX 10.9 clang60 | [root_v6.02.10.macosx64-10.9-clang60.dmg](https://root.cern.ch/download/root_v6.02.10.macosx64-10.9-clang60.dmg) | 131M |
-| OsX 10.9 clang60 | [root_v6.02.10.macosx64-10.9-clang60.tar.gz](https://root.cern.ch/download/root_v6.02.10.macosx64-10.9-clang60.tar.gz) | 132M |
-| OsX 10.10 clang61 | [root_v6.02.10.macosx64-10.10-clang61.dmg](https://root.cern.ch/download/root_v6.02.10.macosx64-10.10-clang61.dmg) | 133M |
-| OsX 10.10 clang61 | [root_v6.02.10.macosx64-10.10-clang61.tar.gz](https://root.cern.ch/download/root_v6.02.10.macosx64-10.10-clang61.tar.gz) | 133M |
-| OsX clang61 | [root_v6.02.10.macosx64-clang61.dmg](https://root.cern.ch/download/root_v6.02.10.macosx64-clang61.dmg) | 133M |
-| OsX clang61 | [root_v6.02.10.macosx64-clang61.tar.gz](https://root.cern.ch/download/root_v6.02.10.macosx64-clang61.tar.gz) | 133M |
+| CentOS Cern 7 gcc4.8 | [root_v6.02.10.Linux-cc7-x86_64-gcc4.8.tar.gz](https://root.cern/download/root_v6.02.10.Linux-cc7-x86_64-gcc4.8.tar.gz) | 148M |
+| CentOS Cern 7 gcc4.9 | [root_v6.02.10.Linux-cc7-x86_64-gcc4.9.tar.gz](https://root.cern/download/root_v6.02.10.Linux-cc7-x86_64-gcc4.9.tar.gz) | 153M |
+| Linux fedora20 gcc4.8 | [root_v6.02.10.Linux-fedora20-x86_64-gcc4.8.tar.gz](https://root.cern/download/root_v6.02.10.Linux-fedora20-x86_64-gcc4.8.tar.gz) | 132M |
+| Scientific Linux Cern 6 gcc4.8 | [root_v6.02.10.Linux-slc6-x86_64-gcc4.8.tar.gz](https://root.cern/download/root_v6.02.10.Linux-slc6-x86_64-gcc4.8.tar.gz) | 147M |
+| Scientific Linux Cern 6 gcc4.9 | [root_v6.02.10.Linux-slc6-x86_64-gcc4.9.tar.gz](https://root.cern/download/root_v6.02.10.Linux-slc6-x86_64-gcc4.9.tar.gz) | 152M |
+| Ubuntu 14 gcc4.8 | [root_v6.02.10.Linux-ubuntu14-x86_64-gcc4.8.tar.gz](https://root.cern/download/root_v6.02.10.Linux-ubuntu14-x86_64-gcc4.8.tar.gz) | 138M |
+| OsX 10.8 clang51 | [root_v6.02.10.macosx64-10.8-clang51.dmg](https://root.cern/download/root_v6.02.10.macosx64-10.8-clang51.dmg) | 133M |
+| OsX 10.8 clang51 | [root_v6.02.10.macosx64-10.8-clang51.tar.gz](https://root.cern/download/root_v6.02.10.macosx64-10.8-clang51.tar.gz) | 133M |
+| OsX 10.9 clang60 | [root_v6.02.10.macosx64-10.9-clang60.dmg](https://root.cern/download/root_v6.02.10.macosx64-10.9-clang60.dmg) | 131M |
+| OsX 10.9 clang60 | [root_v6.02.10.macosx64-10.9-clang60.tar.gz](https://root.cern/download/root_v6.02.10.macosx64-10.9-clang60.tar.gz) | 132M |
+| OsX 10.10 clang61 | [root_v6.02.10.macosx64-10.10-clang61.dmg](https://root.cern/download/root_v6.02.10.macosx64-10.10-clang61.dmg) | 133M |
+| OsX 10.10 clang61 | [root_v6.02.10.macosx64-10.10-clang61.tar.gz](https://root.cern/download/root_v6.02.10.macosx64-10.10-clang61.tar.gz) | 133M |
+| OsX clang61 | [root_v6.02.10.macosx64-clang61.dmg](https://root.cern/download/root_v6.02.10.macosx64-clang61.dmg) | 133M |
+| OsX clang61 | [root_v6.02.10.macosx64-clang61.tar.gz](https://root.cern/download/root_v6.02.10.macosx64-clang61.tar.gz) | 133M |
 
 
 
@@ -67,7 +67,7 @@ To use ROOT directly from AFS:
 The entire ROOT source can be obtained from our public Git repository:
 
 ~~~
-git clone http://root.cern.ch/git/root.git
+git clone http://root.cern/git/root.git
 ~~~
 The release specific tag can be obtained using:
 ~~~

--- a/_releases/release-60212.md
+++ b/_releases/release-60212.md
@@ -13,31 +13,31 @@ sidebar:
 
 ## Release Notes
 
-The release notes for this release can be found [here](https://root.cern.ch/root-version-v6-02-00-patch-release-notes)
+The release notes for this release can be found [here](https://root.cern/root-version-v6-02-00-patch-release-notes)
 
 ## Source distribution
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v6.02.12.source.tar.gz](https://root.cern.ch/download/root_v6.02.12.source.tar.gz) |  95M |
+| source | [root_v6.02.12.source.tar.gz](https://root.cern/download/root_v6.02.12.source.tar.gz) |  95M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| CentOS Cern 7 gcc4.8 | [root_v6.02.12.Linux-cc7-x86_64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v6.02.12.Linux-cc7-x86_64-gcc4.8.tar.gz) | 148M |
-| CentOS Cern 7 gcc4.9 | [root_v6.02.12.Linux-cc7-x86_64-gcc4.9.tar.gz](https://root.cern.ch/download/root_v6.02.12.Linux-cc7-x86_64-gcc4.9.tar.gz) | 153M |
-| Linux fedora20 gcc4.8 | [root_v6.02.12.Linux-fedora20-x86_64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v6.02.12.Linux-fedora20-x86_64-gcc4.8.tar.gz) | 133M |
-| Scientific Linux Cern 6 gcc4.8 | [root_v6.02.12.Linux-slc6-x86_64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v6.02.12.Linux-slc6-x86_64-gcc4.8.tar.gz) | 147M |
-| Scientific Linux Cern 6 gcc4.9 | [root_v6.02.12.Linux-slc6-x86_64-gcc4.9.tar.gz](https://root.cern.ch/download/root_v6.02.12.Linux-slc6-x86_64-gcc4.9.tar.gz) | 153M |
-| Ubuntu 14 gcc4.8 | [root_v6.02.12.Linux-ubuntu14-x86_64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v6.02.12.Linux-ubuntu14-x86_64-gcc4.8.tar.gz) | 133M |
-| OsX 10.8 clang51 | [root_v6.02.12.macosx64-10.8-clang51.dmg](https://root.cern.ch/download/root_v6.02.12.macosx64-10.8-clang51.dmg) | 133M |
-| OsX 10.8 clang51 | [root_v6.02.12.macosx64-10.8-clang51.tar.gz](https://root.cern.ch/download/root_v6.02.12.macosx64-10.8-clang51.tar.gz) | 133M |
-| OsX 10.9 clang60 | [root_v6.02.12.macosx64-10.9-clang60.dmg](https://root.cern.ch/download/root_v6.02.12.macosx64-10.9-clang60.dmg) | 131M |
-| OsX 10.9 clang60 | [root_v6.02.12.macosx64-10.9-clang60.tar.gz](https://root.cern.ch/download/root_v6.02.12.macosx64-10.9-clang60.tar.gz) | 132M |
-| OsX 10.10 clang61 | [root_v6.02.12.macosx64-10.10-clang61.dmg](https://root.cern.ch/download/root_v6.02.12.macosx64-10.10-clang61.dmg) | 133M |
-| OsX 10.10 clang61 | [root_v6.02.12.macosx64-10.10-clang61.tar.gz](https://root.cern.ch/download/root_v6.02.12.macosx64-10.10-clang61.tar.gz) | 133M |
+| CentOS Cern 7 gcc4.8 | [root_v6.02.12.Linux-cc7-x86_64-gcc4.8.tar.gz](https://root.cern/download/root_v6.02.12.Linux-cc7-x86_64-gcc4.8.tar.gz) | 148M |
+| CentOS Cern 7 gcc4.9 | [root_v6.02.12.Linux-cc7-x86_64-gcc4.9.tar.gz](https://root.cern/download/root_v6.02.12.Linux-cc7-x86_64-gcc4.9.tar.gz) | 153M |
+| Linux fedora20 gcc4.8 | [root_v6.02.12.Linux-fedora20-x86_64-gcc4.8.tar.gz](https://root.cern/download/root_v6.02.12.Linux-fedora20-x86_64-gcc4.8.tar.gz) | 133M |
+| Scientific Linux Cern 6 gcc4.8 | [root_v6.02.12.Linux-slc6-x86_64-gcc4.8.tar.gz](https://root.cern/download/root_v6.02.12.Linux-slc6-x86_64-gcc4.8.tar.gz) | 147M |
+| Scientific Linux Cern 6 gcc4.9 | [root_v6.02.12.Linux-slc6-x86_64-gcc4.9.tar.gz](https://root.cern/download/root_v6.02.12.Linux-slc6-x86_64-gcc4.9.tar.gz) | 153M |
+| Ubuntu 14 gcc4.8 | [root_v6.02.12.Linux-ubuntu14-x86_64-gcc4.8.tar.gz](https://root.cern/download/root_v6.02.12.Linux-ubuntu14-x86_64-gcc4.8.tar.gz) | 133M |
+| OsX 10.8 clang51 | [root_v6.02.12.macosx64-10.8-clang51.dmg](https://root.cern/download/root_v6.02.12.macosx64-10.8-clang51.dmg) | 133M |
+| OsX 10.8 clang51 | [root_v6.02.12.macosx64-10.8-clang51.tar.gz](https://root.cern/download/root_v6.02.12.macosx64-10.8-clang51.tar.gz) | 133M |
+| OsX 10.9 clang60 | [root_v6.02.12.macosx64-10.9-clang60.dmg](https://root.cern/download/root_v6.02.12.macosx64-10.9-clang60.dmg) | 131M |
+| OsX 10.9 clang60 | [root_v6.02.12.macosx64-10.9-clang60.tar.gz](https://root.cern/download/root_v6.02.12.macosx64-10.9-clang60.tar.gz) | 132M |
+| OsX 10.10 clang61 | [root_v6.02.12.macosx64-10.10-clang61.dmg](https://root.cern/download/root_v6.02.12.macosx64-10.10-clang61.dmg) | 133M |
+| OsX 10.10 clang61 | [root_v6.02.12.macosx64-10.10-clang61.tar.gz](https://root.cern/download/root_v6.02.12.macosx64-10.10-clang61.tar.gz) | 133M |
 
 
 
@@ -67,7 +67,7 @@ To use ROOT directly from AFS:
 The entire ROOT source can be obtained from our public Git repository:
 
 ~~~
-git clone http://root.cern.ch/git/root.git
+git clone http://root.cern/git/root.git
 ~~~
 The release specific tag can be obtained using:
 ~~~

--- a/_releases/release-60302.md
+++ b/_releases/release-60302.md
@@ -15,16 +15,16 @@ sidebar:
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v6.03.02.source.tar.gz](https://root.cern.ch/download/root_v6.03.02.source.tar.gz) |  95M |
+| source | [root_v6.03.02.source.tar.gz](https://root.cern/download/root_v6.03.02.source.tar.gz) |  95M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| Scientific Linux Cern 6_amd64 gcc4.8 | [root_v6.03.02.Linux-slc6_amd64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v6.03.02.Linux-slc6_amd64-gcc4.8.tar.gz) | 147M |
-| OsX 10.9 i386 | [root_v6.03.02.macosx64-10.9-i386.tar.gz](https://root.cern.ch/download/root_v6.03.02.macosx64-10.9-i386.tar.gz) | 132M |
-| OsX 10.10 i386 | [root_v6.03.02.macosx64-10.10-i386.tar.gz](https://root.cern.ch/download/root_v6.03.02.macosx64-10.10-i386.tar.gz) | 132M |
+| Scientific Linux Cern 6_amd64 gcc4.8 | [root_v6.03.02.Linux-slc6_amd64-gcc4.8.tar.gz](https://root.cern/download/root_v6.03.02.Linux-slc6_amd64-gcc4.8.tar.gz) | 147M |
+| OsX 10.9 i386 | [root_v6.03.02.macosx64-10.9-i386.tar.gz](https://root.cern/download/root_v6.03.02.macosx64-10.9-i386.tar.gz) | 132M |
+| OsX 10.10 i386 | [root_v6.03.02.macosx64-10.10-i386.tar.gz](https://root.cern/download/root_v6.03.02.macosx64-10.10-i386.tar.gz) | 132M |
 
 
 
@@ -51,7 +51,7 @@ To use ROOT directly from AFS:
 The entire ROOT source can be obtained from our public Git repository:
 
 ~~~
-git clone http://root.cern.ch/git/root.git
+git clone http://root.cern/git/root.git
 ~~~
 The release specific tag can be obtained using:
 ~~~

--- a/_releases/release-60304.md
+++ b/_releases/release-60304.md
@@ -15,24 +15,24 @@ sidebar:
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v6.03.04.source.tar.gz](https://root.cern.ch/download/root_v6.03.04.source.tar.gz) |  93M |
+| source | [root_v6.03.04.source.tar.gz](https://root.cern/download/root_v6.03.04.source.tar.gz) |  93M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| CentOS Cern 7 gcc4.8 | [root_v6.03.04.Linux-cc7-x86_64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v6.03.04.Linux-cc7-x86_64-gcc4.8.tar.gz) | 157M |
-| Linux fedora20 gcc4.8 | [root_v6.03.04.Linux-fedora20-x86_64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v6.03.04.Linux-fedora20-x86_64-gcc4.8.tar.gz) | 142M |
-| Scientific Linux Cern 6 gcc4.8 | [root_v6.03.04.Linux-slc6-x86_64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v6.03.04.Linux-slc6-x86_64-gcc4.8.tar.gz) | 156M |
-| Scientific Linux Cern 6 gcc4.9 | [root_v6.03.04.Linux-slc6-x86_64-gcc4.9.tar.gz](https://root.cern.ch/download/root_v6.03.04.Linux-slc6-x86_64-gcc4.9.tar.gz) | 162M |
-| Ubuntu 14 gcc4.8 | [root_v6.03.04.Linux-ubuntu14-x86_64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v6.03.04.Linux-ubuntu14-x86_64-gcc4.8.tar.gz) | 142M |
-| OsX 10.8 clang51 | [root_v6.03.04.macosx64-10.8-clang51.dmg](https://root.cern.ch/download/root_v6.03.04.macosx64-10.8-clang51.dmg) | 137M |
-| OsX 10.8 clang51 | [root_v6.03.04.macosx64-10.8-clang51.tar.gz](https://root.cern.ch/download/root_v6.03.04.macosx64-10.8-clang51.tar.gz) | 138M |
-| OsX 10.9 clang60 | [root_v6.03.04.macosx64-10.9-clang60.dmg](https://root.cern.ch/download/root_v6.03.04.macosx64-10.9-clang60.dmg) | 136M |
-| OsX 10.9 clang60 | [root_v6.03.04.macosx64-10.9-clang60.tar.gz](https://root.cern.ch/download/root_v6.03.04.macosx64-10.9-clang60.tar.gz) | 136M |
-| OsX 10.10 clang61 | [root_v6.03.04.macosx64-10.10-clang61.dmg](https://root.cern.ch/download/root_v6.03.04.macosx64-10.10-clang61.dmg) | 138M |
-| OsX 10.10 clang61 | [root_v6.03.04.macosx64-10.10-clang61.tar.gz](https://root.cern.ch/download/root_v6.03.04.macosx64-10.10-clang61.tar.gz) | 138M |
+| CentOS Cern 7 gcc4.8 | [root_v6.03.04.Linux-cc7-x86_64-gcc4.8.tar.gz](https://root.cern/download/root_v6.03.04.Linux-cc7-x86_64-gcc4.8.tar.gz) | 157M |
+| Linux fedora20 gcc4.8 | [root_v6.03.04.Linux-fedora20-x86_64-gcc4.8.tar.gz](https://root.cern/download/root_v6.03.04.Linux-fedora20-x86_64-gcc4.8.tar.gz) | 142M |
+| Scientific Linux Cern 6 gcc4.8 | [root_v6.03.04.Linux-slc6-x86_64-gcc4.8.tar.gz](https://root.cern/download/root_v6.03.04.Linux-slc6-x86_64-gcc4.8.tar.gz) | 156M |
+| Scientific Linux Cern 6 gcc4.9 | [root_v6.03.04.Linux-slc6-x86_64-gcc4.9.tar.gz](https://root.cern/download/root_v6.03.04.Linux-slc6-x86_64-gcc4.9.tar.gz) | 162M |
+| Ubuntu 14 gcc4.8 | [root_v6.03.04.Linux-ubuntu14-x86_64-gcc4.8.tar.gz](https://root.cern/download/root_v6.03.04.Linux-ubuntu14-x86_64-gcc4.8.tar.gz) | 142M |
+| OsX 10.8 clang51 | [root_v6.03.04.macosx64-10.8-clang51.dmg](https://root.cern/download/root_v6.03.04.macosx64-10.8-clang51.dmg) | 137M |
+| OsX 10.8 clang51 | [root_v6.03.04.macosx64-10.8-clang51.tar.gz](https://root.cern/download/root_v6.03.04.macosx64-10.8-clang51.tar.gz) | 138M |
+| OsX 10.9 clang60 | [root_v6.03.04.macosx64-10.9-clang60.dmg](https://root.cern/download/root_v6.03.04.macosx64-10.9-clang60.dmg) | 136M |
+| OsX 10.9 clang60 | [root_v6.03.04.macosx64-10.9-clang60.tar.gz](https://root.cern/download/root_v6.03.04.macosx64-10.9-clang60.tar.gz) | 136M |
+| OsX 10.10 clang61 | [root_v6.03.04.macosx64-10.10-clang61.dmg](https://root.cern/download/root_v6.03.04.macosx64-10.10-clang61.dmg) | 138M |
+| OsX 10.10 clang61 | [root_v6.03.04.macosx64-10.10-clang61.tar.gz](https://root.cern/download/root_v6.03.04.macosx64-10.10-clang61.tar.gz) | 138M |
 
 
 
@@ -66,7 +66,7 @@ To use ROOT directly from AFS:
 The entire ROOT source can be obtained from our public Git repository:
 
 ~~~
-git clone http://root.cern.ch/git/root.git
+git clone http://root.cern/git/root.git
 ~~~
 The release specific tag can be obtained using:
 ~~~

--- a/_releases/release-60400.md
+++ b/_releases/release-60400.md
@@ -22,31 +22,31 @@ The ROOT team is proud to announce the release of ROOT 6.04/00 featuring many us
 
 ## Release Notes
 
-The release notes for this release can be found [here](https://root.cern.ch/root/html604/notes/release-notes.html)
+The release notes for this release can be found [here](https://root.cern/root/html604/notes/release-notes.html)
 
 ## Source distribution
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v6.04.00.source.tar.gz](https://root.cern.ch/download/root_v6.04.00.source.tar.gz) |  95M |
+| source | [root_v6.04.00.source.tar.gz](https://root.cern/download/root_v6.04.00.source.tar.gz) |  95M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| CentOS Cern 7 gcc4.8 | [root_v6.04.00.Linux-cc7-x86_64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v6.04.00.Linux-cc7-x86_64-gcc4.8.tar.gz) | 161M |
-| CentOS Cern 7 gcc4.9 | [root_v6.04.00.Linux-cc7-x86_64-gcc4.9.tar.gz](https://root.cern.ch/download/root_v6.04.00.Linux-cc7-x86_64-gcc4.9.tar.gz) | 166M |
-| Linux fedora20 gcc4.8 | [root_v6.04.00.Linux-fedora20-x86_64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v6.04.00.Linux-fedora20-x86_64-gcc4.8.tar.gz) | 147M |
-| Scientific Linux Cern 6 gcc4.8 | [root_v6.04.00.Linux-slc6-x86_64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v6.04.00.Linux-slc6-x86_64-gcc4.8.tar.gz) | 160M |
-| Scientific Linux Cern 6 gcc4.9 | [root_v6.04.00.Linux-slc6-x86_64-gcc4.9.tar.gz](https://root.cern.ch/download/root_v6.04.00.Linux-slc6-x86_64-gcc4.9.tar.gz) | 166M |
-| Ubuntu 14 gcc4.8 | [root_v6.04.00.Linux-ubuntu14-x86_64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v6.04.00.Linux-ubuntu14-x86_64-gcc4.8.tar.gz) | 151M |
-| OsX 10.8 clang51 | [root_v6.04.00.macosx64-10.8-clang51.dmg](https://root.cern.ch/download/root_v6.04.00.macosx64-10.8-clang51.dmg) | 141M |
-| OsX 10.8 clang51 | [root_v6.04.00.macosx64-10.8-clang51.tar.gz](https://root.cern.ch/download/root_v6.04.00.macosx64-10.8-clang51.tar.gz) | 142M |
-| OsX 10.9 clang60 | [root_v6.04.00.macosx64-10.9-clang60.dmg](https://root.cern.ch/download/root_v6.04.00.macosx64-10.9-clang60.dmg) | 139M |
-| OsX 10.9 clang60 | [root_v6.04.00.macosx64-10.9-clang60.tar.gz](https://root.cern.ch/download/root_v6.04.00.macosx64-10.9-clang60.tar.gz) | 140M |
-| OsX 10.10 clang61 | [root_v6.04.00.macosx64-10.10-clang61.dmg](https://root.cern.ch/download/root_v6.04.00.macosx64-10.10-clang61.dmg) | 142M |
-| OsX 10.10 clang61 | [root_v6.04.00.macosx64-10.10-clang61.tar.gz](https://root.cern.ch/download/root_v6.04.00.macosx64-10.10-clang61.tar.gz) | 142M |
+| CentOS Cern 7 gcc4.8 | [root_v6.04.00.Linux-cc7-x86_64-gcc4.8.tar.gz](https://root.cern/download/root_v6.04.00.Linux-cc7-x86_64-gcc4.8.tar.gz) | 161M |
+| CentOS Cern 7 gcc4.9 | [root_v6.04.00.Linux-cc7-x86_64-gcc4.9.tar.gz](https://root.cern/download/root_v6.04.00.Linux-cc7-x86_64-gcc4.9.tar.gz) | 166M |
+| Linux fedora20 gcc4.8 | [root_v6.04.00.Linux-fedora20-x86_64-gcc4.8.tar.gz](https://root.cern/download/root_v6.04.00.Linux-fedora20-x86_64-gcc4.8.tar.gz) | 147M |
+| Scientific Linux Cern 6 gcc4.8 | [root_v6.04.00.Linux-slc6-x86_64-gcc4.8.tar.gz](https://root.cern/download/root_v6.04.00.Linux-slc6-x86_64-gcc4.8.tar.gz) | 160M |
+| Scientific Linux Cern 6 gcc4.9 | [root_v6.04.00.Linux-slc6-x86_64-gcc4.9.tar.gz](https://root.cern/download/root_v6.04.00.Linux-slc6-x86_64-gcc4.9.tar.gz) | 166M |
+| Ubuntu 14 gcc4.8 | [root_v6.04.00.Linux-ubuntu14-x86_64-gcc4.8.tar.gz](https://root.cern/download/root_v6.04.00.Linux-ubuntu14-x86_64-gcc4.8.tar.gz) | 151M |
+| OsX 10.8 clang51 | [root_v6.04.00.macosx64-10.8-clang51.dmg](https://root.cern/download/root_v6.04.00.macosx64-10.8-clang51.dmg) | 141M |
+| OsX 10.8 clang51 | [root_v6.04.00.macosx64-10.8-clang51.tar.gz](https://root.cern/download/root_v6.04.00.macosx64-10.8-clang51.tar.gz) | 142M |
+| OsX 10.9 clang60 | [root_v6.04.00.macosx64-10.9-clang60.dmg](https://root.cern/download/root_v6.04.00.macosx64-10.9-clang60.dmg) | 139M |
+| OsX 10.9 clang60 | [root_v6.04.00.macosx64-10.9-clang60.tar.gz](https://root.cern/download/root_v6.04.00.macosx64-10.9-clang60.tar.gz) | 140M |
+| OsX 10.10 clang61 | [root_v6.04.00.macosx64-10.10-clang61.dmg](https://root.cern/download/root_v6.04.00.macosx64-10.10-clang61.dmg) | 142M |
+| OsX 10.10 clang61 | [root_v6.04.00.macosx64-10.10-clang61.tar.gz](https://root.cern/download/root_v6.04.00.macosx64-10.10-clang61.tar.gz) | 142M |
 
 
 
@@ -76,7 +76,7 @@ To use ROOT directly from AFS:
 The entire ROOT source can be obtained from our public Git repository:
 
 ~~~
-git clone http://root.cern.ch/git/root.git
+git clone http://root.cern/git/root.git
 ~~~
 The release specific tag can be obtained using:
 ~~~

--- a/_releases/release-60402.md
+++ b/_releases/release-60402.md
@@ -13,31 +13,31 @@ sidebar:
 
 ## Release Notes
 
-The release notes for this release can be found [here](https://root.cern.ch/root/html604/notes/release-notes.html)
+The release notes for this release can be found [here](https://root.cern/root/html604/notes/release-notes.html)
 
 ## Source distribution
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v6.04.02.source.tar.gz](https://root.cern.ch/download/root_v6.04.02.source.tar.gz) |  95M |
+| source | [root_v6.04.02.source.tar.gz](https://root.cern/download/root_v6.04.02.source.tar.gz) |  95M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| CentOS Cern 7 gcc4.8 | [root_v6.04.02.Linux-cc7-x86_64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v6.04.02.Linux-cc7-x86_64-gcc4.8.tar.gz) | 161M |
-| CentOS Cern 7 gcc4.9 | [root_v6.04.02.Linux-cc7-x86_64-gcc4.9.tar.gz](https://root.cern.ch/download/root_v6.04.02.Linux-cc7-x86_64-gcc4.9.tar.gz) | 167M |
-| Linux fedora20 gcc4.8 | [root_v6.04.02.Linux-fedora20-x86_64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v6.04.02.Linux-fedora20-x86_64-gcc4.8.tar.gz) | 147M |
-| Scientific Linux Cern 6 gcc4.8 | [root_v6.04.02.Linux-slc6-x86_64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v6.04.02.Linux-slc6-x86_64-gcc4.8.tar.gz) | 160M |
-| Scientific Linux Cern 6 gcc4.9 | [root_v6.04.02.Linux-slc6-x86_64-gcc4.9.tar.gz](https://root.cern.ch/download/root_v6.04.02.Linux-slc6-x86_64-gcc4.9.tar.gz) | 167M |
-| Ubuntu 14 gcc4.8 | [root_v6.04.02.Linux-ubuntu14-x86_64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v6.04.02.Linux-ubuntu14-x86_64-gcc4.8.tar.gz) | 151M |
-| OsX 10.8 clang51 | [root_v6.04.02.macosx64-10.8-clang51.dmg](https://root.cern.ch/download/root_v6.04.02.macosx64-10.8-clang51.dmg) | 141M |
-| OsX 10.8 clang51 | [root_v6.04.02.macosx64-10.8-clang51.tar.gz](https://root.cern.ch/download/root_v6.04.02.macosx64-10.8-clang51.tar.gz) | 142M |
-| OsX 10.9 clang60 | [root_v6.04.02.macosx64-10.9-clang60.dmg](https://root.cern.ch/download/root_v6.04.02.macosx64-10.9-clang60.dmg) | 139M |
-| OsX 10.9 clang60 | [root_v6.04.02.macosx64-10.9-clang60.tar.gz](https://root.cern.ch/download/root_v6.04.02.macosx64-10.9-clang60.tar.gz) | 140M |
-| OsX 10.10 clang61 | [root_v6.04.02.macosx64-10.10-clang61.dmg](https://root.cern.ch/download/root_v6.04.02.macosx64-10.10-clang61.dmg) | 142M |
-| OsX 10.10 clang61 | [root_v6.04.02.macosx64-10.10-clang61.tar.gz](https://root.cern.ch/download/root_v6.04.02.macosx64-10.10-clang61.tar.gz) | 142M |
+| CentOS Cern 7 gcc4.8 | [root_v6.04.02.Linux-cc7-x86_64-gcc4.8.tar.gz](https://root.cern/download/root_v6.04.02.Linux-cc7-x86_64-gcc4.8.tar.gz) | 161M |
+| CentOS Cern 7 gcc4.9 | [root_v6.04.02.Linux-cc7-x86_64-gcc4.9.tar.gz](https://root.cern/download/root_v6.04.02.Linux-cc7-x86_64-gcc4.9.tar.gz) | 167M |
+| Linux fedora20 gcc4.8 | [root_v6.04.02.Linux-fedora20-x86_64-gcc4.8.tar.gz](https://root.cern/download/root_v6.04.02.Linux-fedora20-x86_64-gcc4.8.tar.gz) | 147M |
+| Scientific Linux Cern 6 gcc4.8 | [root_v6.04.02.Linux-slc6-x86_64-gcc4.8.tar.gz](https://root.cern/download/root_v6.04.02.Linux-slc6-x86_64-gcc4.8.tar.gz) | 160M |
+| Scientific Linux Cern 6 gcc4.9 | [root_v6.04.02.Linux-slc6-x86_64-gcc4.9.tar.gz](https://root.cern/download/root_v6.04.02.Linux-slc6-x86_64-gcc4.9.tar.gz) | 167M |
+| Ubuntu 14 gcc4.8 | [root_v6.04.02.Linux-ubuntu14-x86_64-gcc4.8.tar.gz](https://root.cern/download/root_v6.04.02.Linux-ubuntu14-x86_64-gcc4.8.tar.gz) | 151M |
+| OsX 10.8 clang51 | [root_v6.04.02.macosx64-10.8-clang51.dmg](https://root.cern/download/root_v6.04.02.macosx64-10.8-clang51.dmg) | 141M |
+| OsX 10.8 clang51 | [root_v6.04.02.macosx64-10.8-clang51.tar.gz](https://root.cern/download/root_v6.04.02.macosx64-10.8-clang51.tar.gz) | 142M |
+| OsX 10.9 clang60 | [root_v6.04.02.macosx64-10.9-clang60.dmg](https://root.cern/download/root_v6.04.02.macosx64-10.9-clang60.dmg) | 139M |
+| OsX 10.9 clang60 | [root_v6.04.02.macosx64-10.9-clang60.tar.gz](https://root.cern/download/root_v6.04.02.macosx64-10.9-clang60.tar.gz) | 140M |
+| OsX 10.10 clang61 | [root_v6.04.02.macosx64-10.10-clang61.dmg](https://root.cern/download/root_v6.04.02.macosx64-10.10-clang61.dmg) | 142M |
+| OsX 10.10 clang61 | [root_v6.04.02.macosx64-10.10-clang61.tar.gz](https://root.cern/download/root_v6.04.02.macosx64-10.10-clang61.tar.gz) | 142M |
 
 
 
@@ -67,7 +67,7 @@ To use ROOT directly from AFS:
 The entire ROOT source can be obtained from our public Git repository:
 
 ~~~
-git clone http://root.cern.ch/git/root.git
+git clone http://root.cern/git/root.git
 ~~~
 The release specific tag can be obtained using:
 ~~~

--- a/_releases/release-60404.md
+++ b/_releases/release-60404.md
@@ -13,30 +13,30 @@ sidebar:
 
 ## Release Notes
 
-The release notes for this release can be found [here](https://root.cern.ch/root/html604/notes/release-notes.html#release-6.0404)
+The release notes for this release can be found [here](https://root.cern/root/html604/notes/release-notes.html#release-6.0404)
 
 ## Source distribution
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v6.04.04.source.tar.gz](https://root.cern.ch/download/root_v6.04.04.source.tar.gz) |  95M |
+| source | [root_v6.04.04.source.tar.gz](https://root.cern/download/root_v6.04.04.source.tar.gz) |  95M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| CentOS Cern 7 gcc4.8 | [root_v6.04.04.Linux-cc7-x86_64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v6.04.04.Linux-cc7-x86_64-gcc4.8.tar.gz) | 163M |
-| CentOS Cern 7 gcc4.9 | [root_v6.04.04.Linux-cc7-x86_64-gcc4.9.tar.gz](https://root.cern.ch/download/root_v6.04.04.Linux-cc7-x86_64-gcc4.9.tar.gz) | 169M |
-| Scientific Linux Cern 6 gcc4.8 | [root_v6.04.04.Linux-slc6-x86_64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v6.04.04.Linux-slc6-x86_64-gcc4.8.tar.gz) | 162M |
-| Scientific Linux Cern 6 gcc4.9 | [root_v6.04.04.Linux-slc6-x86_64-gcc4.9.tar.gz](https://root.cern.ch/download/root_v6.04.04.Linux-slc6-x86_64-gcc4.9.tar.gz) | 169M |
-| Ubuntu 14 gcc4.8 | [root_v6.04.04.Linux-ubuntu14-x86_64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v6.04.04.Linux-ubuntu14-x86_64-gcc4.8.tar.gz) | 151M |
-| OsX 10.8 clang51 | [root_v6.04.04.macosx64-10.8-clang51.dmg](https://root.cern.ch/download/root_v6.04.04.macosx64-10.8-clang51.dmg) | 141M |
-| OsX 10.8 clang51 | [root_v6.04.04.macosx64-10.8-clang51.tar.gz](https://root.cern.ch/download/root_v6.04.04.macosx64-10.8-clang51.tar.gz) | 142M |
-| OsX 10.9 clang60 | [root_v6.04.04.macosx64-10.9-clang60.dmg](https://root.cern.ch/download/root_v6.04.04.macosx64-10.9-clang60.dmg) | 140M |
-| OsX 10.9 clang60 | [root_v6.04.04.macosx64-10.9-clang60.tar.gz](https://root.cern.ch/download/root_v6.04.04.macosx64-10.9-clang60.tar.gz) | 140M |
-| OsX 10.10 clang61 | [root_v6.04.04.macosx64-10.10-clang61.dmg](https://root.cern.ch/download/root_v6.04.04.macosx64-10.10-clang61.dmg) | 142M |
-| OsX 10.10 clang61 | [root_v6.04.04.macosx64-10.10-clang61.tar.gz](https://root.cern.ch/download/root_v6.04.04.macosx64-10.10-clang61.tar.gz) | 142M |
+| CentOS Cern 7 gcc4.8 | [root_v6.04.04.Linux-cc7-x86_64-gcc4.8.tar.gz](https://root.cern/download/root_v6.04.04.Linux-cc7-x86_64-gcc4.8.tar.gz) | 163M |
+| CentOS Cern 7 gcc4.9 | [root_v6.04.04.Linux-cc7-x86_64-gcc4.9.tar.gz](https://root.cern/download/root_v6.04.04.Linux-cc7-x86_64-gcc4.9.tar.gz) | 169M |
+| Scientific Linux Cern 6 gcc4.8 | [root_v6.04.04.Linux-slc6-x86_64-gcc4.8.tar.gz](https://root.cern/download/root_v6.04.04.Linux-slc6-x86_64-gcc4.8.tar.gz) | 162M |
+| Scientific Linux Cern 6 gcc4.9 | [root_v6.04.04.Linux-slc6-x86_64-gcc4.9.tar.gz](https://root.cern/download/root_v6.04.04.Linux-slc6-x86_64-gcc4.9.tar.gz) | 169M |
+| Ubuntu 14 gcc4.8 | [root_v6.04.04.Linux-ubuntu14-x86_64-gcc4.8.tar.gz](https://root.cern/download/root_v6.04.04.Linux-ubuntu14-x86_64-gcc4.8.tar.gz) | 151M |
+| OsX 10.8 clang51 | [root_v6.04.04.macosx64-10.8-clang51.dmg](https://root.cern/download/root_v6.04.04.macosx64-10.8-clang51.dmg) | 141M |
+| OsX 10.8 clang51 | [root_v6.04.04.macosx64-10.8-clang51.tar.gz](https://root.cern/download/root_v6.04.04.macosx64-10.8-clang51.tar.gz) | 142M |
+| OsX 10.9 clang60 | [root_v6.04.04.macosx64-10.9-clang60.dmg](https://root.cern/download/root_v6.04.04.macosx64-10.9-clang60.dmg) | 140M |
+| OsX 10.9 clang60 | [root_v6.04.04.macosx64-10.9-clang60.tar.gz](https://root.cern/download/root_v6.04.04.macosx64-10.9-clang60.tar.gz) | 140M |
+| OsX 10.10 clang61 | [root_v6.04.04.macosx64-10.10-clang61.dmg](https://root.cern/download/root_v6.04.04.macosx64-10.10-clang61.dmg) | 142M |
+| OsX 10.10 clang61 | [root_v6.04.04.macosx64-10.10-clang61.tar.gz](https://root.cern/download/root_v6.04.04.macosx64-10.10-clang61.tar.gz) | 142M |
 
 
 
@@ -66,7 +66,7 @@ To use ROOT directly from AFS:
 The entire ROOT source can be obtained from our public Git repository:
 
 ~~~
-git clone http://root.cern.ch/git/root.git
+git clone http://root.cern/git/root.git
 ~~~
 The release specific tag can be obtained using:
 ~~~

--- a/_releases/release-60406.md
+++ b/_releases/release-60406.md
@@ -13,31 +13,31 @@ sidebar:
 
 ## Release Notes
 
-The release notes for this release can be found [here](https://root.cern.ch/root/html604/notes/release-notes.html#release-6.0406)
+The release notes for this release can be found [here](https://root.cern/root/html604/notes/release-notes.html#release-6.0406)
 
 ## Source distribution
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v6.04.06.source.tar.gz](https://root.cern.ch/download/root_v6.04.06.source.tar.gz) |  95M |
+| source | [root_v6.04.06.source.tar.gz](https://root.cern/download/root_v6.04.06.source.tar.gz) |  95M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| CentOS Cern 7 gcc4.8 | [root_v6.04.06.Linux-cc7-x86_64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v6.04.06.Linux-cc7-x86_64-gcc4.8.tar.gz) | 163M |
-| CentOS Cern 7 gcc4.9 | [root_v6.04.06.Linux-cc7-x86_64-gcc4.9.tar.gz](https://root.cern.ch/download/root_v6.04.06.Linux-cc7-x86_64-gcc4.9.tar.gz) | 169M |
-| Linux fedora20 gcc4.8 | [root_v6.04.06.Linux-fedora20-x86_64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v6.04.06.Linux-fedora20-x86_64-gcc4.8.tar.gz) | 147M |
-| Scientific Linux Cern 6 gcc4.8 | [root_v6.04.06.Linux-slc6-x86_64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v6.04.06.Linux-slc6-x86_64-gcc4.8.tar.gz) | 162M |
-| Scientific Linux Cern 6 gcc4.9 | [root_v6.04.06.Linux-slc6-x86_64-gcc4.9.tar.gz](https://root.cern.ch/download/root_v6.04.06.Linux-slc6-x86_64-gcc4.9.tar.gz) | 169M |
-| Ubuntu 14 gcc4.8 | [root_v6.04.06.Linux-ubuntu14-x86_64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v6.04.06.Linux-ubuntu14-x86_64-gcc4.8.tar.gz) | 151M |
-| OsX 10.8 clang51 | [root_v6.04.06.macosx64-10.8-clang51.dmg](https://root.cern.ch/download/root_v6.04.06.macosx64-10.8-clang51.dmg) | 141M |
-| OsX 10.8 clang51 | [root_v6.04.06.macosx64-10.8-clang51.tar.gz](https://root.cern.ch/download/root_v6.04.06.macosx64-10.8-clang51.tar.gz) | 142M |
-| OsX 10.9 clang60 | [root_v6.04.06.macosx64-10.9-clang60.dmg](https://root.cern.ch/download/root_v6.04.06.macosx64-10.9-clang60.dmg) | 140M |
-| OsX 10.9 clang60 | [root_v6.04.06.macosx64-10.9-clang60.tar.gz](https://root.cern.ch/download/root_v6.04.06.macosx64-10.9-clang60.tar.gz) | 140M |
-| OsX 10.10 clang70 | [root_v6.04.06.macosx64-10.10-clang70.dmg](https://root.cern.ch/download/root_v6.04.06.macosx64-10.10-clang70.dmg) | 140M |
-| OsX 10.10 clang70 | [root_v6.04.06.macosx64-10.10-clang70.tar.gz](https://root.cern.ch/download/root_v6.04.06.macosx64-10.10-clang70.tar.gz) | 141M |
+| CentOS Cern 7 gcc4.8 | [root_v6.04.06.Linux-cc7-x86_64-gcc4.8.tar.gz](https://root.cern/download/root_v6.04.06.Linux-cc7-x86_64-gcc4.8.tar.gz) | 163M |
+| CentOS Cern 7 gcc4.9 | [root_v6.04.06.Linux-cc7-x86_64-gcc4.9.tar.gz](https://root.cern/download/root_v6.04.06.Linux-cc7-x86_64-gcc4.9.tar.gz) | 169M |
+| Linux fedora20 gcc4.8 | [root_v6.04.06.Linux-fedora20-x86_64-gcc4.8.tar.gz](https://root.cern/download/root_v6.04.06.Linux-fedora20-x86_64-gcc4.8.tar.gz) | 147M |
+| Scientific Linux Cern 6 gcc4.8 | [root_v6.04.06.Linux-slc6-x86_64-gcc4.8.tar.gz](https://root.cern/download/root_v6.04.06.Linux-slc6-x86_64-gcc4.8.tar.gz) | 162M |
+| Scientific Linux Cern 6 gcc4.9 | [root_v6.04.06.Linux-slc6-x86_64-gcc4.9.tar.gz](https://root.cern/download/root_v6.04.06.Linux-slc6-x86_64-gcc4.9.tar.gz) | 169M |
+| Ubuntu 14 gcc4.8 | [root_v6.04.06.Linux-ubuntu14-x86_64-gcc4.8.tar.gz](https://root.cern/download/root_v6.04.06.Linux-ubuntu14-x86_64-gcc4.8.tar.gz) | 151M |
+| OsX 10.8 clang51 | [root_v6.04.06.macosx64-10.8-clang51.dmg](https://root.cern/download/root_v6.04.06.macosx64-10.8-clang51.dmg) | 141M |
+| OsX 10.8 clang51 | [root_v6.04.06.macosx64-10.8-clang51.tar.gz](https://root.cern/download/root_v6.04.06.macosx64-10.8-clang51.tar.gz) | 142M |
+| OsX 10.9 clang60 | [root_v6.04.06.macosx64-10.9-clang60.dmg](https://root.cern/download/root_v6.04.06.macosx64-10.9-clang60.dmg) | 140M |
+| OsX 10.9 clang60 | [root_v6.04.06.macosx64-10.9-clang60.tar.gz](https://root.cern/download/root_v6.04.06.macosx64-10.9-clang60.tar.gz) | 140M |
+| OsX 10.10 clang70 | [root_v6.04.06.macosx64-10.10-clang70.dmg](https://root.cern/download/root_v6.04.06.macosx64-10.10-clang70.dmg) | 140M |
+| OsX 10.10 clang70 | [root_v6.04.06.macosx64-10.10-clang70.tar.gz](https://root.cern/download/root_v6.04.06.macosx64-10.10-clang70.tar.gz) | 141M |
 
 
 
@@ -67,7 +67,7 @@ To use ROOT directly from AFS:
 The entire ROOT source can be obtained from our public Git repository:
 
 ~~~
-git clone http://root.cern.ch/git/root.git
+git clone http://root.cern/git/root.git
 ~~~
 The release specific tag can be obtained using:
 ~~~

--- a/_releases/release-60408.md
+++ b/_releases/release-60408.md
@@ -13,37 +13,37 @@ sidebar:
 
 ## Highlights
 
-- A number of fixes with respect 6.04/06 (see the full list of fixes in the [release notes](https://root.cern.ch/root/html604/notes/release-notes.html#release-6.0408)).
+- A number of fixes with respect 6.04/06 (see the full list of fixes in the [release notes](https://root.cern/root/html604/notes/release-notes.html#release-6.0408)).
 - Better support for Mac OS X 10.11 (El Capitan). Note that the binaries for Mac OS X 10.11 has been produced and can also be downloaded from this page, but the built in Davix module has been disabled because the required OpenSSL has been removed in this OS X version. We will put it back once this issue is solved.
 
 ## Release Notes
 
-The release notes for this release can be found [here](https://root.cern.ch/root/html604/notes/release-notes.html#release-6.0408)
+The release notes for this release can be found [here](https://root.cern/root/html604/notes/release-notes.html#release-6.0408)
 
 ## Source distribution
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v6.04.08.source.tar.gz](https://root.cern.ch/download/root_v6.04.08.source.tar.gz) |  95M |
+| source | [root_v6.04.08.source.tar.gz](https://root.cern/download/root_v6.04.08.source.tar.gz) |  95M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| CentOS Cern 7 gcc4.8 | [root_v6.04.08.Linux-cc7-x86_64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v6.04.08.Linux-cc7-x86_64-gcc4.8.tar.gz) | 160M |
-| CentOS Cern 7 gcc4.9 | [root_v6.04.08.Linux-cc7-x86_64-gcc4.9.tar.gz](https://root.cern.ch/download/root_v6.04.08.Linux-cc7-x86_64-gcc4.9.tar.gz) | 167M |
-| Linux fedora20 gcc4.8 | [root_v6.04.08.Linux-fedora20-x86_64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v6.04.08.Linux-fedora20-x86_64-gcc4.8.tar.gz) | 144M |
-| Linux fedora21 gcc4.9 | [root_v6.04.08.Linux-fedora21-x86_64-gcc4.9.tar.gz](https://root.cern.ch/download/root_v6.04.08.Linux-fedora21-x86_64-gcc4.9.tar.gz) | 149M |
-| Scientific Linux Cern 6 gcc4.8 | [root_v6.04.08.Linux-slc6-x86_64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v6.04.08.Linux-slc6-x86_64-gcc4.8.tar.gz) | 159M |
-| Scientific Linux Cern 6 gcc4.9 | [root_v6.04.08.Linux-slc6-x86_64-gcc4.9.tar.gz](https://root.cern.ch/download/root_v6.04.08.Linux-slc6-x86_64-gcc4.9.tar.gz) | 167M |
-| Ubuntu 14 gcc4.8 | [root_v6.04.08.Linux-ubuntu14-x86_64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v6.04.08.Linux-ubuntu14-x86_64-gcc4.8.tar.gz) | 149M |
-| OsX 10.9 clang60 | [root_v6.04.08.macosx64-10.9-clang60.dmg](https://root.cern.ch/download/root_v6.04.08.macosx64-10.9-clang60.dmg) | 138M |
-| OsX 10.9 clang60 | [root_v6.04.08.macosx64-10.9-clang60.tar.gz](https://root.cern.ch/download/root_v6.04.08.macosx64-10.9-clang60.tar.gz) | 139M |
-| OsX 10.10 clang70 | [root_v6.04.08.macosx64-10.10-clang70.dmg](https://root.cern.ch/download/root_v6.04.08.macosx64-10.10-clang70.dmg) | 139M |
-| OsX 10.10 clang70 | [root_v6.04.08.macosx64-10.10-clang70.tar.gz](https://root.cern.ch/download/root_v6.04.08.macosx64-10.10-clang70.tar.gz) | 140M |
-| OsX 10.11 clang70 | [root_v6.04.08.macosx64-10.11-clang70.dmg](https://root.cern.ch/download/root_v6.04.08.macosx64-10.11-clang70.dmg) | 139M |
-| OsX 10.11 clang70 | [root_v6.04.08.macosx64-10.11-clang70.tar.gz](https://root.cern.ch/download/root_v6.04.08.macosx64-10.11-clang70.tar.gz) | 139M |
+| CentOS Cern 7 gcc4.8 | [root_v6.04.08.Linux-cc7-x86_64-gcc4.8.tar.gz](https://root.cern/download/root_v6.04.08.Linux-cc7-x86_64-gcc4.8.tar.gz) | 160M |
+| CentOS Cern 7 gcc4.9 | [root_v6.04.08.Linux-cc7-x86_64-gcc4.9.tar.gz](https://root.cern/download/root_v6.04.08.Linux-cc7-x86_64-gcc4.9.tar.gz) | 167M |
+| Linux fedora20 gcc4.8 | [root_v6.04.08.Linux-fedora20-x86_64-gcc4.8.tar.gz](https://root.cern/download/root_v6.04.08.Linux-fedora20-x86_64-gcc4.8.tar.gz) | 144M |
+| Linux fedora21 gcc4.9 | [root_v6.04.08.Linux-fedora21-x86_64-gcc4.9.tar.gz](https://root.cern/download/root_v6.04.08.Linux-fedora21-x86_64-gcc4.9.tar.gz) | 149M |
+| Scientific Linux Cern 6 gcc4.8 | [root_v6.04.08.Linux-slc6-x86_64-gcc4.8.tar.gz](https://root.cern/download/root_v6.04.08.Linux-slc6-x86_64-gcc4.8.tar.gz) | 159M |
+| Scientific Linux Cern 6 gcc4.9 | [root_v6.04.08.Linux-slc6-x86_64-gcc4.9.tar.gz](https://root.cern/download/root_v6.04.08.Linux-slc6-x86_64-gcc4.9.tar.gz) | 167M |
+| Ubuntu 14 gcc4.8 | [root_v6.04.08.Linux-ubuntu14-x86_64-gcc4.8.tar.gz](https://root.cern/download/root_v6.04.08.Linux-ubuntu14-x86_64-gcc4.8.tar.gz) | 149M |
+| OsX 10.9 clang60 | [root_v6.04.08.macosx64-10.9-clang60.dmg](https://root.cern/download/root_v6.04.08.macosx64-10.9-clang60.dmg) | 138M |
+| OsX 10.9 clang60 | [root_v6.04.08.macosx64-10.9-clang60.tar.gz](https://root.cern/download/root_v6.04.08.macosx64-10.9-clang60.tar.gz) | 139M |
+| OsX 10.10 clang70 | [root_v6.04.08.macosx64-10.10-clang70.dmg](https://root.cern/download/root_v6.04.08.macosx64-10.10-clang70.dmg) | 139M |
+| OsX 10.10 clang70 | [root_v6.04.08.macosx64-10.10-clang70.tar.gz](https://root.cern/download/root_v6.04.08.macosx64-10.10-clang70.tar.gz) | 140M |
+| OsX 10.11 clang70 | [root_v6.04.08.macosx64-10.11-clang70.dmg](https://root.cern/download/root_v6.04.08.macosx64-10.11-clang70.dmg) | 139M |
+| OsX 10.11 clang70 | [root_v6.04.08.macosx64-10.11-clang70.tar.gz](https://root.cern/download/root_v6.04.08.macosx64-10.11-clang70.tar.gz) | 139M |
 
 
 
@@ -73,7 +73,7 @@ To use ROOT directly from AFS:
 The entire ROOT source can be obtained from our public Git repository:
 
 ~~~
-git clone http://root.cern.ch/git/root.git
+git clone http://root.cern/git/root.git
 ~~~
 The release specific tag can be obtained using:
 ~~~

--- a/_releases/release-60410.md
+++ b/_releases/release-60410.md
@@ -13,30 +13,30 @@ sidebar:
 
 ## Release Notes
 
-The release notes for this release can be found [here](https://root.cern.ch/root/html604/notes/release-notes.html#release-6.0410)
+The release notes for this release can be found [here](https://root.cern/root/html604/notes/release-notes.html#release-6.0410)
 
 ## Source distribution
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v6.04.10.source.tar.gz](https://root.cern.ch/download/root_v6.04.10.source.tar.gz) |  96M |
+| source | [root_v6.04.10.source.tar.gz](https://root.cern/download/root_v6.04.10.source.tar.gz) |  96M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| CentOS Cern 7 gcc4.8 | [root_v6.04.10.Linux-cc7-x86_64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v6.04.10.Linux-cc7-x86_64-gcc4.8.tar.gz) | 160M |
-| CentOS Cern 7 gcc4.9 | [root_v6.04.10.Linux-cc7-x86_64-gcc4.9.tar.gz](https://root.cern.ch/download/root_v6.04.10.Linux-cc7-x86_64-gcc4.9.tar.gz) | 167M |
-| Linux fedora20 gcc4.8 | [root_v6.04.10.Linux-fedora20-x86_64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v6.04.10.Linux-fedora20-x86_64-gcc4.8.tar.gz) | 144M |
-| Linux fedora21 gcc4.9 | [root_v6.04.10.Linux-fedora21-x86_64-gcc4.9.tar.gz](https://root.cern.ch/download/root_v6.04.10.Linux-fedora21-x86_64-gcc4.9.tar.gz) | 149M |
-| Scientific Linux Cern 6 gcc4.8 | [root_v6.04.10.Linux-slc6-x86_64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v6.04.10.Linux-slc6-x86_64-gcc4.8.tar.gz) | 159M |
-| Scientific Linux Cern 6 gcc4.9 | [root_v6.04.10.Linux-slc6-x86_64-gcc4.9.tar.gz](https://root.cern.ch/download/root_v6.04.10.Linux-slc6-x86_64-gcc4.9.tar.gz) | 167M |
-| Ubuntu 14 gcc4.8 | [root_v6.04.10.Linux-ubuntu14-x86_64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v6.04.10.Linux-ubuntu14-x86_64-gcc4.8.tar.gz) | 149M |
-| OsX 10.10 clang70 | [root_v6.04.10.macosx64-10.10-clang70.dmg](https://root.cern.ch/download/root_v6.04.10.macosx64-10.10-clang70.dmg) | 139M |
-| OsX 10.10 clang70 | [root_v6.04.10.macosx64-10.10-clang70.tar.gz](https://root.cern.ch/download/root_v6.04.10.macosx64-10.10-clang70.tar.gz) | 140M |
-| OsX 10.11 clang70 | [root_v6.04.10.macosx64-10.11-clang70.dmg](https://root.cern.ch/download/root_v6.04.10.macosx64-10.11-clang70.dmg) | 139M |
-| OsX 10.11 clang70 | [root_v6.04.10.macosx64-10.11-clang70.tar.gz](https://root.cern.ch/download/root_v6.04.10.macosx64-10.11-clang70.tar.gz) | 139M |
+| CentOS Cern 7 gcc4.8 | [root_v6.04.10.Linux-cc7-x86_64-gcc4.8.tar.gz](https://root.cern/download/root_v6.04.10.Linux-cc7-x86_64-gcc4.8.tar.gz) | 160M |
+| CentOS Cern 7 gcc4.9 | [root_v6.04.10.Linux-cc7-x86_64-gcc4.9.tar.gz](https://root.cern/download/root_v6.04.10.Linux-cc7-x86_64-gcc4.9.tar.gz) | 167M |
+| Linux fedora20 gcc4.8 | [root_v6.04.10.Linux-fedora20-x86_64-gcc4.8.tar.gz](https://root.cern/download/root_v6.04.10.Linux-fedora20-x86_64-gcc4.8.tar.gz) | 144M |
+| Linux fedora21 gcc4.9 | [root_v6.04.10.Linux-fedora21-x86_64-gcc4.9.tar.gz](https://root.cern/download/root_v6.04.10.Linux-fedora21-x86_64-gcc4.9.tar.gz) | 149M |
+| Scientific Linux Cern 6 gcc4.8 | [root_v6.04.10.Linux-slc6-x86_64-gcc4.8.tar.gz](https://root.cern/download/root_v6.04.10.Linux-slc6-x86_64-gcc4.8.tar.gz) | 159M |
+| Scientific Linux Cern 6 gcc4.9 | [root_v6.04.10.Linux-slc6-x86_64-gcc4.9.tar.gz](https://root.cern/download/root_v6.04.10.Linux-slc6-x86_64-gcc4.9.tar.gz) | 167M |
+| Ubuntu 14 gcc4.8 | [root_v6.04.10.Linux-ubuntu14-x86_64-gcc4.8.tar.gz](https://root.cern/download/root_v6.04.10.Linux-ubuntu14-x86_64-gcc4.8.tar.gz) | 149M |
+| OsX 10.10 clang70 | [root_v6.04.10.macosx64-10.10-clang70.dmg](https://root.cern/download/root_v6.04.10.macosx64-10.10-clang70.dmg) | 139M |
+| OsX 10.10 clang70 | [root_v6.04.10.macosx64-10.10-clang70.tar.gz](https://root.cern/download/root_v6.04.10.macosx64-10.10-clang70.tar.gz) | 140M |
+| OsX 10.11 clang70 | [root_v6.04.10.macosx64-10.11-clang70.dmg](https://root.cern/download/root_v6.04.10.macosx64-10.11-clang70.dmg) | 139M |
+| OsX 10.11 clang70 | [root_v6.04.10.macosx64-10.11-clang70.tar.gz](https://root.cern/download/root_v6.04.10.macosx64-10.11-clang70.tar.gz) | 139M |
 
 
 
@@ -66,7 +66,7 @@ To use ROOT directly from AFS:
 The entire ROOT source can be obtained from our public Git repository:
 
 ~~~
-git clone http://root.cern.ch/git/root.git
+git clone http://root.cern/git/root.git
 ~~~
 The release specific tag can be obtained using:
 ~~~

--- a/_releases/release-60412.md
+++ b/_releases/release-60412.md
@@ -16,31 +16,31 @@ Patch release of 6.04 with some essential fixes required by ATLAS. See the relea
 
 ## Release Notes
 
-The release notes for this release can be found [here](https://root.cern.ch/doc/v604/release-notes.html#release-6.0412)
+The release notes for this release can be found [here](https://root.cern/doc/v604/release-notes.html#release-6.0412)
 
 ## Source distribution
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v6.04.12.source.tar.gz](https://root.cern.ch/download/root_v6.04.12.source.tar.gz) |  95M |
+| source | [root_v6.04.12.source.tar.gz](https://root.cern/download/root_v6.04.12.source.tar.gz) |  95M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| CentOS Cern 7 gcc4.9 | [root_v6.04.12.Linux-cc7-x86_64-gcc4.9.tar.gz](https://root.cern.ch/download/root_v6.04.12.Linux-cc7-x86_64-gcc4.9.tar.gz) | 167M |
-| Linux fedora20 gcc4.8 | [root_v6.04.12.Linux-fedora20-x86_64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v6.04.12.Linux-fedora20-x86_64-gcc4.8.tar.gz) | 144M |
-| Linux fedora21 gcc4.9 | [root_v6.04.12.Linux-fedora21-x86_64-gcc4.9.tar.gz](https://root.cern.ch/download/root_v6.04.12.Linux-fedora21-x86_64-gcc4.9.tar.gz) | 149M |
-| Scientific Linux Cern 6 gcc4.8 | [root_v6.04.12.Linux-slc6-x86_64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v6.04.12.Linux-slc6-x86_64-gcc4.8.tar.gz) | 160M |
-| Scientific Linux Cern 6 gcc4.9 | [root_v6.04.12.Linux-slc6-x86_64-gcc4.9.tar.gz](https://root.cern.ch/download/root_v6.04.12.Linux-slc6-x86_64-gcc4.9.tar.gz) | 167M |
-| Ubuntu 14 gcc4.8 | [root_v6.04.12.Linux-ubuntu14-x86_64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v6.04.12.Linux-ubuntu14-x86_64-gcc4.8.tar.gz) | 148M |
-| OsX 10.9 clang60 | [root_v6.04.12.macosx64-10.9-clang60.dmg](https://root.cern.ch/download/root_v6.04.12.macosx64-10.9-clang60.dmg) | 139M |
-| OsX 10.9 clang60 | [root_v6.04.12.macosx64-10.9-clang60.tar.gz](https://root.cern.ch/download/root_v6.04.12.macosx64-10.9-clang60.tar.gz) | 139M |
-| OsX 10.10 clang70 | [root_v6.04.12.macosx64-10.10-clang70.dmg](https://root.cern.ch/download/root_v6.04.12.macosx64-10.10-clang70.dmg) | 139M |
-| OsX 10.10 clang70 | [root_v6.04.12.macosx64-10.10-clang70.tar.gz](https://root.cern.ch/download/root_v6.04.12.macosx64-10.10-clang70.tar.gz) | 140M |
-| OsX 10.11 clang70 | [root_v6.04.12.macosx64-10.11-clang70.dmg](https://root.cern.ch/download/root_v6.04.12.macosx64-10.11-clang70.dmg) | 139M |
-| OsX 10.11 clang70 | [root_v6.04.12.macosx64-10.11-clang70.tar.gz](https://root.cern.ch/download/root_v6.04.12.macosx64-10.11-clang70.tar.gz) | 139M |
+| CentOS Cern 7 gcc4.9 | [root_v6.04.12.Linux-cc7-x86_64-gcc4.9.tar.gz](https://root.cern/download/root_v6.04.12.Linux-cc7-x86_64-gcc4.9.tar.gz) | 167M |
+| Linux fedora20 gcc4.8 | [root_v6.04.12.Linux-fedora20-x86_64-gcc4.8.tar.gz](https://root.cern/download/root_v6.04.12.Linux-fedora20-x86_64-gcc4.8.tar.gz) | 144M |
+| Linux fedora21 gcc4.9 | [root_v6.04.12.Linux-fedora21-x86_64-gcc4.9.tar.gz](https://root.cern/download/root_v6.04.12.Linux-fedora21-x86_64-gcc4.9.tar.gz) | 149M |
+| Scientific Linux Cern 6 gcc4.8 | [root_v6.04.12.Linux-slc6-x86_64-gcc4.8.tar.gz](https://root.cern/download/root_v6.04.12.Linux-slc6-x86_64-gcc4.8.tar.gz) | 160M |
+| Scientific Linux Cern 6 gcc4.9 | [root_v6.04.12.Linux-slc6-x86_64-gcc4.9.tar.gz](https://root.cern/download/root_v6.04.12.Linux-slc6-x86_64-gcc4.9.tar.gz) | 167M |
+| Ubuntu 14 gcc4.8 | [root_v6.04.12.Linux-ubuntu14-x86_64-gcc4.8.tar.gz](https://root.cern/download/root_v6.04.12.Linux-ubuntu14-x86_64-gcc4.8.tar.gz) | 148M |
+| OsX 10.9 clang60 | [root_v6.04.12.macosx64-10.9-clang60.dmg](https://root.cern/download/root_v6.04.12.macosx64-10.9-clang60.dmg) | 139M |
+| OsX 10.9 clang60 | [root_v6.04.12.macosx64-10.9-clang60.tar.gz](https://root.cern/download/root_v6.04.12.macosx64-10.9-clang60.tar.gz) | 139M |
+| OsX 10.10 clang70 | [root_v6.04.12.macosx64-10.10-clang70.dmg](https://root.cern/download/root_v6.04.12.macosx64-10.10-clang70.dmg) | 139M |
+| OsX 10.10 clang70 | [root_v6.04.12.macosx64-10.10-clang70.tar.gz](https://root.cern/download/root_v6.04.12.macosx64-10.10-clang70.tar.gz) | 140M |
+| OsX 10.11 clang70 | [root_v6.04.12.macosx64-10.11-clang70.dmg](https://root.cern/download/root_v6.04.12.macosx64-10.11-clang70.dmg) | 139M |
+| OsX 10.11 clang70 | [root_v6.04.12.macosx64-10.11-clang70.tar.gz](https://root.cern/download/root_v6.04.12.macosx64-10.11-clang70.tar.gz) | 139M |
 
 
 
@@ -69,7 +69,7 @@ To use ROOT directly from AFS:
 The entire ROOT source can be obtained from our public Git repository:
 
 ~~~
-git clone http://root.cern.ch/git/root.git
+git clone http://root.cern/git/root.git
 ~~~
 The release specific tag can be obtained using:
 ~~~

--- a/_releases/release-60414.md
+++ b/_releases/release-60414.md
@@ -13,32 +13,32 @@ sidebar:
 
 ## Release Notes
 
-The release notes for this release can be found [here](https://root.cern.ch/doc/v604/release-notes.html#release-6.0414).
+The release notes for this release can be found [here](https://root.cern/doc/v604/release-notes.html#release-6.0414).
 
 ## Source distribution
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v6.04.14.source.tar.gz](https://root.cern.ch/download/root_v6.04.14.source.tar.gz) |  96M |
+| source | [root_v6.04.14.source.tar.gz](https://root.cern/download/root_v6.04.14.source.tar.gz) |  96M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| CentOS Cern 7 gcc4.8 | [root_v6.04.14.Linux-centos7-x86_64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v6.04.14.Linux-centos7-x86_64-gcc4.8.tar.gz) | 160M |
-| CentOS Cern 7 gcc4.9 | [root_v6.04.14.Linux-centos7-x86_64-gcc4.9.tar.gz](https://root.cern.ch/download/root_v6.04.14.Linux-centos7-x86_64-gcc4.9.tar.gz) | 167M |
-| Linux fedora20 gcc4.8 | [root_v6.04.14.Linux-fedora20-x86_64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v6.04.14.Linux-fedora20-x86_64-gcc4.8.tar.gz) | 143M |
-| Linux fedora21 gcc4.9 | [root_v6.04.14.Linux-fedora21-x86_64-gcc4.9.tar.gz](https://root.cern.ch/download/root_v6.04.14.Linux-fedora21-x86_64-gcc4.9.tar.gz) | 149M |
-| Scientific Linux Cern 6 gcc4.8 | [root_v6.04.14.Linux-slc6-x86_64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v6.04.14.Linux-slc6-x86_64-gcc4.8.tar.gz) | 160M |
-| Scientific Linux Cern 6 gcc4.9 | [root_v6.04.14.Linux-slc6-x86_64-gcc4.9.tar.gz](https://root.cern.ch/download/root_v6.04.14.Linux-slc6-x86_64-gcc4.9.tar.gz) | 167M |
-| Ubuntu 14 gcc4.8 | [root_v6.04.14.Linux-ubuntu14-x86_64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v6.04.14.Linux-ubuntu14-x86_64-gcc4.8.tar.gz) | 149M |
-| OsX 10.9 clang60 | [root_v6.04.14.macosx64-10.9-clang60.dmg](https://root.cern.ch/download/root_v6.04.14.macosx64-10.9-clang60.dmg) | 139M |
-| OsX 10.9 clang60 | [root_v6.04.14.macosx64-10.9-clang60.tar.gz](https://root.cern.ch/download/root_v6.04.14.macosx64-10.9-clang60.tar.gz) | 139M |
-| OsX 10.10 clang70 | [root_v6.04.14.macosx64-10.10-clang70.dmg](https://root.cern.ch/download/root_v6.04.14.macosx64-10.10-clang70.dmg) | 139M |
-| OsX 10.10 clang70 | [root_v6.04.14.macosx64-10.10-clang70.tar.gz](https://root.cern.ch/download/root_v6.04.14.macosx64-10.10-clang70.tar.gz) | 140M |
-| OsX 10.11 clang70 | [root_v6.04.14.macosx64-10.11-clang70.dmg](https://root.cern.ch/download/root_v6.04.14.macosx64-10.11-clang70.dmg) | 141M |
-| OsX 10.11 clang70 | [root_v6.04.14.macosx64-10.11-clang70.tar.gz](https://root.cern.ch/download/root_v6.04.14.macosx64-10.11-clang70.tar.gz) | 142M |
+| CentOS Cern 7 gcc4.8 | [root_v6.04.14.Linux-centos7-x86_64-gcc4.8.tar.gz](https://root.cern/download/root_v6.04.14.Linux-centos7-x86_64-gcc4.8.tar.gz) | 160M |
+| CentOS Cern 7 gcc4.9 | [root_v6.04.14.Linux-centos7-x86_64-gcc4.9.tar.gz](https://root.cern/download/root_v6.04.14.Linux-centos7-x86_64-gcc4.9.tar.gz) | 167M |
+| Linux fedora20 gcc4.8 | [root_v6.04.14.Linux-fedora20-x86_64-gcc4.8.tar.gz](https://root.cern/download/root_v6.04.14.Linux-fedora20-x86_64-gcc4.8.tar.gz) | 143M |
+| Linux fedora21 gcc4.9 | [root_v6.04.14.Linux-fedora21-x86_64-gcc4.9.tar.gz](https://root.cern/download/root_v6.04.14.Linux-fedora21-x86_64-gcc4.9.tar.gz) | 149M |
+| Scientific Linux Cern 6 gcc4.8 | [root_v6.04.14.Linux-slc6-x86_64-gcc4.8.tar.gz](https://root.cern/download/root_v6.04.14.Linux-slc6-x86_64-gcc4.8.tar.gz) | 160M |
+| Scientific Linux Cern 6 gcc4.9 | [root_v6.04.14.Linux-slc6-x86_64-gcc4.9.tar.gz](https://root.cern/download/root_v6.04.14.Linux-slc6-x86_64-gcc4.9.tar.gz) | 167M |
+| Ubuntu 14 gcc4.8 | [root_v6.04.14.Linux-ubuntu14-x86_64-gcc4.8.tar.gz](https://root.cern/download/root_v6.04.14.Linux-ubuntu14-x86_64-gcc4.8.tar.gz) | 149M |
+| OsX 10.9 clang60 | [root_v6.04.14.macosx64-10.9-clang60.dmg](https://root.cern/download/root_v6.04.14.macosx64-10.9-clang60.dmg) | 139M |
+| OsX 10.9 clang60 | [root_v6.04.14.macosx64-10.9-clang60.tar.gz](https://root.cern/download/root_v6.04.14.macosx64-10.9-clang60.tar.gz) | 139M |
+| OsX 10.10 clang70 | [root_v6.04.14.macosx64-10.10-clang70.dmg](https://root.cern/download/root_v6.04.14.macosx64-10.10-clang70.dmg) | 139M |
+| OsX 10.10 clang70 | [root_v6.04.14.macosx64-10.10-clang70.tar.gz](https://root.cern/download/root_v6.04.14.macosx64-10.10-clang70.tar.gz) | 140M |
+| OsX 10.11 clang70 | [root_v6.04.14.macosx64-10.11-clang70.dmg](https://root.cern/download/root_v6.04.14.macosx64-10.11-clang70.dmg) | 141M |
+| OsX 10.11 clang70 | [root_v6.04.14.macosx64-10.11-clang70.tar.gz](https://root.cern/download/root_v6.04.14.macosx64-10.11-clang70.tar.gz) | 142M |
 
 
 
@@ -65,7 +65,7 @@ Standalone installations with minimal external dependencies are available at:
 The entire ROOT source can be obtained from our public Git repository:
 
 ~~~
-git clone http://root.cern.ch/git/root.git
+git clone http://root.cern/git/root.git
 ~~~
 The release specific tag can be obtained using:
 ~~~

--- a/_releases/release-60416.md
+++ b/_releases/release-60416.md
@@ -13,32 +13,32 @@ sidebar:
 
 ## Release Notes
 
-The release notes for this release can be found [here](https://root.cern.ch/doc/v604/release-notes.html#release-6.0416).
+The release notes for this release can be found [here](https://root.cern/doc/v604/release-notes.html#release-6.0416).
 
 ## Source distribution
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v6.04.16.source.tar.gz](https://root.cern.ch/download/root_v6.04.16.source.tar.gz) |  96M |
+| source | [root_v6.04.16.source.tar.gz](https://root.cern/download/root_v6.04.16.source.tar.gz) |  96M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| CentOS Cern 7 gcc4.8 | [root_v6.04.16.Linux-centos7-x86_64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v6.04.16.Linux-centos7-x86_64-gcc4.8.tar.gz) | 160M |
-| CentOS Cern 7 gcc4.9 | [root_v6.04.16.Linux-centos7-x86_64-gcc4.9.tar.gz](https://root.cern.ch/download/root_v6.04.16.Linux-centos7-x86_64-gcc4.9.tar.gz) | 167M |
-| Linux fedora20 gcc4.8 | [root_v6.04.16.Linux-fedora20-x86_64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v6.04.16.Linux-fedora20-x86_64-gcc4.8.tar.gz) | 144M |
-| Linux fedora21 gcc4.9 | [root_v6.04.16.Linux-fedora21-x86_64-gcc4.9.tar.gz](https://root.cern.ch/download/root_v6.04.16.Linux-fedora21-x86_64-gcc4.9.tar.gz) | 149M |
-| Scientific Linux Cern 6 gcc4.8 | [root_v6.04.16.Linux-slc6-x86_64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v6.04.16.Linux-slc6-x86_64-gcc4.8.tar.gz) | 160M |
-| Scientific Linux Cern 6 gcc4.9 | [root_v6.04.16.Linux-slc6-x86_64-gcc4.9.tar.gz](https://root.cern.ch/download/root_v6.04.16.Linux-slc6-x86_64-gcc4.9.tar.gz) | 167M |
-| Ubuntu 14 gcc4.8 | [root_v6.04.16.Linux-ubuntu14-x86_64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v6.04.16.Linux-ubuntu14-x86_64-gcc4.8.tar.gz) | 149M |
-| OsX 10.9 clang60 | [root_v6.04.16.macosx64-10.9-clang60.dmg](https://root.cern.ch/download/root_v6.04.16.macosx64-10.9-clang60.dmg) | 139M |
-| OsX 10.9 clang60 | [root_v6.04.16.macosx64-10.9-clang60.tar.gz](https://root.cern.ch/download/root_v6.04.16.macosx64-10.9-clang60.tar.gz) | 139M |
-| OsX 10.10 clang70 | [root_v6.04.16.macosx64-10.10-clang70.dmg](https://root.cern.ch/download/root_v6.04.16.macosx64-10.10-clang70.dmg) | 139M |
-| OsX 10.10 clang70 | [root_v6.04.16.macosx64-10.10-clang70.tar.gz](https://root.cern.ch/download/root_v6.04.16.macosx64-10.10-clang70.tar.gz) | 140M |
-| OsX 10.11 clang70 | [root_v6.04.16.macosx64-10.11-clang70.dmg](https://root.cern.ch/download/root_v6.04.16.macosx64-10.11-clang70.dmg) | 143M |
-| OsX 10.11 clang70 | [root_v6.04.16.macosx64-10.11-clang70.tar.gz](https://root.cern.ch/download/root_v6.04.16.macosx64-10.11-clang70.tar.gz) | 143M |
+| CentOS Cern 7 gcc4.8 | [root_v6.04.16.Linux-centos7-x86_64-gcc4.8.tar.gz](https://root.cern/download/root_v6.04.16.Linux-centos7-x86_64-gcc4.8.tar.gz) | 160M |
+| CentOS Cern 7 gcc4.9 | [root_v6.04.16.Linux-centos7-x86_64-gcc4.9.tar.gz](https://root.cern/download/root_v6.04.16.Linux-centos7-x86_64-gcc4.9.tar.gz) | 167M |
+| Linux fedora20 gcc4.8 | [root_v6.04.16.Linux-fedora20-x86_64-gcc4.8.tar.gz](https://root.cern/download/root_v6.04.16.Linux-fedora20-x86_64-gcc4.8.tar.gz) | 144M |
+| Linux fedora21 gcc4.9 | [root_v6.04.16.Linux-fedora21-x86_64-gcc4.9.tar.gz](https://root.cern/download/root_v6.04.16.Linux-fedora21-x86_64-gcc4.9.tar.gz) | 149M |
+| Scientific Linux Cern 6 gcc4.8 | [root_v6.04.16.Linux-slc6-x86_64-gcc4.8.tar.gz](https://root.cern/download/root_v6.04.16.Linux-slc6-x86_64-gcc4.8.tar.gz) | 160M |
+| Scientific Linux Cern 6 gcc4.9 | [root_v6.04.16.Linux-slc6-x86_64-gcc4.9.tar.gz](https://root.cern/download/root_v6.04.16.Linux-slc6-x86_64-gcc4.9.tar.gz) | 167M |
+| Ubuntu 14 gcc4.8 | [root_v6.04.16.Linux-ubuntu14-x86_64-gcc4.8.tar.gz](https://root.cern/download/root_v6.04.16.Linux-ubuntu14-x86_64-gcc4.8.tar.gz) | 149M |
+| OsX 10.9 clang60 | [root_v6.04.16.macosx64-10.9-clang60.dmg](https://root.cern/download/root_v6.04.16.macosx64-10.9-clang60.dmg) | 139M |
+| OsX 10.9 clang60 | [root_v6.04.16.macosx64-10.9-clang60.tar.gz](https://root.cern/download/root_v6.04.16.macosx64-10.9-clang60.tar.gz) | 139M |
+| OsX 10.10 clang70 | [root_v6.04.16.macosx64-10.10-clang70.dmg](https://root.cern/download/root_v6.04.16.macosx64-10.10-clang70.dmg) | 139M |
+| OsX 10.10 clang70 | [root_v6.04.16.macosx64-10.10-clang70.tar.gz](https://root.cern/download/root_v6.04.16.macosx64-10.10-clang70.tar.gz) | 140M |
+| OsX 10.11 clang70 | [root_v6.04.16.macosx64-10.11-clang70.dmg](https://root.cern/download/root_v6.04.16.macosx64-10.11-clang70.dmg) | 143M |
+| OsX 10.11 clang70 | [root_v6.04.16.macosx64-10.11-clang70.tar.gz](https://root.cern/download/root_v6.04.16.macosx64-10.11-clang70.tar.gz) | 143M |
 
 
 
@@ -65,7 +65,7 @@ Standalone installations with minimal external dependencies are available at:
 The entire ROOT source can be obtained from our public Git repository:
 
 ~~~
-git clone http://root.cern.ch/git/root.git
+git clone http://root.cern/git/root.git
 ~~~
 The release specific tag can be obtained using:
 ~~~

--- a/_releases/release-60418.md
+++ b/_releases/release-60418.md
@@ -16,30 +16,30 @@ Bug fix release. The list of improvements and fixes are in the release notes.
 
 ## Release Notes
 
-The release notes for this release can be found [here](https://root.cern.ch/doc/v604/release-notes.html#release-6.0418).
+The release notes for this release can be found [here](https://root.cern/doc/v604/release-notes.html#release-6.0418).
 
 ## Source distribution
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v6.04.18.source.tar.gz](https://root.cern.ch/download/root_v6.04.18.source.tar.gz) |  95M |
+| source | [root_v6.04.18.source.tar.gz](https://root.cern/download/root_v6.04.18.source.tar.gz) |  95M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| CentOS Cern 7 gcc4.8 | [root_v6.04.18.Linux-centos7-x86_64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v6.04.18.Linux-centos7-x86_64-gcc4.8.tar.gz) | 160M |
-| CentOS Cern 7 gcc4.9 | [root_v6.04.18.Linux-centos7-x86_64-gcc4.9.tar.gz](https://root.cern.ch/download/root_v6.04.18.Linux-centos7-x86_64-gcc4.9.tar.gz) | 167M |
-| Linux fedora20 gcc4.8 | [root_v6.04.18.Linux-fedora20-x86_64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v6.04.18.Linux-fedora20-x86_64-gcc4.8.tar.gz) | 144M |
-| Linux fedora21 gcc4.9 | [root_v6.04.18.Linux-fedora21-x86_64-gcc4.9.tar.gz](https://root.cern.ch/download/root_v6.04.18.Linux-fedora21-x86_64-gcc4.9.tar.gz) | 149M |
-| Scientific Linux Cern 6 gcc4.8 | [root_v6.04.18.Linux-slc6-x86_64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v6.04.18.Linux-slc6-x86_64-gcc4.8.tar.gz) | 160M |
-| Scientific Linux Cern 6 gcc4.9 | [root_v6.04.18.Linux-slc6-x86_64-gcc4.9.tar.gz](https://root.cern.ch/download/root_v6.04.18.Linux-slc6-x86_64-gcc4.9.tar.gz) | 167M |
-| Ubuntu 14 gcc4.8 | [root_v6.04.18.Linux-ubuntu14-x86_64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v6.04.18.Linux-ubuntu14-x86_64-gcc4.8.tar.gz) | 148M |
-| OsX 10.10 clang70 | [root_v6.04.18.macosx64-10.10-clang70.dmg](https://root.cern.ch/download/root_v6.04.18.macosx64-10.10-clang70.dmg) | 139M |
-| OsX 10.10 clang70 | [root_v6.04.18.macosx64-10.10-clang70.tar.gz](https://root.cern.ch/download/root_v6.04.18.macosx64-10.10-clang70.tar.gz) | 140M |
-| OsX 10.11 clang73 | [root_v6.04.18.macosx64-10.11-clang73.dmg](https://root.cern.ch/download/root_v6.04.18.macosx64-10.11-clang73.dmg) | 145M |
-| OsX 10.11 clang73 | [root_v6.04.18.macosx64-10.11-clang73.tar.gz](https://root.cern.ch/download/root_v6.04.18.macosx64-10.11-clang73.tar.gz) | 146M |
+| CentOS Cern 7 gcc4.8 | [root_v6.04.18.Linux-centos7-x86_64-gcc4.8.tar.gz](https://root.cern/download/root_v6.04.18.Linux-centos7-x86_64-gcc4.8.tar.gz) | 160M |
+| CentOS Cern 7 gcc4.9 | [root_v6.04.18.Linux-centos7-x86_64-gcc4.9.tar.gz](https://root.cern/download/root_v6.04.18.Linux-centos7-x86_64-gcc4.9.tar.gz) | 167M |
+| Linux fedora20 gcc4.8 | [root_v6.04.18.Linux-fedora20-x86_64-gcc4.8.tar.gz](https://root.cern/download/root_v6.04.18.Linux-fedora20-x86_64-gcc4.8.tar.gz) | 144M |
+| Linux fedora21 gcc4.9 | [root_v6.04.18.Linux-fedora21-x86_64-gcc4.9.tar.gz](https://root.cern/download/root_v6.04.18.Linux-fedora21-x86_64-gcc4.9.tar.gz) | 149M |
+| Scientific Linux Cern 6 gcc4.8 | [root_v6.04.18.Linux-slc6-x86_64-gcc4.8.tar.gz](https://root.cern/download/root_v6.04.18.Linux-slc6-x86_64-gcc4.8.tar.gz) | 160M |
+| Scientific Linux Cern 6 gcc4.9 | [root_v6.04.18.Linux-slc6-x86_64-gcc4.9.tar.gz](https://root.cern/download/root_v6.04.18.Linux-slc6-x86_64-gcc4.9.tar.gz) | 167M |
+| Ubuntu 14 gcc4.8 | [root_v6.04.18.Linux-ubuntu14-x86_64-gcc4.8.tar.gz](https://root.cern/download/root_v6.04.18.Linux-ubuntu14-x86_64-gcc4.8.tar.gz) | 148M |
+| OsX 10.10 clang70 | [root_v6.04.18.macosx64-10.10-clang70.dmg](https://root.cern/download/root_v6.04.18.macosx64-10.10-clang70.dmg) | 139M |
+| OsX 10.10 clang70 | [root_v6.04.18.macosx64-10.10-clang70.tar.gz](https://root.cern/download/root_v6.04.18.macosx64-10.10-clang70.tar.gz) | 140M |
+| OsX 10.11 clang73 | [root_v6.04.18.macosx64-10.11-clang73.dmg](https://root.cern/download/root_v6.04.18.macosx64-10.11-clang73.dmg) | 145M |
+| OsX 10.11 clang73 | [root_v6.04.18.macosx64-10.11-clang73.tar.gz](https://root.cern/download/root_v6.04.18.macosx64-10.11-clang73.tar.gz) | 146M |
 
 
 
@@ -65,7 +65,7 @@ Standalone installations with minimal external dependencies are available at:
 The entire ROOT source can be obtained from our public Git repository:
 
 ~~~
-git clone http://root.cern.ch/git/root.git
+git clone http://root.cern/git/root.git
 ~~~
 The release specific tag can be obtained using:
 ~~~

--- a/_releases/release-60502.md
+++ b/_releases/release-60502.md
@@ -15,21 +15,21 @@ sidebar:
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v6.05.02.source.tar.gz](https://root.cern.ch/download/root_v6.05.02.source.tar.gz) |  96M |
+| source | [root_v6.05.02.source.tar.gz](https://root.cern/download/root_v6.05.02.source.tar.gz) |  96M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| CentOS Cern 7 gcc4.8 | [root_v6.05.02.Linux-cc7-x86_64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v6.05.02.Linux-cc7-x86_64-gcc4.8.tar.gz) | 164M |
-| CentOS Cern 7 gcc4.9 | [root_v6.05.02.Linux-cc7-x86_64-gcc4.9.tar.gz](https://root.cern.ch/download/root_v6.05.02.Linux-cc7-x86_64-gcc4.9.tar.gz) | 170M |
-| Linux fedora20 gcc4.8 | [root_v6.05.02.Linux-fedora20-x86_64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v6.05.02.Linux-fedora20-x86_64-gcc4.8.tar.gz) | 147M |
-| Scientific Linux Cern 6 gcc4.8 | [root_v6.05.02.Linux-slc6-x86_64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v6.05.02.Linux-slc6-x86_64-gcc4.8.tar.gz) | 163M |
-| Scientific Linux Cern 6 gcc4.9 | [root_v6.05.02.Linux-slc6-x86_64-gcc4.9.tar.gz](https://root.cern.ch/download/root_v6.05.02.Linux-slc6-x86_64-gcc4.9.tar.gz) | 170M |
-| Ubuntu 14 gcc4.8 | [root_v6.05.02.Linux-ubuntu14-x86_64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v6.05.02.Linux-ubuntu14-x86_64-gcc4.8.tar.gz) | 153M |
-| OsX 10.10 clang61 | [root_v6.05.02.macosx64-10.10-clang61.dmg](https://root.cern.ch/download/root_v6.05.02.macosx64-10.10-clang61.dmg) | 143M |
-| OsX 10.10 clang61 | [root_v6.05.02.macosx64-10.10-clang61.tar.gz](https://root.cern.ch/download/root_v6.05.02.macosx64-10.10-clang61.tar.gz) | 143M |
+| CentOS Cern 7 gcc4.8 | [root_v6.05.02.Linux-cc7-x86_64-gcc4.8.tar.gz](https://root.cern/download/root_v6.05.02.Linux-cc7-x86_64-gcc4.8.tar.gz) | 164M |
+| CentOS Cern 7 gcc4.9 | [root_v6.05.02.Linux-cc7-x86_64-gcc4.9.tar.gz](https://root.cern/download/root_v6.05.02.Linux-cc7-x86_64-gcc4.9.tar.gz) | 170M |
+| Linux fedora20 gcc4.8 | [root_v6.05.02.Linux-fedora20-x86_64-gcc4.8.tar.gz](https://root.cern/download/root_v6.05.02.Linux-fedora20-x86_64-gcc4.8.tar.gz) | 147M |
+| Scientific Linux Cern 6 gcc4.8 | [root_v6.05.02.Linux-slc6-x86_64-gcc4.8.tar.gz](https://root.cern/download/root_v6.05.02.Linux-slc6-x86_64-gcc4.8.tar.gz) | 163M |
+| Scientific Linux Cern 6 gcc4.9 | [root_v6.05.02.Linux-slc6-x86_64-gcc4.9.tar.gz](https://root.cern/download/root_v6.05.02.Linux-slc6-x86_64-gcc4.9.tar.gz) | 170M |
+| Ubuntu 14 gcc4.8 | [root_v6.05.02.Linux-ubuntu14-x86_64-gcc4.8.tar.gz](https://root.cern/download/root_v6.05.02.Linux-ubuntu14-x86_64-gcc4.8.tar.gz) | 153M |
+| OsX 10.10 clang61 | [root_v6.05.02.macosx64-10.10-clang61.dmg](https://root.cern/download/root_v6.05.02.macosx64-10.10-clang61.dmg) | 143M |
+| OsX 10.10 clang61 | [root_v6.05.02.macosx64-10.10-clang61.tar.gz](https://root.cern/download/root_v6.05.02.macosx64-10.10-clang61.tar.gz) | 143M |
 
 
 
@@ -59,7 +59,7 @@ To use ROOT directly from AFS:
 The entire ROOT source can be obtained from our public Git repository:
 
 ~~~
-git clone http://root.cern.ch/git/root.git
+git clone http://root.cern/git/root.git
 ~~~
 The release specific tag can be obtained using:
 ~~~

--- a/_releases/release-60600.md
+++ b/_releases/release-60600.md
@@ -18,40 +18,40 @@ Some of the highlights of this release include:
  -  a much more usable new default graphics palette,
  -  a lightweight multi-processing interface to accelerate your analyses
  -  [ROOT
-notebooks](https://root.cern.ch/notebooks/HowTos/HowTo_ROOT-Notebooks.html), a fantastic new way of tutoring and doing interactive
+notebooks](https://root.cern/notebooks/HowTos/HowTo_ROOT-Notebooks.html), a fantastic new way of tutoring and doing interactive
 analysis.
- - most of the [class documentation](https://root.cern.ch/doc/master/) has been
+ - most of the [class documentation](https://root.cern/doc/master/) has been
 migrated to Doxygen.
 
 ## Release Notes
 
-The release notes for this release can be found [here](https://root.cern.ch/doc/v606/release-notes.html).
+The release notes for this release can be found [here](https://root.cern/doc/v606/release-notes.html).
 
 ## Source distribution
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v6.06.00.source.tar.gz](https://root.cern.ch/download/root_v6.06.00.source.tar.gz) | 103M |
+| source | [root_v6.06.00.source.tar.gz](https://root.cern/download/root_v6.06.00.source.tar.gz) | 103M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| CentOS Cern 7 gcc4.8 | [root_v6.06.00.Linux-centos7-x86_64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v6.06.00.Linux-centos7-x86_64-gcc4.8.tar.gz) | 161M |
-| CentOS Cern 7 gcc4.9 | [root_v6.06.00.Linux-centos7-x86_64-gcc4.9.tar.gz](https://root.cern.ch/download/root_v6.06.00.Linux-centos7-x86_64-gcc4.9.tar.gz) | 168M |
-| Linux fedora20 gcc4.8 | [root_v6.06.00.Linux-fedora20-x86_64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v6.06.00.Linux-fedora20-x86_64-gcc4.8.tar.gz) | 145M |
-| Linux fedora21 gcc4.9 | [root_v6.06.00.Linux-fedora21-x86_64-gcc4.9.tar.gz](https://root.cern.ch/download/root_v6.06.00.Linux-fedora21-x86_64-gcc4.9.tar.gz) | 151M |
-| Linux fedora22 gcc5.1 | [root_v6.06.00.Linux-fedora22-x86_64-gcc5.1.tar.gz](https://root.cern.ch/download/root_v6.06.00.Linux-fedora22-x86_64-gcc5.1.tar.gz) | 150M |
-| Scientific Linux Cern 6 gcc4.8 | [root_v6.06.00.Linux-slc6-x86_64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v6.06.00.Linux-slc6-x86_64-gcc4.8.tar.gz) | 160M |
-| Scientific Linux Cern 6 gcc4.9 | [root_v6.06.00.Linux-slc6-x86_64-gcc4.9.tar.gz](https://root.cern.ch/download/root_v6.06.00.Linux-slc6-x86_64-gcc4.9.tar.gz) | 167M |
-| Ubuntu 14 gcc4.8 | [root_v6.06.00.Linux-ubuntu14-x86_64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v6.06.00.Linux-ubuntu14-x86_64-gcc4.8.tar.gz) | 150M |
-| OsX 10.9 clang60 | [root_v6.06.00.macosx64-10.9-clang60.dmg](https://root.cern.ch/download/root_v6.06.00.macosx64-10.9-clang60.dmg) | 139M |
-| OsX 10.9 clang60 | [root_v6.06.00.macosx64-10.9-clang60.tar.gz](https://root.cern.ch/download/root_v6.06.00.macosx64-10.9-clang60.tar.gz) | 140M |
-| OsX 10.10 clang70 | [root_v6.06.00.macosx64-10.10-clang70.dmg](https://root.cern.ch/download/root_v6.06.00.macosx64-10.10-clang70.dmg) | 140M |
-| OsX 10.10 clang70 | [root_v6.06.00.macosx64-10.10-clang70.tar.gz](https://root.cern.ch/download/root_v6.06.00.macosx64-10.10-clang70.tar.gz) | 140M |
-| OsX 10.11 clang70 | [root_v6.06.00.macosx64-10.11-clang70.dmg](https://root.cern.ch/download/root_v6.06.00.macosx64-10.11-clang70.dmg) | 142M |
-| OsX 10.11 clang70 | [root_v6.06.00.macosx64-10.11-clang70.tar.gz](https://root.cern.ch/download/root_v6.06.00.macosx64-10.11-clang70.tar.gz) | 143M |
+| CentOS Cern 7 gcc4.8 | [root_v6.06.00.Linux-centos7-x86_64-gcc4.8.tar.gz](https://root.cern/download/root_v6.06.00.Linux-centos7-x86_64-gcc4.8.tar.gz) | 161M |
+| CentOS Cern 7 gcc4.9 | [root_v6.06.00.Linux-centos7-x86_64-gcc4.9.tar.gz](https://root.cern/download/root_v6.06.00.Linux-centos7-x86_64-gcc4.9.tar.gz) | 168M |
+| Linux fedora20 gcc4.8 | [root_v6.06.00.Linux-fedora20-x86_64-gcc4.8.tar.gz](https://root.cern/download/root_v6.06.00.Linux-fedora20-x86_64-gcc4.8.tar.gz) | 145M |
+| Linux fedora21 gcc4.9 | [root_v6.06.00.Linux-fedora21-x86_64-gcc4.9.tar.gz](https://root.cern/download/root_v6.06.00.Linux-fedora21-x86_64-gcc4.9.tar.gz) | 151M |
+| Linux fedora22 gcc5.1 | [root_v6.06.00.Linux-fedora22-x86_64-gcc5.1.tar.gz](https://root.cern/download/root_v6.06.00.Linux-fedora22-x86_64-gcc5.1.tar.gz) | 150M |
+| Scientific Linux Cern 6 gcc4.8 | [root_v6.06.00.Linux-slc6-x86_64-gcc4.8.tar.gz](https://root.cern/download/root_v6.06.00.Linux-slc6-x86_64-gcc4.8.tar.gz) | 160M |
+| Scientific Linux Cern 6 gcc4.9 | [root_v6.06.00.Linux-slc6-x86_64-gcc4.9.tar.gz](https://root.cern/download/root_v6.06.00.Linux-slc6-x86_64-gcc4.9.tar.gz) | 167M |
+| Ubuntu 14 gcc4.8 | [root_v6.06.00.Linux-ubuntu14-x86_64-gcc4.8.tar.gz](https://root.cern/download/root_v6.06.00.Linux-ubuntu14-x86_64-gcc4.8.tar.gz) | 150M |
+| OsX 10.9 clang60 | [root_v6.06.00.macosx64-10.9-clang60.dmg](https://root.cern/download/root_v6.06.00.macosx64-10.9-clang60.dmg) | 139M |
+| OsX 10.9 clang60 | [root_v6.06.00.macosx64-10.9-clang60.tar.gz](https://root.cern/download/root_v6.06.00.macosx64-10.9-clang60.tar.gz) | 140M |
+| OsX 10.10 clang70 | [root_v6.06.00.macosx64-10.10-clang70.dmg](https://root.cern/download/root_v6.06.00.macosx64-10.10-clang70.dmg) | 140M |
+| OsX 10.10 clang70 | [root_v6.06.00.macosx64-10.10-clang70.tar.gz](https://root.cern/download/root_v6.06.00.macosx64-10.10-clang70.tar.gz) | 140M |
+| OsX 10.11 clang70 | [root_v6.06.00.macosx64-10.11-clang70.dmg](https://root.cern/download/root_v6.06.00.macosx64-10.11-clang70.dmg) | 142M |
+| OsX 10.11 clang70 | [root_v6.06.00.macosx64-10.11-clang70.tar.gz](https://root.cern/download/root_v6.06.00.macosx64-10.11-clang70.tar.gz) | 143M |
 
 
 
@@ -81,7 +81,7 @@ To use ROOT directly from AFS:
 The entire ROOT source can be obtained from our public Git repository:
 
 ~~~
-git clone http://root.cern.ch/git/root.git
+git clone http://root.cern/git/root.git
 ~~~
 The release specific tag can be obtained using:
 ~~~

--- a/_releases/release-60602.md
+++ b/_releases/release-60602.md
@@ -17,33 +17,33 @@ Patch version on top of 6.06/00 with a number of fixes. See release notes for de
 
 ## Release Notes
 
-The release notes for this release can be found [here](https://root.cern.ch/doc/v606/release-notes.html#release-6.0602).
+The release notes for this release can be found [here](https://root.cern/doc/v606/release-notes.html#release-6.0602).
 
 ## Source distribution
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v6.06.02.source.tar.gz](https://root.cern.ch/download/root_v6.06.02.source.tar.gz) | 103M |
+| source | [root_v6.06.02.source.tar.gz](https://root.cern/download/root_v6.06.02.source.tar.gz) | 103M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| CentOS Cern 7 gcc4.8 | [root_v6.06.02.Linux-centos7-x86_64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v6.06.02.Linux-centos7-x86_64-gcc4.8.tar.gz) | 162M |
-| CentOS Cern 7 gcc4.9 | [root_v6.06.02.Linux-centos7-x86_64-gcc4.9.tar.gz](https://root.cern.ch/download/root_v6.06.02.Linux-centos7-x86_64-gcc4.9.tar.gz) | 168M |
-| Linux fedora20 gcc4.8 | [root_v6.06.02.Linux-fedora20-x86_64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v6.06.02.Linux-fedora20-x86_64-gcc4.8.tar.gz) | 145M |
-| Linux fedora21 gcc4.9 | [root_v6.06.02.Linux-fedora21-x86_64-gcc4.9.tar.gz](https://root.cern.ch/download/root_v6.06.02.Linux-fedora21-x86_64-gcc4.9.tar.gz) | 151M |
-| Linux fedora22 gcc5.1 | [root_v6.06.02.Linux-fedora22-x86_64-gcc5.1.tar.gz](https://root.cern.ch/download/root_v6.06.02.Linux-fedora22-x86_64-gcc5.1.tar.gz) | 151M |
-| Scientific Linux Cern 6 gcc4.8 | [root_v6.06.02.Linux-slc6-x86_64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v6.06.02.Linux-slc6-x86_64-gcc4.8.tar.gz) | 161M |
-| Scientific Linux Cern 6 gcc4.9 | [root_v6.06.02.Linux-slc6-x86_64-gcc4.9.tar.gz](https://root.cern.ch/download/root_v6.06.02.Linux-slc6-x86_64-gcc4.9.tar.gz) | 168M |
-| Ubuntu 14 gcc4.8 | [root_v6.06.02.Linux-ubuntu14-x86_64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v6.06.02.Linux-ubuntu14-x86_64-gcc4.8.tar.gz) | 146M |
-| OsX 10.9 clang60 | [root_v6.06.02.macosx64-10.9-clang60.dmg](https://root.cern.ch/download/root_v6.06.02.macosx64-10.9-clang60.dmg) | 140M |
-| OsX 10.9 clang60 | [root_v6.06.02.macosx64-10.9-clang60.tar.gz](https://root.cern.ch/download/root_v6.06.02.macosx64-10.9-clang60.tar.gz) | 141M |
-| OsX 10.10 clang70 | [root_v6.06.02.macosx64-10.10-clang70.dmg](https://root.cern.ch/download/root_v6.06.02.macosx64-10.10-clang70.dmg) | 141M |
-| OsX 10.10 clang70 | [root_v6.06.02.macosx64-10.10-clang70.tar.gz](https://root.cern.ch/download/root_v6.06.02.macosx64-10.10-clang70.tar.gz) | 141M |
-| OsX 10.11 clang70 | [root_v6.06.02.macosx64-10.11-clang70.dmg](https://root.cern.ch/download/root_v6.06.02.macosx64-10.11-clang70.dmg) | 144M |
-| OsX 10.11 clang70 | [root_v6.06.02.macosx64-10.11-clang70.tar.gz](https://root.cern.ch/download/root_v6.06.02.macosx64-10.11-clang70.tar.gz) | 144M |
+| CentOS Cern 7 gcc4.8 | [root_v6.06.02.Linux-centos7-x86_64-gcc4.8.tar.gz](https://root.cern/download/root_v6.06.02.Linux-centos7-x86_64-gcc4.8.tar.gz) | 162M |
+| CentOS Cern 7 gcc4.9 | [root_v6.06.02.Linux-centos7-x86_64-gcc4.9.tar.gz](https://root.cern/download/root_v6.06.02.Linux-centos7-x86_64-gcc4.9.tar.gz) | 168M |
+| Linux fedora20 gcc4.8 | [root_v6.06.02.Linux-fedora20-x86_64-gcc4.8.tar.gz](https://root.cern/download/root_v6.06.02.Linux-fedora20-x86_64-gcc4.8.tar.gz) | 145M |
+| Linux fedora21 gcc4.9 | [root_v6.06.02.Linux-fedora21-x86_64-gcc4.9.tar.gz](https://root.cern/download/root_v6.06.02.Linux-fedora21-x86_64-gcc4.9.tar.gz) | 151M |
+| Linux fedora22 gcc5.1 | [root_v6.06.02.Linux-fedora22-x86_64-gcc5.1.tar.gz](https://root.cern/download/root_v6.06.02.Linux-fedora22-x86_64-gcc5.1.tar.gz) | 151M |
+| Scientific Linux Cern 6 gcc4.8 | [root_v6.06.02.Linux-slc6-x86_64-gcc4.8.tar.gz](https://root.cern/download/root_v6.06.02.Linux-slc6-x86_64-gcc4.8.tar.gz) | 161M |
+| Scientific Linux Cern 6 gcc4.9 | [root_v6.06.02.Linux-slc6-x86_64-gcc4.9.tar.gz](https://root.cern/download/root_v6.06.02.Linux-slc6-x86_64-gcc4.9.tar.gz) | 168M |
+| Ubuntu 14 gcc4.8 | [root_v6.06.02.Linux-ubuntu14-x86_64-gcc4.8.tar.gz](https://root.cern/download/root_v6.06.02.Linux-ubuntu14-x86_64-gcc4.8.tar.gz) | 146M |
+| OsX 10.9 clang60 | [root_v6.06.02.macosx64-10.9-clang60.dmg](https://root.cern/download/root_v6.06.02.macosx64-10.9-clang60.dmg) | 140M |
+| OsX 10.9 clang60 | [root_v6.06.02.macosx64-10.9-clang60.tar.gz](https://root.cern/download/root_v6.06.02.macosx64-10.9-clang60.tar.gz) | 141M |
+| OsX 10.10 clang70 | [root_v6.06.02.macosx64-10.10-clang70.dmg](https://root.cern/download/root_v6.06.02.macosx64-10.10-clang70.dmg) | 141M |
+| OsX 10.10 clang70 | [root_v6.06.02.macosx64-10.10-clang70.tar.gz](https://root.cern/download/root_v6.06.02.macosx64-10.10-clang70.tar.gz) | 141M |
+| OsX 10.11 clang70 | [root_v6.06.02.macosx64-10.11-clang70.dmg](https://root.cern/download/root_v6.06.02.macosx64-10.11-clang70.dmg) | 144M |
+| OsX 10.11 clang70 | [root_v6.06.02.macosx64-10.11-clang70.tar.gz](https://root.cern/download/root_v6.06.02.macosx64-10.11-clang70.tar.gz) | 144M |
 
 
 
@@ -70,7 +70,7 @@ Standalone installations with minimal external dependencies are available at:
 The entire ROOT source can be obtained from our public Git repository:
 
 ~~~
-git clone http://root.cern.ch/git/root.git
+git clone http://root.cern/git/root.git
 ~~~
 The release specific tag can be obtained using:
 ~~~

--- a/_releases/release-60604.md
+++ b/_releases/release-60604.md
@@ -13,33 +13,33 @@ sidebar:
 
 ## Release Notes
 
-The release notes for this release can be found [here](https://root.cern.ch/doc/v606/release-notes.html#release-6.0604).
+The release notes for this release can be found [here](https://root.cern/doc/v606/release-notes.html#release-6.0604).
 
 ## Source distribution
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v6.06.04.source.tar.gz](https://root.cern.ch/download/root_v6.06.04.source.tar.gz) | 103M |
+| source | [root_v6.06.04.source.tar.gz](https://root.cern/download/root_v6.06.04.source.tar.gz) | 103M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| CentOS Cern 7 gcc4.8 | [root_v6.06.04.Linux-centos7-x86_64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v6.06.04.Linux-centos7-x86_64-gcc4.8.tar.gz) | 162M |
-| CentOS Cern 7 gcc4.9 | [root_v6.06.04.Linux-centos7-x86_64-gcc4.9.tar.gz](https://root.cern.ch/download/root_v6.06.04.Linux-centos7-x86_64-gcc4.9.tar.gz) | 169M |
-| Linux fedora20 gcc4.8 | [root_v6.06.04.Linux-fedora20-x86_64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v6.06.04.Linux-fedora20-x86_64-gcc4.8.tar.gz) | 145M |
-| Linux fedora21 gcc4.9 | [root_v6.06.04.Linux-fedora21-x86_64-gcc4.9.tar.gz](https://root.cern.ch/download/root_v6.06.04.Linux-fedora21-x86_64-gcc4.9.tar.gz) | 151M |
-| Linux fedora22 gcc5.1 | [root_v6.06.04.Linux-fedora22-x86_64-gcc5.1.tar.gz](https://root.cern.ch/download/root_v6.06.04.Linux-fedora22-x86_64-gcc5.1.tar.gz) | 151M |
-| Scientific Linux Cern 6 gcc4.8 | [root_v6.06.04.Linux-slc6-x86_64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v6.06.04.Linux-slc6-x86_64-gcc4.8.tar.gz) | 161M |
-| Scientific Linux Cern 6 gcc4.9 | [root_v6.06.04.Linux-slc6-x86_64-gcc4.9.tar.gz](https://root.cern.ch/download/root_v6.06.04.Linux-slc6-x86_64-gcc4.9.tar.gz) | 168M |
-| Ubuntu 14 gcc4.8 | [root_v6.06.04.Linux-ubuntu14-x86_64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v6.06.04.Linux-ubuntu14-x86_64-gcc4.8.tar.gz) | 150M |
-| OsX 10.9 clang60 | [root_v6.06.04.macosx64-10.9-clang60.dmg](https://root.cern.ch/download/root_v6.06.04.macosx64-10.9-clang60.dmg) | 140M |
-| OsX 10.9 clang60 | [root_v6.06.04.macosx64-10.9-clang60.tar.gz](https://root.cern.ch/download/root_v6.06.04.macosx64-10.9-clang60.tar.gz) | 141M |
-| OsX 10.10 clang70 | [root_v6.06.04.macosx64-10.10-clang70.dmg](https://root.cern.ch/download/root_v6.06.04.macosx64-10.10-clang70.dmg) | 140M |
-| OsX 10.10 clang70 | [root_v6.06.04.macosx64-10.10-clang70.tar.gz](https://root.cern.ch/download/root_v6.06.04.macosx64-10.10-clang70.tar.gz) | 141M |
-| OsX 10.11 clang73 | [root_v6.06.04.macosx64-10.11-clang73.dmg](https://root.cern.ch/download/root_v6.06.04.macosx64-10.11-clang73.dmg) | 146M |
-| OsX 10.11 clang73 | [root_v6.06.04.macosx64-10.11-clang73.tar.gz](https://root.cern.ch/download/root_v6.06.04.macosx64-10.11-clang73.tar.gz) | 147M |
+| CentOS Cern 7 gcc4.8 | [root_v6.06.04.Linux-centos7-x86_64-gcc4.8.tar.gz](https://root.cern/download/root_v6.06.04.Linux-centos7-x86_64-gcc4.8.tar.gz) | 162M |
+| CentOS Cern 7 gcc4.9 | [root_v6.06.04.Linux-centos7-x86_64-gcc4.9.tar.gz](https://root.cern/download/root_v6.06.04.Linux-centos7-x86_64-gcc4.9.tar.gz) | 169M |
+| Linux fedora20 gcc4.8 | [root_v6.06.04.Linux-fedora20-x86_64-gcc4.8.tar.gz](https://root.cern/download/root_v6.06.04.Linux-fedora20-x86_64-gcc4.8.tar.gz) | 145M |
+| Linux fedora21 gcc4.9 | [root_v6.06.04.Linux-fedora21-x86_64-gcc4.9.tar.gz](https://root.cern/download/root_v6.06.04.Linux-fedora21-x86_64-gcc4.9.tar.gz) | 151M |
+| Linux fedora22 gcc5.1 | [root_v6.06.04.Linux-fedora22-x86_64-gcc5.1.tar.gz](https://root.cern/download/root_v6.06.04.Linux-fedora22-x86_64-gcc5.1.tar.gz) | 151M |
+| Scientific Linux Cern 6 gcc4.8 | [root_v6.06.04.Linux-slc6-x86_64-gcc4.8.tar.gz](https://root.cern/download/root_v6.06.04.Linux-slc6-x86_64-gcc4.8.tar.gz) | 161M |
+| Scientific Linux Cern 6 gcc4.9 | [root_v6.06.04.Linux-slc6-x86_64-gcc4.9.tar.gz](https://root.cern/download/root_v6.06.04.Linux-slc6-x86_64-gcc4.9.tar.gz) | 168M |
+| Ubuntu 14 gcc4.8 | [root_v6.06.04.Linux-ubuntu14-x86_64-gcc4.8.tar.gz](https://root.cern/download/root_v6.06.04.Linux-ubuntu14-x86_64-gcc4.8.tar.gz) | 150M |
+| OsX 10.9 clang60 | [root_v6.06.04.macosx64-10.9-clang60.dmg](https://root.cern/download/root_v6.06.04.macosx64-10.9-clang60.dmg) | 140M |
+| OsX 10.9 clang60 | [root_v6.06.04.macosx64-10.9-clang60.tar.gz](https://root.cern/download/root_v6.06.04.macosx64-10.9-clang60.tar.gz) | 141M |
+| OsX 10.10 clang70 | [root_v6.06.04.macosx64-10.10-clang70.dmg](https://root.cern/download/root_v6.06.04.macosx64-10.10-clang70.dmg) | 140M |
+| OsX 10.10 clang70 | [root_v6.06.04.macosx64-10.10-clang70.tar.gz](https://root.cern/download/root_v6.06.04.macosx64-10.10-clang70.tar.gz) | 141M |
+| OsX 10.11 clang73 | [root_v6.06.04.macosx64-10.11-clang73.dmg](https://root.cern/download/root_v6.06.04.macosx64-10.11-clang73.dmg) | 146M |
+| OsX 10.11 clang73 | [root_v6.06.04.macosx64-10.11-clang73.tar.gz](https://root.cern/download/root_v6.06.04.macosx64-10.11-clang73.tar.gz) | 147M |
 
 
 
@@ -66,7 +66,7 @@ Standalone installations with minimal external dependencies are available at:
 The entire ROOT source can be obtained from our public Git repository:
 
 ~~~
-git clone http://root.cern.ch/git/root.git
+git clone http://root.cern/git/root.git
 ~~~
 The release specific tag can be obtained using:
 ~~~

--- a/_releases/release-60606.md
+++ b/_releases/release-60606.md
@@ -16,33 +16,33 @@ Patch release fixing a number of issues. See release notes.
 
 ## Release Notes
 
-The release notes for this release can be found [here](https://root.cern.ch/doc/v606/release-notes.html#release-6.0606).
+The release notes for this release can be found [here](https://root.cern/doc/v606/release-notes.html#release-6.0606).
 
 ## Source distribution
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v6.06.06.source.tar.gz](https://root.cern.ch/download/root_v6.06.06.source.tar.gz) | 103M |
+| source | [root_v6.06.06.source.tar.gz](https://root.cern/download/root_v6.06.06.source.tar.gz) | 103M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| CentOS Cern 7 gcc4.8 | [root_v6.06.06.Linux-centos7-x86_64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v6.06.06.Linux-centos7-x86_64-gcc4.8.tar.gz) | 162M |
-| CentOS Cern 7 gcc4.9 | [root_v6.06.06.Linux-centos7-x86_64-gcc4.9.tar.gz](https://root.cern.ch/download/root_v6.06.06.Linux-centos7-x86_64-gcc4.9.tar.gz) | 169M |
-| Linux fedora20 gcc4.8 | [root_v6.06.06.Linux-fedora20-x86_64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v6.06.06.Linux-fedora20-x86_64-gcc4.8.tar.gz) | 145M |
-| Linux fedora21 gcc4.9 | [root_v6.06.06.Linux-fedora21-x86_64-gcc4.9.tar.gz](https://root.cern.ch/download/root_v6.06.06.Linux-fedora21-x86_64-gcc4.9.tar.gz) | 151M |
-| Linux fedora22 gcc5.3 | [root_v6.06.06.Linux-fedora22-x86_64-gcc5.3.tar.gz](https://root.cern.ch/download/root_v6.06.06.Linux-fedora22-x86_64-gcc5.3.tar.gz) | 152M |
-| Scientific Linux Cern 6 gcc4.8 | [root_v6.06.06.Linux-slc6-x86_64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v6.06.06.Linux-slc6-x86_64-gcc4.8.tar.gz) | 161M |
-| Scientific Linux Cern 6 gcc4.9 | [root_v6.06.06.Linux-slc6-x86_64-gcc4.9.tar.gz](https://root.cern.ch/download/root_v6.06.06.Linux-slc6-x86_64-gcc4.9.tar.gz) | 168M |
-| Ubuntu 14 gcc4.8 | [root_v6.06.06.Linux-ubuntu14-x86_64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v6.06.06.Linux-ubuntu14-x86_64-gcc4.8.tar.gz) | 150M |
-| OsX 10.9 clang60 | [root_v6.06.06.macosx64-10.9-clang60.dmg](https://root.cern.ch/download/root_v6.06.06.macosx64-10.9-clang60.dmg) | 140M |
-| OsX 10.9 clang60 | [root_v6.06.06.macosx64-10.9-clang60.tar.gz](https://root.cern.ch/download/root_v6.06.06.macosx64-10.9-clang60.tar.gz) | 141M |
-| OsX 10.10 clang70 | [root_v6.06.06.macosx64-10.10-clang70.dmg](https://root.cern.ch/download/root_v6.06.06.macosx64-10.10-clang70.dmg) | 140M |
-| OsX 10.10 clang70 | [root_v6.06.06.macosx64-10.10-clang70.tar.gz](https://root.cern.ch/download/root_v6.06.06.macosx64-10.10-clang70.tar.gz) | 141M |
-| OsX 10.11 clang73 | [root_v6.06.06.macosx64-10.11-clang73.dmg](https://root.cern.ch/download/root_v6.06.06.macosx64-10.11-clang73.dmg) | 146M |
-| OsX 10.11 clang73 | [root_v6.06.06.macosx64-10.11-clang73.tar.gz](https://root.cern.ch/download/root_v6.06.06.macosx64-10.11-clang73.tar.gz) | 147M |
+| CentOS Cern 7 gcc4.8 | [root_v6.06.06.Linux-centos7-x86_64-gcc4.8.tar.gz](https://root.cern/download/root_v6.06.06.Linux-centos7-x86_64-gcc4.8.tar.gz) | 162M |
+| CentOS Cern 7 gcc4.9 | [root_v6.06.06.Linux-centos7-x86_64-gcc4.9.tar.gz](https://root.cern/download/root_v6.06.06.Linux-centos7-x86_64-gcc4.9.tar.gz) | 169M |
+| Linux fedora20 gcc4.8 | [root_v6.06.06.Linux-fedora20-x86_64-gcc4.8.tar.gz](https://root.cern/download/root_v6.06.06.Linux-fedora20-x86_64-gcc4.8.tar.gz) | 145M |
+| Linux fedora21 gcc4.9 | [root_v6.06.06.Linux-fedora21-x86_64-gcc4.9.tar.gz](https://root.cern/download/root_v6.06.06.Linux-fedora21-x86_64-gcc4.9.tar.gz) | 151M |
+| Linux fedora22 gcc5.3 | [root_v6.06.06.Linux-fedora22-x86_64-gcc5.3.tar.gz](https://root.cern/download/root_v6.06.06.Linux-fedora22-x86_64-gcc5.3.tar.gz) | 152M |
+| Scientific Linux Cern 6 gcc4.8 | [root_v6.06.06.Linux-slc6-x86_64-gcc4.8.tar.gz](https://root.cern/download/root_v6.06.06.Linux-slc6-x86_64-gcc4.8.tar.gz) | 161M |
+| Scientific Linux Cern 6 gcc4.9 | [root_v6.06.06.Linux-slc6-x86_64-gcc4.9.tar.gz](https://root.cern/download/root_v6.06.06.Linux-slc6-x86_64-gcc4.9.tar.gz) | 168M |
+| Ubuntu 14 gcc4.8 | [root_v6.06.06.Linux-ubuntu14-x86_64-gcc4.8.tar.gz](https://root.cern/download/root_v6.06.06.Linux-ubuntu14-x86_64-gcc4.8.tar.gz) | 150M |
+| OsX 10.9 clang60 | [root_v6.06.06.macosx64-10.9-clang60.dmg](https://root.cern/download/root_v6.06.06.macosx64-10.9-clang60.dmg) | 140M |
+| OsX 10.9 clang60 | [root_v6.06.06.macosx64-10.9-clang60.tar.gz](https://root.cern/download/root_v6.06.06.macosx64-10.9-clang60.tar.gz) | 141M |
+| OsX 10.10 clang70 | [root_v6.06.06.macosx64-10.10-clang70.dmg](https://root.cern/download/root_v6.06.06.macosx64-10.10-clang70.dmg) | 140M |
+| OsX 10.10 clang70 | [root_v6.06.06.macosx64-10.10-clang70.tar.gz](https://root.cern/download/root_v6.06.06.macosx64-10.10-clang70.tar.gz) | 141M |
+| OsX 10.11 clang73 | [root_v6.06.06.macosx64-10.11-clang73.dmg](https://root.cern/download/root_v6.06.06.macosx64-10.11-clang73.dmg) | 146M |
+| OsX 10.11 clang73 | [root_v6.06.06.macosx64-10.11-clang73.tar.gz](https://root.cern/download/root_v6.06.06.macosx64-10.11-clang73.tar.gz) | 147M |
 
 
 
@@ -69,7 +69,7 @@ Standalone installations with minimal external dependencies are available at:
 The entire ROOT source can be obtained from our public Git repository:
 
 ~~~
-git clone http://root.cern.ch/git/root.git
+git clone http://root.cern/git/root.git
 ~~~
 The release specific tag can be obtained using:
 ~~~

--- a/_releases/release-60608.md
+++ b/_releases/release-60608.md
@@ -16,33 +16,33 @@ Bug fixes release.
 
 ## Release Notes
 
-The release notes for this release can be found [here](https://root.cern.ch/doc/v606/release-notes.html#release-6.0608).
+The release notes for this release can be found [here](https://root.cern/doc/v606/release-notes.html#release-6.0608).
 
 ## Source distribution
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v6.06.08.source.tar.gz](https://root.cern.ch/download/root_v6.06.08.source.tar.gz) | 103M |
+| source | [root_v6.06.08.source.tar.gz](https://root.cern/download/root_v6.06.08.source.tar.gz) | 103M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| CentOS Cern 7 gcc4.8 | [root_v6.06.08.Linux-centos7-x86_64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v6.06.08.Linux-centos7-x86_64-gcc4.8.tar.gz) | 162M |
-| CentOS Cern 7 gcc4.9 | [root_v6.06.08.Linux-centos7-x86_64-gcc4.9.tar.gz](https://root.cern.ch/download/root_v6.06.08.Linux-centos7-x86_64-gcc4.9.tar.gz) | 169M |
-| Linux fedora20 gcc4.8 | [root_v6.06.08.Linux-fedora20-x86_64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v6.06.08.Linux-fedora20-x86_64-gcc4.8.tar.gz) | 146M |
-| Linux fedora21 gcc4.9 | [root_v6.06.08.Linux-fedora21-x86_64-gcc4.9.tar.gz](https://root.cern.ch/download/root_v6.06.08.Linux-fedora21-x86_64-gcc4.9.tar.gz) | 151M |
-| Linux fedora22 gcc5.3 | [root_v6.06.08.Linux-fedora22-x86_64-gcc5.3.tar.gz](https://root.cern.ch/download/root_v6.06.08.Linux-fedora22-x86_64-gcc5.3.tar.gz) | 152M |
-| Scientific Linux Cern 6 gcc4.8 | [root_v6.06.08.Linux-slc6-x86_64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v6.06.08.Linux-slc6-x86_64-gcc4.8.tar.gz) | 161M |
-| Scientific Linux Cern 6 gcc4.9 | [root_v6.06.08.Linux-slc6-x86_64-gcc4.9.tar.gz](https://root.cern.ch/download/root_v6.06.08.Linux-slc6-x86_64-gcc4.9.tar.gz) | 168M |
-| Ubuntu 14 gcc4.8 | [root_v6.06.08.Linux-ubuntu14-x86_64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v6.06.08.Linux-ubuntu14-x86_64-gcc4.8.tar.gz) | 150M |
-| OsX 10.9 clang60 | [root_v6.06.08.macosx64-10.9-clang60.dmg](https://root.cern.ch/download/root_v6.06.08.macosx64-10.9-clang60.dmg) | 140M |
-| OsX 10.9 clang60 | [root_v6.06.08.macosx64-10.9-clang60.tar.gz](https://root.cern.ch/download/root_v6.06.08.macosx64-10.9-clang60.tar.gz) | 141M |
-| OsX 10.10 clang70 | [root_v6.06.08.macosx64-10.10-clang70.dmg](https://root.cern.ch/download/root_v6.06.08.macosx64-10.10-clang70.dmg) | 140M |
-| OsX 10.10 clang70 | [root_v6.06.08.macosx64-10.10-clang70.tar.gz](https://root.cern.ch/download/root_v6.06.08.macosx64-10.10-clang70.tar.gz) | 141M |
-| OsX 10.11 clang73 | [root_v6.06.08.macosx64-10.11-clang73.dmg](https://root.cern.ch/download/root_v6.06.08.macosx64-10.11-clang73.dmg) | 146M |
-| OsX 10.11 clang73 | [root_v6.06.08.macosx64-10.11-clang73.tar.gz](https://root.cern.ch/download/root_v6.06.08.macosx64-10.11-clang73.tar.gz) | 147M |
+| CentOS Cern 7 gcc4.8 | [root_v6.06.08.Linux-centos7-x86_64-gcc4.8.tar.gz](https://root.cern/download/root_v6.06.08.Linux-centos7-x86_64-gcc4.8.tar.gz) | 162M |
+| CentOS Cern 7 gcc4.9 | [root_v6.06.08.Linux-centos7-x86_64-gcc4.9.tar.gz](https://root.cern/download/root_v6.06.08.Linux-centos7-x86_64-gcc4.9.tar.gz) | 169M |
+| Linux fedora20 gcc4.8 | [root_v6.06.08.Linux-fedora20-x86_64-gcc4.8.tar.gz](https://root.cern/download/root_v6.06.08.Linux-fedora20-x86_64-gcc4.8.tar.gz) | 146M |
+| Linux fedora21 gcc4.9 | [root_v6.06.08.Linux-fedora21-x86_64-gcc4.9.tar.gz](https://root.cern/download/root_v6.06.08.Linux-fedora21-x86_64-gcc4.9.tar.gz) | 151M |
+| Linux fedora22 gcc5.3 | [root_v6.06.08.Linux-fedora22-x86_64-gcc5.3.tar.gz](https://root.cern/download/root_v6.06.08.Linux-fedora22-x86_64-gcc5.3.tar.gz) | 152M |
+| Scientific Linux Cern 6 gcc4.8 | [root_v6.06.08.Linux-slc6-x86_64-gcc4.8.tar.gz](https://root.cern/download/root_v6.06.08.Linux-slc6-x86_64-gcc4.8.tar.gz) | 161M |
+| Scientific Linux Cern 6 gcc4.9 | [root_v6.06.08.Linux-slc6-x86_64-gcc4.9.tar.gz](https://root.cern/download/root_v6.06.08.Linux-slc6-x86_64-gcc4.9.tar.gz) | 168M |
+| Ubuntu 14 gcc4.8 | [root_v6.06.08.Linux-ubuntu14-x86_64-gcc4.8.tar.gz](https://root.cern/download/root_v6.06.08.Linux-ubuntu14-x86_64-gcc4.8.tar.gz) | 150M |
+| OsX 10.9 clang60 | [root_v6.06.08.macosx64-10.9-clang60.dmg](https://root.cern/download/root_v6.06.08.macosx64-10.9-clang60.dmg) | 140M |
+| OsX 10.9 clang60 | [root_v6.06.08.macosx64-10.9-clang60.tar.gz](https://root.cern/download/root_v6.06.08.macosx64-10.9-clang60.tar.gz) | 141M |
+| OsX 10.10 clang70 | [root_v6.06.08.macosx64-10.10-clang70.dmg](https://root.cern/download/root_v6.06.08.macosx64-10.10-clang70.dmg) | 140M |
+| OsX 10.10 clang70 | [root_v6.06.08.macosx64-10.10-clang70.tar.gz](https://root.cern/download/root_v6.06.08.macosx64-10.10-clang70.tar.gz) | 141M |
+| OsX 10.11 clang73 | [root_v6.06.08.macosx64-10.11-clang73.dmg](https://root.cern/download/root_v6.06.08.macosx64-10.11-clang73.dmg) | 146M |
+| OsX 10.11 clang73 | [root_v6.06.08.macosx64-10.11-clang73.tar.gz](https://root.cern/download/root_v6.06.08.macosx64-10.11-clang73.tar.gz) | 147M |
 
 
 
@@ -72,7 +72,7 @@ Standalone installations with minimal external dependencies are available at:
 The entire ROOT source can be obtained from our public Git repository:
 
 ~~~
-git clone http://root.cern.ch/git/root.git
+git clone http://root.cern/git/root.git
 ~~~
 The release specific tag can be obtained using:
 ~~~

--- a/_releases/release-60800.md
+++ b/_releases/release-60800.md
@@ -13,36 +13,36 @@ sidebar:
 
 ## Release Notes
 
-The release notes for this release can be found [here](https://root.cern.ch/doc/v608/release-notes.html).
+The release notes for this release can be found [here](https://root.cern/doc/v608/release-notes.html).
 
 ## Source distribution
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v6.08.00.source.tar.gz](https://root.cern.ch/download/root_v6.08.00.source.tar.gz) | 149M |
+| source | [root_v6.08.00.source.tar.gz](https://root.cern/download/root_v6.08.00.source.tar.gz) | 149M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| CentOS Cern 7 gcc4.8 | [root_v6.08.00.Linux-centos7-x86_64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v6.08.00.Linux-centos7-x86_64-gcc4.8.tar.gz) | 196M |
-| Linux fedora22 gcc5.3 | [root_v6.08.00.Linux-fedora22-x86_64-gcc5.3.tar.gz](https://root.cern.ch/download/root_v6.08.00.Linux-fedora22-x86_64-gcc5.3.tar.gz) | 185M |
-| Linux fedora24 gcc6.1 | [root_v6.08.00.Linux-fedora24-x86_64-gcc6.1.tar.gz](https://root.cern.ch/download/root_v6.08.00.Linux-fedora24-x86_64-gcc6.1.tar.gz) | 165M |
-| Ubuntu 14 gcc4.8 | [root_v6.08.00.Linux-ubuntu14-x86_64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v6.08.00.Linux-ubuntu14-x86_64-gcc4.8.tar.gz) | 183M |
-| Ubuntu 16 gcc5.4 | [root_v6.08.00.Linux-ubuntu16-x86_64-gcc5.4.tar.gz](https://root.cern.ch/download/root_v6.08.00.Linux-ubuntu16-x86_64-gcc5.4.tar.gz) | 186M |
-| OsX 10.10 clang70 | [root_v6.08.00.macosx64-10.10-clang70.dmg](https://root.cern.ch/download/root_v6.08.00.macosx64-10.10-clang70.dmg) | 157M |
-| OsX 10.10 clang70 | [root_v6.08.00.macosx64-10.10-clang70.tar.gz](https://root.cern.ch/download/root_v6.08.00.macosx64-10.10-clang70.tar.gz) | 158M |
-| OsX 10.10 | [root_v6.08.00.macosx64-10.10.dmg](https://root.cern.ch/download/root_v6.08.00.macosx64-10.10.dmg) | 157M |
-| OsX 10.10 | [root_v6.08.00.macosx64-10.10.tar.gz](https://root.cern.ch/download/root_v6.08.00.macosx64-10.10.tar.gz) | 158M |
-| OsX 10.11 clang73 | [root_v6.08.00.macosx64-10.11-clang73.dmg](https://root.cern.ch/download/root_v6.08.00.macosx64-10.11-clang73.dmg) | 162M |
-| OsX 10.11 clang73 | [root_v6.08.00.macosx64-10.11-clang73.tar.gz](https://root.cern.ch/download/root_v6.08.00.macosx64-10.11-clang73.tar.gz) | 163M |
-| OsX 10.11 | [root_v6.08.00.macosx64-10.11.dmg](https://root.cern.ch/download/root_v6.08.00.macosx64-10.11.dmg) | 162M |
-| OsX 10.11 | [root_v6.08.00.macosx64-10.11.tar.gz](https://root.cern.ch/download/root_v6.08.00.macosx64-10.11.tar.gz) | 163M |
-| OsX 10.12 clang80 | [root_v6.08.00.macosx64-10.12-clang80.dmg](https://root.cern.ch/download/root_v6.08.00.macosx64-10.12-clang80.dmg) | 165M |
-| OsX 10.12 clang80 | [root_v6.08.00.macosx64-10.12-clang80.tar.gz](https://root.cern.ch/download/root_v6.08.00.macosx64-10.12-clang80.tar.gz) | 166M |
-| OsX 10.12 | [root_v6.08.00.macosx64-10.12.dmg](https://root.cern.ch/download/root_v6.08.00.macosx64-10.12.dmg) | 165M |
-| OsX 10.12 | [root_v6.08.00.macosx64-10.12.tar.gz](https://root.cern.ch/download/root_v6.08.00.macosx64-10.12.tar.gz) | 166M |
+| CentOS Cern 7 gcc4.8 | [root_v6.08.00.Linux-centos7-x86_64-gcc4.8.tar.gz](https://root.cern/download/root_v6.08.00.Linux-centos7-x86_64-gcc4.8.tar.gz) | 196M |
+| Linux fedora22 gcc5.3 | [root_v6.08.00.Linux-fedora22-x86_64-gcc5.3.tar.gz](https://root.cern/download/root_v6.08.00.Linux-fedora22-x86_64-gcc5.3.tar.gz) | 185M |
+| Linux fedora24 gcc6.1 | [root_v6.08.00.Linux-fedora24-x86_64-gcc6.1.tar.gz](https://root.cern/download/root_v6.08.00.Linux-fedora24-x86_64-gcc6.1.tar.gz) | 165M |
+| Ubuntu 14 gcc4.8 | [root_v6.08.00.Linux-ubuntu14-x86_64-gcc4.8.tar.gz](https://root.cern/download/root_v6.08.00.Linux-ubuntu14-x86_64-gcc4.8.tar.gz) | 183M |
+| Ubuntu 16 gcc5.4 | [root_v6.08.00.Linux-ubuntu16-x86_64-gcc5.4.tar.gz](https://root.cern/download/root_v6.08.00.Linux-ubuntu16-x86_64-gcc5.4.tar.gz) | 186M |
+| OsX 10.10 clang70 | [root_v6.08.00.macosx64-10.10-clang70.dmg](https://root.cern/download/root_v6.08.00.macosx64-10.10-clang70.dmg) | 157M |
+| OsX 10.10 clang70 | [root_v6.08.00.macosx64-10.10-clang70.tar.gz](https://root.cern/download/root_v6.08.00.macosx64-10.10-clang70.tar.gz) | 158M |
+| OsX 10.10 | [root_v6.08.00.macosx64-10.10.dmg](https://root.cern/download/root_v6.08.00.macosx64-10.10.dmg) | 157M |
+| OsX 10.10 | [root_v6.08.00.macosx64-10.10.tar.gz](https://root.cern/download/root_v6.08.00.macosx64-10.10.tar.gz) | 158M |
+| OsX 10.11 clang73 | [root_v6.08.00.macosx64-10.11-clang73.dmg](https://root.cern/download/root_v6.08.00.macosx64-10.11-clang73.dmg) | 162M |
+| OsX 10.11 clang73 | [root_v6.08.00.macosx64-10.11-clang73.tar.gz](https://root.cern/download/root_v6.08.00.macosx64-10.11-clang73.tar.gz) | 163M |
+| OsX 10.11 | [root_v6.08.00.macosx64-10.11.dmg](https://root.cern/download/root_v6.08.00.macosx64-10.11.dmg) | 162M |
+| OsX 10.11 | [root_v6.08.00.macosx64-10.11.tar.gz](https://root.cern/download/root_v6.08.00.macosx64-10.11.tar.gz) | 163M |
+| OsX 10.12 clang80 | [root_v6.08.00.macosx64-10.12-clang80.dmg](https://root.cern/download/root_v6.08.00.macosx64-10.12-clang80.dmg) | 165M |
+| OsX 10.12 clang80 | [root_v6.08.00.macosx64-10.12-clang80.tar.gz](https://root.cern/download/root_v6.08.00.macosx64-10.12-clang80.tar.gz) | 166M |
+| OsX 10.12 | [root_v6.08.00.macosx64-10.12.dmg](https://root.cern/download/root_v6.08.00.macosx64-10.12.dmg) | 165M |
+| OsX 10.12 | [root_v6.08.00.macosx64-10.12.tar.gz](https://root.cern/download/root_v6.08.00.macosx64-10.12.tar.gz) | 166M |
 
 
 
@@ -69,7 +69,7 @@ Standalone installations with minimal external dependencies are available at:
 The entire ROOT source can be obtained from our public Git repository:
 
 ~~~
-git clone http://root.cern.ch/git/root.git
+git clone http://root.cern/git/root.git
 ~~~
 The release specific tag can be obtained using:
 ~~~

--- a/_releases/release-60802.md
+++ b/_releases/release-60802.md
@@ -16,30 +16,30 @@ Basically only bug fixes. The actual list issues solved by this release can be f
 
 ## Release Notes
 
-The release notes for this release can be found [here](https://root.cern.ch/doc/v608/release-notes.html#release-6.0802).
+The release notes for this release can be found [here](https://root.cern/doc/v608/release-notes.html#release-6.0802).
 
 ## Source distribution
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v6.08.02.source.tar.gz](https://root.cern.ch/download/root_v6.08.02.source.tar.gz) | 149M |
+| source | [root_v6.08.02.source.tar.gz](https://root.cern/download/root_v6.08.02.source.tar.gz) | 149M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| CentOS Cern 7 gcc4.8 | [root_v6.08.02.Linux-centos7-x86_64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v6.08.02.Linux-centos7-x86_64-gcc4.8.tar.gz) | 196M |
-| Linux fedora22 gcc5.3 | [root_v6.08.02.Linux-fedora22-x86_64-gcc5.3.tar.gz](https://root.cern.ch/download/root_v6.08.02.Linux-fedora22-x86_64-gcc5.3.tar.gz) | 185M |
-| Linux fedora24 gcc6.1 | [root_v6.08.02.Linux-fedora24-x86_64-gcc6.1.tar.gz](https://root.cern.ch/download/root_v6.08.02.Linux-fedora24-x86_64-gcc6.1.tar.gz) | 165M |
-| Ubuntu 14 gcc4.8 | [root_v6.08.02.Linux-ubuntu14-x86_64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v6.08.02.Linux-ubuntu14-x86_64-gcc4.8.tar.gz) | 182M |
-| Ubuntu 16 gcc5.4 | [root_v6.08.02.Linux-ubuntu16-x86_64-gcc5.4.tar.gz](https://root.cern.ch/download/root_v6.08.02.Linux-ubuntu16-x86_64-gcc5.4.tar.gz) | 186M |
-| OsX 10.10 clang70 | [root_v6.08.02.macosx64-10.10-clang70.dmg](https://root.cern.ch/download/root_v6.08.02.macosx64-10.10-clang70.dmg) | 157M |
-| OsX 10.10 clang70 | [root_v6.08.02.macosx64-10.10-clang70.tar.gz](https://root.cern.ch/download/root_v6.08.02.macosx64-10.10-clang70.tar.gz) | 158M |
-| OsX 10.11 clang80 | [root_v6.08.02.macosx64-10.11-clang80.dmg](https://root.cern.ch/download/root_v6.08.02.macosx64-10.11-clang80.dmg) | 163M |
-| OsX 10.11 clang80 | [root_v6.08.02.macosx64-10.11-clang80.tar.gz](https://root.cern.ch/download/root_v6.08.02.macosx64-10.11-clang80.tar.gz) | 163M |
-| OsX 10.12 clang80 | [root_v6.08.02.macosx64-10.12-clang80.dmg](https://root.cern.ch/download/root_v6.08.02.macosx64-10.12-clang80.dmg) | 167M |
-| OsX 10.12 clang80 | [root_v6.08.02.macosx64-10.12-clang80.tar.gz](https://root.cern.ch/download/root_v6.08.02.macosx64-10.12-clang80.tar.gz) | 168M |
+| CentOS Cern 7 gcc4.8 | [root_v6.08.02.Linux-centos7-x86_64-gcc4.8.tar.gz](https://root.cern/download/root_v6.08.02.Linux-centos7-x86_64-gcc4.8.tar.gz) | 196M |
+| Linux fedora22 gcc5.3 | [root_v6.08.02.Linux-fedora22-x86_64-gcc5.3.tar.gz](https://root.cern/download/root_v6.08.02.Linux-fedora22-x86_64-gcc5.3.tar.gz) | 185M |
+| Linux fedora24 gcc6.1 | [root_v6.08.02.Linux-fedora24-x86_64-gcc6.1.tar.gz](https://root.cern/download/root_v6.08.02.Linux-fedora24-x86_64-gcc6.1.tar.gz) | 165M |
+| Ubuntu 14 gcc4.8 | [root_v6.08.02.Linux-ubuntu14-x86_64-gcc4.8.tar.gz](https://root.cern/download/root_v6.08.02.Linux-ubuntu14-x86_64-gcc4.8.tar.gz) | 182M |
+| Ubuntu 16 gcc5.4 | [root_v6.08.02.Linux-ubuntu16-x86_64-gcc5.4.tar.gz](https://root.cern/download/root_v6.08.02.Linux-ubuntu16-x86_64-gcc5.4.tar.gz) | 186M |
+| OsX 10.10 clang70 | [root_v6.08.02.macosx64-10.10-clang70.dmg](https://root.cern/download/root_v6.08.02.macosx64-10.10-clang70.dmg) | 157M |
+| OsX 10.10 clang70 | [root_v6.08.02.macosx64-10.10-clang70.tar.gz](https://root.cern/download/root_v6.08.02.macosx64-10.10-clang70.tar.gz) | 158M |
+| OsX 10.11 clang80 | [root_v6.08.02.macosx64-10.11-clang80.dmg](https://root.cern/download/root_v6.08.02.macosx64-10.11-clang80.dmg) | 163M |
+| OsX 10.11 clang80 | [root_v6.08.02.macosx64-10.11-clang80.tar.gz](https://root.cern/download/root_v6.08.02.macosx64-10.11-clang80.tar.gz) | 163M |
+| OsX 10.12 clang80 | [root_v6.08.02.macosx64-10.12-clang80.dmg](https://root.cern/download/root_v6.08.02.macosx64-10.12-clang80.dmg) | 167M |
+| OsX 10.12 clang80 | [root_v6.08.02.macosx64-10.12-clang80.tar.gz](https://root.cern/download/root_v6.08.02.macosx64-10.12-clang80.tar.gz) | 168M |
 
 
 
@@ -66,7 +66,7 @@ Standalone installations with minimal external dependencies are available at:
 The entire ROOT source can be obtained from our public Git repository:
 
 ~~~
-git clone http://root.cern.ch/git/root.git
+git clone http://root.cern/git/root.git
 ~~~
 The release specific tag can be obtained using:
 ~~~

--- a/_releases/release-60804.md
+++ b/_releases/release-60804.md
@@ -16,30 +16,30 @@ Bug fix release. See notes for details.
 
 ## Release Notes
 
-The release notes for this release can be found [here](https://root.cern.ch/doc/v608/release-notes.html#release-6.0804).
+The release notes for this release can be found [here](https://root.cern/doc/v608/release-notes.html#release-6.0804).
 
 ## Source distribution
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v6.08.04.source.tar.gz](https://root.cern.ch/download/root_v6.08.04.source.tar.gz) | 149M |
+| source | [root_v6.08.04.source.tar.gz](https://root.cern/download/root_v6.08.04.source.tar.gz) | 149M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| CentOS Cern 7 gcc4.8 | [root_v6.08.04.Linux-centos7-x86_64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v6.08.04.Linux-centos7-x86_64-gcc4.8.tar.gz) | 196M |
-| Linux fedora22 gcc5.3 | [root_v6.08.04.Linux-fedora22-x86_64-gcc5.3.tar.gz](https://root.cern.ch/download/root_v6.08.04.Linux-fedora22-x86_64-gcc5.3.tar.gz) | 185M |
-| Linux fedora24 gcc6.1 | [root_v6.08.04.Linux-fedora24-x86_64-gcc6.1.tar.gz](https://root.cern.ch/download/root_v6.08.04.Linux-fedora24-x86_64-gcc6.1.tar.gz) | 185M |
-| Ubuntu 14 gcc4.8 | [root_v6.08.04.Linux-ubuntu14-x86_64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v6.08.04.Linux-ubuntu14-x86_64-gcc4.8.tar.gz) | 182M |
-| Ubuntu 16 gcc5.4 | [root_v6.08.04.Linux-ubuntu16-x86_64-gcc5.4.tar.gz](https://root.cern.ch/download/root_v6.08.04.Linux-ubuntu16-x86_64-gcc5.4.tar.gz) | 182M |
-| OsX 10.10 clang70 | [root_v6.08.04.macosx64-10.10-clang70.dmg](https://root.cern.ch/download/root_v6.08.04.macosx64-10.10-clang70.dmg) | 157M |
-| OsX 10.10 clang70 | [root_v6.08.04.macosx64-10.10-clang70.tar.gz](https://root.cern.ch/download/root_v6.08.04.macosx64-10.10-clang70.tar.gz) | 158M |
-| OsX 10.11 clang80 | [root_v6.08.04.macosx64-10.11-clang80.dmg](https://root.cern.ch/download/root_v6.08.04.macosx64-10.11-clang80.dmg) | 163M |
-| OsX 10.11 clang80 | [root_v6.08.04.macosx64-10.11-clang80.tar.gz](https://root.cern.ch/download/root_v6.08.04.macosx64-10.11-clang80.tar.gz) | 163M |
-| OsX 10.12 clang80 | [root_v6.08.04.macosx64-10.12-clang80.dmg](https://root.cern.ch/download/root_v6.08.04.macosx64-10.12-clang80.dmg) | 169M |
-| OsX 10.12 clang80 | [root_v6.08.04.macosx64-10.12-clang80.tar.gz](https://root.cern.ch/download/root_v6.08.04.macosx64-10.12-clang80.tar.gz) | 170M |
+| CentOS Cern 7 gcc4.8 | [root_v6.08.04.Linux-centos7-x86_64-gcc4.8.tar.gz](https://root.cern/download/root_v6.08.04.Linux-centos7-x86_64-gcc4.8.tar.gz) | 196M |
+| Linux fedora22 gcc5.3 | [root_v6.08.04.Linux-fedora22-x86_64-gcc5.3.tar.gz](https://root.cern/download/root_v6.08.04.Linux-fedora22-x86_64-gcc5.3.tar.gz) | 185M |
+| Linux fedora24 gcc6.1 | [root_v6.08.04.Linux-fedora24-x86_64-gcc6.1.tar.gz](https://root.cern/download/root_v6.08.04.Linux-fedora24-x86_64-gcc6.1.tar.gz) | 185M |
+| Ubuntu 14 gcc4.8 | [root_v6.08.04.Linux-ubuntu14-x86_64-gcc4.8.tar.gz](https://root.cern/download/root_v6.08.04.Linux-ubuntu14-x86_64-gcc4.8.tar.gz) | 182M |
+| Ubuntu 16 gcc5.4 | [root_v6.08.04.Linux-ubuntu16-x86_64-gcc5.4.tar.gz](https://root.cern/download/root_v6.08.04.Linux-ubuntu16-x86_64-gcc5.4.tar.gz) | 182M |
+| OsX 10.10 clang70 | [root_v6.08.04.macosx64-10.10-clang70.dmg](https://root.cern/download/root_v6.08.04.macosx64-10.10-clang70.dmg) | 157M |
+| OsX 10.10 clang70 | [root_v6.08.04.macosx64-10.10-clang70.tar.gz](https://root.cern/download/root_v6.08.04.macosx64-10.10-clang70.tar.gz) | 158M |
+| OsX 10.11 clang80 | [root_v6.08.04.macosx64-10.11-clang80.dmg](https://root.cern/download/root_v6.08.04.macosx64-10.11-clang80.dmg) | 163M |
+| OsX 10.11 clang80 | [root_v6.08.04.macosx64-10.11-clang80.tar.gz](https://root.cern/download/root_v6.08.04.macosx64-10.11-clang80.tar.gz) | 163M |
+| OsX 10.12 clang80 | [root_v6.08.04.macosx64-10.12-clang80.dmg](https://root.cern/download/root_v6.08.04.macosx64-10.12-clang80.dmg) | 169M |
+| OsX 10.12 clang80 | [root_v6.08.04.macosx64-10.12-clang80.tar.gz](https://root.cern/download/root_v6.08.04.macosx64-10.12-clang80.tar.gz) | 170M |
 
 
 
@@ -65,7 +65,7 @@ Standalone installations with minimal external dependencies are available at:
 The entire ROOT source can be obtained from our public Git repository:
 
 ~~~
-git clone http://root.cern.ch/git/root.git
+git clone http://root.cern/git/root.git
 ~~~
 The release specific tag can be obtained using:
 ~~~

--- a/_releases/release-60806.md
+++ b/_releases/release-60806.md
@@ -13,30 +13,30 @@ sidebar:
 
 ## Release Notes
 
-The release notes for this release can be found [here](https://root.cern.ch/doc/v608/release-notes.html#release-6.0806).
+The release notes for this release can be found [here](https://root.cern/doc/v608/release-notes.html#release-6.0806).
 
 ## Source distribution
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v6.08.06.source.tar.gz](https://root.cern.ch/download/root_v6.08.06.source.tar.gz) | 149M |
+| source | [root_v6.08.06.source.tar.gz](https://root.cern/download/root_v6.08.06.source.tar.gz) | 149M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| CentOS Cern 7 gcc4.8 | [root_v6.08.06.Linux-centos7-x86_64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v6.08.06.Linux-centos7-x86_64-gcc4.8.tar.gz) | 196M |
-| Linux fedora22 gcc5.3 | [root_v6.08.06.Linux-fedora22-x86_64-gcc5.3.tar.gz](https://root.cern.ch/download/root_v6.08.06.Linux-fedora22-x86_64-gcc5.3.tar.gz) | 185M |
-| Linux fedora24 gcc6.1 | [root_v6.08.06.Linux-fedora24-x86_64-gcc6.1.tar.gz](https://root.cern.ch/download/root_v6.08.06.Linux-fedora24-x86_64-gcc6.1.tar.gz) | 165M |
-| Ubuntu 14 gcc4.8 | [root_v6.08.06.Linux-ubuntu14-x86_64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v6.08.06.Linux-ubuntu14-x86_64-gcc4.8.tar.gz) | 182M |
-| Ubuntu 16 gcc5.4 | [root_v6.08.06.Linux-ubuntu16-x86_64-gcc5.4.tar.gz](https://root.cern.ch/download/root_v6.08.06.Linux-ubuntu16-x86_64-gcc5.4.tar.gz) | 186M |
-| OsX 10.10 clang70 | [root_v6.08.06.macosx64-10.10-clang70.dmg](https://root.cern.ch/download/root_v6.08.06.macosx64-10.10-clang70.dmg) | 157M |
-| OsX 10.10 clang70 | [root_v6.08.06.macosx64-10.10-clang70.tar.gz](https://root.cern.ch/download/root_v6.08.06.macosx64-10.10-clang70.tar.gz) | 158M |
-| OsX 10.11 clang80 | [root_v6.08.06.macosx64-10.11-clang80.dmg](https://root.cern.ch/download/root_v6.08.06.macosx64-10.11-clang80.dmg) | 163M |
-| OsX 10.11 clang80 | [root_v6.08.06.macosx64-10.11-clang80.tar.gz](https://root.cern.ch/download/root_v6.08.06.macosx64-10.11-clang80.tar.gz) | 163M |
-| OsX 10.12 clang80 | [root_v6.08.06.macosx64-10.12-clang80.dmg](https://root.cern.ch/download/root_v6.08.06.macosx64-10.12-clang80.dmg) | 169M |
-| OsX 10.12 clang80 | [root_v6.08.06.macosx64-10.12-clang80.tar.gz](https://root.cern.ch/download/root_v6.08.06.macosx64-10.12-clang80.tar.gz) | 170M |
+| CentOS Cern 7 gcc4.8 | [root_v6.08.06.Linux-centos7-x86_64-gcc4.8.tar.gz](https://root.cern/download/root_v6.08.06.Linux-centos7-x86_64-gcc4.8.tar.gz) | 196M |
+| Linux fedora22 gcc5.3 | [root_v6.08.06.Linux-fedora22-x86_64-gcc5.3.tar.gz](https://root.cern/download/root_v6.08.06.Linux-fedora22-x86_64-gcc5.3.tar.gz) | 185M |
+| Linux fedora24 gcc6.1 | [root_v6.08.06.Linux-fedora24-x86_64-gcc6.1.tar.gz](https://root.cern/download/root_v6.08.06.Linux-fedora24-x86_64-gcc6.1.tar.gz) | 165M |
+| Ubuntu 14 gcc4.8 | [root_v6.08.06.Linux-ubuntu14-x86_64-gcc4.8.tar.gz](https://root.cern/download/root_v6.08.06.Linux-ubuntu14-x86_64-gcc4.8.tar.gz) | 182M |
+| Ubuntu 16 gcc5.4 | [root_v6.08.06.Linux-ubuntu16-x86_64-gcc5.4.tar.gz](https://root.cern/download/root_v6.08.06.Linux-ubuntu16-x86_64-gcc5.4.tar.gz) | 186M |
+| OsX 10.10 clang70 | [root_v6.08.06.macosx64-10.10-clang70.dmg](https://root.cern/download/root_v6.08.06.macosx64-10.10-clang70.dmg) | 157M |
+| OsX 10.10 clang70 | [root_v6.08.06.macosx64-10.10-clang70.tar.gz](https://root.cern/download/root_v6.08.06.macosx64-10.10-clang70.tar.gz) | 158M |
+| OsX 10.11 clang80 | [root_v6.08.06.macosx64-10.11-clang80.dmg](https://root.cern/download/root_v6.08.06.macosx64-10.11-clang80.dmg) | 163M |
+| OsX 10.11 clang80 | [root_v6.08.06.macosx64-10.11-clang80.tar.gz](https://root.cern/download/root_v6.08.06.macosx64-10.11-clang80.tar.gz) | 163M |
+| OsX 10.12 clang80 | [root_v6.08.06.macosx64-10.12-clang80.dmg](https://root.cern/download/root_v6.08.06.macosx64-10.12-clang80.dmg) | 169M |
+| OsX 10.12 clang80 | [root_v6.08.06.macosx64-10.12-clang80.tar.gz](https://root.cern/download/root_v6.08.06.macosx64-10.12-clang80.tar.gz) | 170M |
 
 
 
@@ -63,7 +63,7 @@ Standalone installations with minimal external dependencies are available at:
 The entire ROOT source can be obtained from our public Git repository:
 
 ~~~
-git clone http://root.cern.ch/git/root.git
+git clone http://root.cern/git/root.git
 ~~~
 The release specific tag can be obtained using:
 ~~~

--- a/_releases/release-60902.md
+++ b/_releases/release-60902.md
@@ -28,24 +28,24 @@ Some highlights:
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v6.09.02.source.tar.gz](https://root.cern.ch/download/root_v6.09.02.source.tar.gz) | 150M |
+| source | [root_v6.09.02.source.tar.gz](https://root.cern/download/root_v6.09.02.source.tar.gz) | 150M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| CentOS Cern 7 gcc4.8 | [root_v6.09.02.Linux-centos7-x86_64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v6.09.02.Linux-centos7-x86_64-gcc4.8.tar.gz) | 143M |
-| Linux fedora22 gcc5.3 | [root_v6.09.02.Linux-fedora22-x86_64-gcc5.3.tar.gz](https://root.cern.ch/download/root_v6.09.02.Linux-fedora22-x86_64-gcc5.3.tar.gz) | 130M |
-| Linux fedora24 gcc6.1 | [root_v6.09.02.Linux-fedora24-x86_64-gcc6.1.tar.gz](https://root.cern.ch/download/root_v6.09.02.Linux-fedora24-x86_64-gcc6.1.tar.gz) | 110M |
-| Ubuntu 14 gcc4.8 | [root_v6.09.02.Linux-ubuntu14-x86_64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v6.09.02.Linux-ubuntu14-x86_64-gcc4.8.tar.gz) | 129M |
-| Ubuntu 16 gcc5.4 | [root_v6.09.02.Linux-ubuntu16-x86_64-gcc5.4.tar.gz](https://root.cern.ch/download/root_v6.09.02.Linux-ubuntu16-x86_64-gcc5.4.tar.gz) | 130M |
-| OsX 10.10 clang70 | [root_v6.09.02.macosx64-10.10-clang70.dmg](https://root.cern.ch/download/root_v6.09.02.macosx64-10.10-clang70.dmg) | 113M |
-| OsX 10.10 clang70 | [root_v6.09.02.macosx64-10.10-clang70.tar.gz](https://root.cern.ch/download/root_v6.09.02.macosx64-10.10-clang70.tar.gz) | 114M |
-| OsX 10.11 clang80 | [root_v6.09.02.macosx64-10.11-clang80.dmg](https://root.cern.ch/download/root_v6.09.02.macosx64-10.11-clang80.dmg) | 118M |
-| OsX 10.11 clang80 | [root_v6.09.02.macosx64-10.11-clang80.tar.gz](https://root.cern.ch/download/root_v6.09.02.macosx64-10.11-clang80.tar.gz) | 118M |
-| OsX 10.12 clang80 | [root_v6.09.02.macosx64-10.12-clang80.dmg](https://root.cern.ch/download/root_v6.09.02.macosx64-10.12-clang80.dmg) | 125M |
-| OsX 10.12 clang80 | [root_v6.09.02.macosx64-10.12-clang80.tar.gz](https://root.cern.ch/download/root_v6.09.02.macosx64-10.12-clang80.tar.gz) | 125M |
+| CentOS Cern 7 gcc4.8 | [root_v6.09.02.Linux-centos7-x86_64-gcc4.8.tar.gz](https://root.cern/download/root_v6.09.02.Linux-centos7-x86_64-gcc4.8.tar.gz) | 143M |
+| Linux fedora22 gcc5.3 | [root_v6.09.02.Linux-fedora22-x86_64-gcc5.3.tar.gz](https://root.cern/download/root_v6.09.02.Linux-fedora22-x86_64-gcc5.3.tar.gz) | 130M |
+| Linux fedora24 gcc6.1 | [root_v6.09.02.Linux-fedora24-x86_64-gcc6.1.tar.gz](https://root.cern/download/root_v6.09.02.Linux-fedora24-x86_64-gcc6.1.tar.gz) | 110M |
+| Ubuntu 14 gcc4.8 | [root_v6.09.02.Linux-ubuntu14-x86_64-gcc4.8.tar.gz](https://root.cern/download/root_v6.09.02.Linux-ubuntu14-x86_64-gcc4.8.tar.gz) | 129M |
+| Ubuntu 16 gcc5.4 | [root_v6.09.02.Linux-ubuntu16-x86_64-gcc5.4.tar.gz](https://root.cern/download/root_v6.09.02.Linux-ubuntu16-x86_64-gcc5.4.tar.gz) | 130M |
+| OsX 10.10 clang70 | [root_v6.09.02.macosx64-10.10-clang70.dmg](https://root.cern/download/root_v6.09.02.macosx64-10.10-clang70.dmg) | 113M |
+| OsX 10.10 clang70 | [root_v6.09.02.macosx64-10.10-clang70.tar.gz](https://root.cern/download/root_v6.09.02.macosx64-10.10-clang70.tar.gz) | 114M |
+| OsX 10.11 clang80 | [root_v6.09.02.macosx64-10.11-clang80.dmg](https://root.cern/download/root_v6.09.02.macosx64-10.11-clang80.dmg) | 118M |
+| OsX 10.11 clang80 | [root_v6.09.02.macosx64-10.11-clang80.tar.gz](https://root.cern/download/root_v6.09.02.macosx64-10.11-clang80.tar.gz) | 118M |
+| OsX 10.12 clang80 | [root_v6.09.02.macosx64-10.12-clang80.dmg](https://root.cern/download/root_v6.09.02.macosx64-10.12-clang80.dmg) | 125M |
+| OsX 10.12 clang80 | [root_v6.09.02.macosx64-10.12-clang80.tar.gz](https://root.cern/download/root_v6.09.02.macosx64-10.12-clang80.tar.gz) | 125M |
 
 
 
@@ -73,7 +73,7 @@ Standalone installations with minimal external dependencies are available at:
 The entire ROOT source can be obtained from our public Git repository:
 
 ~~~
-git clone http://root.cern.ch/git/root.git
+git clone http://root.cern/git/root.git
 ~~~
 The release specific tag can be obtained using:
 ~~~

--- a/_releases/release-61000.md
+++ b/_releases/release-61000.md
@@ -24,30 +24,30 @@ This is the first release of the 6.10 production series. It includes a number of
 
 ## Release Notes
 
-The release notes for this release can be found [here](https://root.cern.ch/doc/v610/release-notes.html).
+The release notes for this release can be found [here](https://root.cern/doc/v610/release-notes.html).
 
 ## Source distribution
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v6.10.00.source.tar.gz](https://root.cern.ch/download/root_v6.10.00.source.tar.gz) | 150M |
+| source | [root_v6.10.00.source.tar.gz](https://root.cern/download/root_v6.10.00.source.tar.gz) | 150M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| CentOS Cern 7 gcc4.8 | [root_v6.10.00.Linux-centos7-x86_64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v6.10.00.Linux-centos7-x86_64-gcc4.8.tar.gz) | 146M |
-| Linux fedora22 gcc5.3 | [root_v6.10.00.Linux-fedora22-x86_64-gcc5.3.tar.gz](https://root.cern.ch/download/root_v6.10.00.Linux-fedora22-x86_64-gcc5.3.tar.gz) | 133M |
-| Linux fedora24 gcc6.1 | [root_v6.10.00.Linux-fedora24-x86_64-gcc6.1.tar.gz](https://root.cern.ch/download/root_v6.10.00.Linux-fedora24-x86_64-gcc6.1.tar.gz) | 113M |
-| Ubuntu 14 gcc4.8 | [root_v6.10.00.Linux-ubuntu14-x86_64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v6.10.00.Linux-ubuntu14-x86_64-gcc4.8.tar.gz) | 131M |
-| Ubuntu 16 gcc5.4 | [root_v6.10.00.Linux-ubuntu16-x86_64-gcc5.4.tar.gz](https://root.cern.ch/download/root_v6.10.00.Linux-ubuntu16-x86_64-gcc5.4.tar.gz) | 133M |
-| OsX 10.10 clang70 | [root_v6.10.00.macosx64-10.10-clang70.dmg](https://root.cern.ch/download/root_v6.10.00.macosx64-10.10-clang70.dmg) | 115M |
-| OsX 10.10 clang70 | [root_v6.10.00.macosx64-10.10-clang70.tar.gz](https://root.cern.ch/download/root_v6.10.00.macosx64-10.10-clang70.tar.gz) | 116M |
-| OsX 10.11 clang80 | [root_v6.10.00.macosx64-10.11-clang80.dmg](https://root.cern.ch/download/root_v6.10.00.macosx64-10.11-clang80.dmg) | 120M |
-| OsX 10.11 clang80 | [root_v6.10.00.macosx64-10.11-clang80.tar.gz](https://root.cern.ch/download/root_v6.10.00.macosx64-10.11-clang80.tar.gz) | 120M |
-| OsX 10.12 clang80 | [root_v6.10.00.macosx64-10.12-clang80.dmg](https://root.cern.ch/download/root_v6.10.00.macosx64-10.12-clang80.dmg) | 123M |
-| OsX 10.12 clang80 | [root_v6.10.00.macosx64-10.12-clang80.tar.gz](https://root.cern.ch/download/root_v6.10.00.macosx64-10.12-clang80.tar.gz) | 123M |
+| CentOS Cern 7 gcc4.8 | [root_v6.10.00.Linux-centos7-x86_64-gcc4.8.tar.gz](https://root.cern/download/root_v6.10.00.Linux-centos7-x86_64-gcc4.8.tar.gz) | 146M |
+| Linux fedora22 gcc5.3 | [root_v6.10.00.Linux-fedora22-x86_64-gcc5.3.tar.gz](https://root.cern/download/root_v6.10.00.Linux-fedora22-x86_64-gcc5.3.tar.gz) | 133M |
+| Linux fedora24 gcc6.1 | [root_v6.10.00.Linux-fedora24-x86_64-gcc6.1.tar.gz](https://root.cern/download/root_v6.10.00.Linux-fedora24-x86_64-gcc6.1.tar.gz) | 113M |
+| Ubuntu 14 gcc4.8 | [root_v6.10.00.Linux-ubuntu14-x86_64-gcc4.8.tar.gz](https://root.cern/download/root_v6.10.00.Linux-ubuntu14-x86_64-gcc4.8.tar.gz) | 131M |
+| Ubuntu 16 gcc5.4 | [root_v6.10.00.Linux-ubuntu16-x86_64-gcc5.4.tar.gz](https://root.cern/download/root_v6.10.00.Linux-ubuntu16-x86_64-gcc5.4.tar.gz) | 133M |
+| OsX 10.10 clang70 | [root_v6.10.00.macosx64-10.10-clang70.dmg](https://root.cern/download/root_v6.10.00.macosx64-10.10-clang70.dmg) | 115M |
+| OsX 10.10 clang70 | [root_v6.10.00.macosx64-10.10-clang70.tar.gz](https://root.cern/download/root_v6.10.00.macosx64-10.10-clang70.tar.gz) | 116M |
+| OsX 10.11 clang80 | [root_v6.10.00.macosx64-10.11-clang80.dmg](https://root.cern/download/root_v6.10.00.macosx64-10.11-clang80.dmg) | 120M |
+| OsX 10.11 clang80 | [root_v6.10.00.macosx64-10.11-clang80.tar.gz](https://root.cern/download/root_v6.10.00.macosx64-10.11-clang80.tar.gz) | 120M |
+| OsX 10.12 clang80 | [root_v6.10.00.macosx64-10.12-clang80.dmg](https://root.cern/download/root_v6.10.00.macosx64-10.12-clang80.dmg) | 123M |
+| OsX 10.12 clang80 | [root_v6.10.00.macosx64-10.12-clang80.tar.gz](https://root.cern/download/root_v6.10.00.macosx64-10.12-clang80.tar.gz) | 123M |
 
 
 
@@ -78,7 +78,7 @@ Standalone installations with minimal external dependencies are available at:
 The entire ROOT source can be obtained from our public Git repository:
 
 ~~~
-git clone http://root.cern.ch/git/root.git
+git clone http://root.cern/git/root.git
 ~~~
 The release specific tag can be obtained using:
 ~~~

--- a/_releases/release-61002.md
+++ b/_releases/release-61002.md
@@ -13,30 +13,30 @@ sidebar:
 
 ## Release Notes
 
-The release notes for this release can be found [here](https://root.cern.ch/doc/v610/release-notes.html#release-6.1002).
+The release notes for this release can be found [here](https://root.cern/doc/v610/release-notes.html#release-6.1002).
 
 ## Source distribution
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v6.10.02.source.tar.gz](https://root.cern.ch/download/root_v6.10.02.source.tar.gz) | 150M |
+| source | [root_v6.10.02.source.tar.gz](https://root.cern/download/root_v6.10.02.source.tar.gz) | 150M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| CentOS Cern 7 gcc4.8 | [root_v6.10.02.Linux-centos7-x86_64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v6.10.02.Linux-centos7-x86_64-gcc4.8.tar.gz) | 146M |
-| Linux fedora22 gcc5.3 | [root_v6.10.02.Linux-fedora22-x86_64-gcc5.3.tar.gz](https://root.cern.ch/download/root_v6.10.02.Linux-fedora22-x86_64-gcc5.3.tar.gz) | 133M |
-| Linux fedora24 gcc6.1 | [root_v6.10.02.Linux-fedora24-x86_64-gcc6.1.tar.gz](https://root.cern.ch/download/root_v6.10.02.Linux-fedora24-x86_64-gcc6.1.tar.gz) | 113M |
-| Ubuntu 14 gcc4.8 | [root_v6.10.02.Linux-ubuntu14-x86_64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v6.10.02.Linux-ubuntu14-x86_64-gcc4.8.tar.gz) | 131M |
-| Ubuntu 16 gcc5.4 | [root_v6.10.02.Linux-ubuntu16-x86_64-gcc5.4.tar.gz](https://root.cern.ch/download/root_v6.10.02.Linux-ubuntu16-x86_64-gcc5.4.tar.gz) | 133M |
-| OsX 10.10 clang70 | [root_v6.10.02.macosx64-10.10-clang70.dmg](https://root.cern.ch/download/root_v6.10.02.macosx64-10.10-clang70.dmg) | 115M |
-| OsX 10.10 clang70 | [root_v6.10.02.macosx64-10.10-clang70.tar.gz](https://root.cern.ch/download/root_v6.10.02.macosx64-10.10-clang70.tar.gz) | 116M |
-| OsX 10.11 clang80 | [root_v6.10.02.macosx64-10.11-clang80.dmg](https://root.cern.ch/download/root_v6.10.02.macosx64-10.11-clang80.dmg) | 120M |
-| OsX 10.11 clang80 | [root_v6.10.02.macosx64-10.11-clang80.tar.gz](https://root.cern.ch/download/root_v6.10.02.macosx64-10.11-clang80.tar.gz) | 120M |
-| OsX 10.12 clang81 | [root_v6.10.02.macosx64-10.12-clang81.dmg](https://root.cern.ch/download/root_v6.10.02.macosx64-10.12-clang81.dmg) | 128M |
-| OsX 10.12 clang81 | [root_v6.10.02.macosx64-10.12-clang81.tar.gz](https://root.cern.ch/download/root_v6.10.02.macosx64-10.12-clang81.tar.gz) | 129M |
+| CentOS Cern 7 gcc4.8 | [root_v6.10.02.Linux-centos7-x86_64-gcc4.8.tar.gz](https://root.cern/download/root_v6.10.02.Linux-centos7-x86_64-gcc4.8.tar.gz) | 146M |
+| Linux fedora22 gcc5.3 | [root_v6.10.02.Linux-fedora22-x86_64-gcc5.3.tar.gz](https://root.cern/download/root_v6.10.02.Linux-fedora22-x86_64-gcc5.3.tar.gz) | 133M |
+| Linux fedora24 gcc6.1 | [root_v6.10.02.Linux-fedora24-x86_64-gcc6.1.tar.gz](https://root.cern/download/root_v6.10.02.Linux-fedora24-x86_64-gcc6.1.tar.gz) | 113M |
+| Ubuntu 14 gcc4.8 | [root_v6.10.02.Linux-ubuntu14-x86_64-gcc4.8.tar.gz](https://root.cern/download/root_v6.10.02.Linux-ubuntu14-x86_64-gcc4.8.tar.gz) | 131M |
+| Ubuntu 16 gcc5.4 | [root_v6.10.02.Linux-ubuntu16-x86_64-gcc5.4.tar.gz](https://root.cern/download/root_v6.10.02.Linux-ubuntu16-x86_64-gcc5.4.tar.gz) | 133M |
+| OsX 10.10 clang70 | [root_v6.10.02.macosx64-10.10-clang70.dmg](https://root.cern/download/root_v6.10.02.macosx64-10.10-clang70.dmg) | 115M |
+| OsX 10.10 clang70 | [root_v6.10.02.macosx64-10.10-clang70.tar.gz](https://root.cern/download/root_v6.10.02.macosx64-10.10-clang70.tar.gz) | 116M |
+| OsX 10.11 clang80 | [root_v6.10.02.macosx64-10.11-clang80.dmg](https://root.cern/download/root_v6.10.02.macosx64-10.11-clang80.dmg) | 120M |
+| OsX 10.11 clang80 | [root_v6.10.02.macosx64-10.11-clang80.tar.gz](https://root.cern/download/root_v6.10.02.macosx64-10.11-clang80.tar.gz) | 120M |
+| OsX 10.12 clang81 | [root_v6.10.02.macosx64-10.12-clang81.dmg](https://root.cern/download/root_v6.10.02.macosx64-10.12-clang81.dmg) | 128M |
+| OsX 10.12 clang81 | [root_v6.10.02.macosx64-10.12-clang81.tar.gz](https://root.cern/download/root_v6.10.02.macosx64-10.12-clang81.tar.gz) | 129M |
 
 
 
@@ -66,7 +66,7 @@ Standalone installations with minimal external dependencies are available at:
 The entire ROOT source can be obtained from our public Git repository:
 
 ~~~
-git clone http://root.cern.ch/git/root.git
+git clone http://root.cern/git/root.git
 ~~~
 The release specific tag can be obtained using:
 ~~~

--- a/_releases/release-61004.md
+++ b/_releases/release-61004.md
@@ -17,30 +17,30 @@ Bug fix release. See release notes to see what has been fixed.
 
 ## Release Notes
 
-The release notes for this release can be found [here](https://root.cern.ch/doc/v610/release-notes.html#release-6.1004).
+The release notes for this release can be found [here](https://root.cern/doc/v610/release-notes.html#release-6.1004).
 
 ## Source distribution
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v6.10.04.source.tar.gz](https://root.cern.ch/download/root_v6.10.04.source.tar.gz) | 150M |
+| source | [root_v6.10.04.source.tar.gz](https://root.cern/download/root_v6.10.04.source.tar.gz) | 150M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| CentOS Cern 7 gcc4.8 | [root_v6.10.04.Linux-centos7-x86_64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v6.10.04.Linux-centos7-x86_64-gcc4.8.tar.gz) | 146M |
-| Linux fedora22 gcc5.3 | [root_v6.10.04.Linux-fedora22-x86_64-gcc5.3.tar.gz](https://root.cern.ch/download/root_v6.10.04.Linux-fedora22-x86_64-gcc5.3.tar.gz) | 133M |
-| Linux fedora24 gcc6.1 | [root_v6.10.04.Linux-fedora24-x86_64-gcc6.1.tar.gz](https://root.cern.ch/download/root_v6.10.04.Linux-fedora24-x86_64-gcc6.1.tar.gz) | 114M |
-| Ubuntu 14 gcc4.8 | [root_v6.10.04.Linux-ubuntu14-x86_64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v6.10.04.Linux-ubuntu14-x86_64-gcc4.8.tar.gz) | 132M |
-| Ubuntu 16 gcc5.4 | [root_v6.10.04.Linux-ubuntu16-x86_64-gcc5.4.tar.gz](https://root.cern.ch/download/root_v6.10.04.Linux-ubuntu16-x86_64-gcc5.4.tar.gz) | 133M |
-| OsX 10.10 clang70 | [root_v6.10.04.macosx64-10.10-clang70.dmg](https://root.cern.ch/download/root_v6.10.04.macosx64-10.10-clang70.dmg) | 115M |
-| OsX 10.10 clang70 | [root_v6.10.04.macosx64-10.10-clang70.tar.gz](https://root.cern.ch/download/root_v6.10.04.macosx64-10.10-clang70.tar.gz) | 116M |
-| OsX 10.11 clang80 | [root_v6.10.04.macosx64-10.11-clang80.dmg](https://root.cern.ch/download/root_v6.10.04.macosx64-10.11-clang80.dmg) | 120M |
-| OsX 10.11 clang80 | [root_v6.10.04.macosx64-10.11-clang80.tar.gz](https://root.cern.ch/download/root_v6.10.04.macosx64-10.11-clang80.tar.gz) | 120M |
-| OsX 10.12 clang81 | [root_v6.10.04.macosx64-10.12-clang81.dmg](https://root.cern.ch/download/root_v6.10.04.macosx64-10.12-clang81.dmg) | 128M |
-| OsX 10.12 clang81 | [root_v6.10.04.macosx64-10.12-clang81.tar.gz](https://root.cern.ch/download/root_v6.10.04.macosx64-10.12-clang81.tar.gz) | 129M |
+| CentOS Cern 7 gcc4.8 | [root_v6.10.04.Linux-centos7-x86_64-gcc4.8.tar.gz](https://root.cern/download/root_v6.10.04.Linux-centos7-x86_64-gcc4.8.tar.gz) | 146M |
+| Linux fedora22 gcc5.3 | [root_v6.10.04.Linux-fedora22-x86_64-gcc5.3.tar.gz](https://root.cern/download/root_v6.10.04.Linux-fedora22-x86_64-gcc5.3.tar.gz) | 133M |
+| Linux fedora24 gcc6.1 | [root_v6.10.04.Linux-fedora24-x86_64-gcc6.1.tar.gz](https://root.cern/download/root_v6.10.04.Linux-fedora24-x86_64-gcc6.1.tar.gz) | 114M |
+| Ubuntu 14 gcc4.8 | [root_v6.10.04.Linux-ubuntu14-x86_64-gcc4.8.tar.gz](https://root.cern/download/root_v6.10.04.Linux-ubuntu14-x86_64-gcc4.8.tar.gz) | 132M |
+| Ubuntu 16 gcc5.4 | [root_v6.10.04.Linux-ubuntu16-x86_64-gcc5.4.tar.gz](https://root.cern/download/root_v6.10.04.Linux-ubuntu16-x86_64-gcc5.4.tar.gz) | 133M |
+| OsX 10.10 clang70 | [root_v6.10.04.macosx64-10.10-clang70.dmg](https://root.cern/download/root_v6.10.04.macosx64-10.10-clang70.dmg) | 115M |
+| OsX 10.10 clang70 | [root_v6.10.04.macosx64-10.10-clang70.tar.gz](https://root.cern/download/root_v6.10.04.macosx64-10.10-clang70.tar.gz) | 116M |
+| OsX 10.11 clang80 | [root_v6.10.04.macosx64-10.11-clang80.dmg](https://root.cern/download/root_v6.10.04.macosx64-10.11-clang80.dmg) | 120M |
+| OsX 10.11 clang80 | [root_v6.10.04.macosx64-10.11-clang80.tar.gz](https://root.cern/download/root_v6.10.04.macosx64-10.11-clang80.tar.gz) | 120M |
+| OsX 10.12 clang81 | [root_v6.10.04.macosx64-10.12-clang81.dmg](https://root.cern/download/root_v6.10.04.macosx64-10.12-clang81.dmg) | 128M |
+| OsX 10.12 clang81 | [root_v6.10.04.macosx64-10.12-clang81.tar.gz](https://root.cern/download/root_v6.10.04.macosx64-10.12-clang81.tar.gz) | 129M |
 
 
 

--- a/_releases/release-61006.md
+++ b/_releases/release-61006.md
@@ -13,30 +13,30 @@ sidebar:
 
 ## Release Notes
 
-The release notes for this release can be found [here](https://root.cern.ch/doc/v610/release-notes.html#release-6.1006).
+The release notes for this release can be found [here](https://root.cern/doc/v610/release-notes.html#release-6.1006).
 
 ## Source distribution
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v6.10.06.source.tar.gz](https://root.cern.ch/download/root_v6.10.06.source.tar.gz) | 150M |
+| source | [root_v6.10.06.source.tar.gz](https://root.cern/download/root_v6.10.06.source.tar.gz) | 150M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| CentOS Cern 7 gcc4.8 | [root_v6.10.06.Linux-centos7-x86_64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v6.10.06.Linux-centos7-x86_64-gcc4.8.tar.gz) | 124M |
-| Linux fedora22 gcc5.3 | [root_v6.10.06.Linux-fedora22-x86_64-gcc5.3.tar.gz](https://root.cern.ch/download/root_v6.10.06.Linux-fedora22-x86_64-gcc5.3.tar.gz) | 110M |
-| Linux fedora24 gcc6.1 | [root_v6.10.06.Linux-fedora24-x86_64-gcc6.1.tar.gz](https://root.cern.ch/download/root_v6.10.06.Linux-fedora24-x86_64-gcc6.1.tar.gz) | 107M |
-| Ubuntu 14 gcc4.8 | [root_v6.10.06.Linux-ubuntu14-x86_64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v6.10.06.Linux-ubuntu14-x86_64-gcc4.8.tar.gz) | 109M |
-| Ubuntu 16 gcc5.4 | [root_v6.10.06.Linux-ubuntu16-x86_64-gcc5.4.tar.gz](https://root.cern.ch/download/root_v6.10.06.Linux-ubuntu16-x86_64-gcc5.4.tar.gz) | 110M |
-| OsX 10.10 clang70 | [root_v6.10.06.macosx64-10.10-clang70.dmg](https://root.cern.ch/download/root_v6.10.06.macosx64-10.10-clang70.dmg) | 110M |
-| OsX 10.10 clang70 | [root_v6.10.06.macosx64-10.10-clang70.tar.gz](https://root.cern.ch/download/root_v6.10.06.macosx64-10.10-clang70.tar.gz) | 110M |
-| OsX 10.11 clang80 | [root_v6.10.06.macosx64-10.11-clang80.dmg](https://root.cern.ch/download/root_v6.10.06.macosx64-10.11-clang80.dmg) | 111M |
-| OsX 10.11 clang80 | [root_v6.10.06.macosx64-10.11-clang80.tar.gz](https://root.cern.ch/download/root_v6.10.06.macosx64-10.11-clang80.tar.gz) | 111M |
-| OsX 10.12 clang81 | [root_v6.10.06.macosx64-10.12-clang81.dmg](https://root.cern.ch/download/root_v6.10.06.macosx64-10.12-clang81.dmg) | 111M |
-| OsX 10.12 clang81 | [root_v6.10.06.macosx64-10.12-clang81.tar.gz](https://root.cern.ch/download/root_v6.10.06.macosx64-10.12-clang81.tar.gz) | 111M |
+| CentOS Cern 7 gcc4.8 | [root_v6.10.06.Linux-centos7-x86_64-gcc4.8.tar.gz](https://root.cern/download/root_v6.10.06.Linux-centos7-x86_64-gcc4.8.tar.gz) | 124M |
+| Linux fedora22 gcc5.3 | [root_v6.10.06.Linux-fedora22-x86_64-gcc5.3.tar.gz](https://root.cern/download/root_v6.10.06.Linux-fedora22-x86_64-gcc5.3.tar.gz) | 110M |
+| Linux fedora24 gcc6.1 | [root_v6.10.06.Linux-fedora24-x86_64-gcc6.1.tar.gz](https://root.cern/download/root_v6.10.06.Linux-fedora24-x86_64-gcc6.1.tar.gz) | 107M |
+| Ubuntu 14 gcc4.8 | [root_v6.10.06.Linux-ubuntu14-x86_64-gcc4.8.tar.gz](https://root.cern/download/root_v6.10.06.Linux-ubuntu14-x86_64-gcc4.8.tar.gz) | 109M |
+| Ubuntu 16 gcc5.4 | [root_v6.10.06.Linux-ubuntu16-x86_64-gcc5.4.tar.gz](https://root.cern/download/root_v6.10.06.Linux-ubuntu16-x86_64-gcc5.4.tar.gz) | 110M |
+| OsX 10.10 clang70 | [root_v6.10.06.macosx64-10.10-clang70.dmg](https://root.cern/download/root_v6.10.06.macosx64-10.10-clang70.dmg) | 110M |
+| OsX 10.10 clang70 | [root_v6.10.06.macosx64-10.10-clang70.tar.gz](https://root.cern/download/root_v6.10.06.macosx64-10.10-clang70.tar.gz) | 110M |
+| OsX 10.11 clang80 | [root_v6.10.06.macosx64-10.11-clang80.dmg](https://root.cern/download/root_v6.10.06.macosx64-10.11-clang80.dmg) | 111M |
+| OsX 10.11 clang80 | [root_v6.10.06.macosx64-10.11-clang80.tar.gz](https://root.cern/download/root_v6.10.06.macosx64-10.11-clang80.tar.gz) | 111M |
+| OsX 10.12 clang81 | [root_v6.10.06.macosx64-10.12-clang81.dmg](https://root.cern/download/root_v6.10.06.macosx64-10.12-clang81.dmg) | 111M |
+| OsX 10.12 clang81 | [root_v6.10.06.macosx64-10.12-clang81.tar.gz](https://root.cern/download/root_v6.10.06.macosx64-10.12-clang81.tar.gz) | 111M |
 
 
 

--- a/_releases/release-61008.md
+++ b/_releases/release-61008.md
@@ -17,30 +17,30 @@ sidebar:
 
 ## Release Notes
 
-The release notes for this release can be found [here](https://root.cern.ch/doc/v610/release-notes.html#release-6.1008).
+The release notes for this release can be found [here](https://root.cern/doc/v610/release-notes.html#release-6.1008).
 
 ## Source distribution
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v6.10.08.source.tar.gz](https://root.cern.ch/download/root_v6.10.08.source.tar.gz) | 150M |
+| source | [root_v6.10.08.source.tar.gz](https://root.cern/download/root_v6.10.08.source.tar.gz) | 150M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| CentOS Cern 7 gcc4.8 | [root_v6.10.08.Linux-centos7-x86_64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v6.10.08.Linux-centos7-x86_64-gcc4.8.tar.gz) | 124M |
-| Linux fedora22 gcc5.3 | [root_v6.10.08.Linux-fedora22-x86_64-gcc5.3.tar.gz](https://root.cern.ch/download/root_v6.10.08.Linux-fedora22-x86_64-gcc5.3.tar.gz) | 110M |
-| Linux fedora24 gcc6.1 | [root_v6.10.08.Linux-fedora24-x86_64-gcc6.1.tar.gz](https://root.cern.ch/download/root_v6.10.08.Linux-fedora24-x86_64-gcc6.1.tar.gz) | 107M |
-| Ubuntu 14 gcc4.8 | [root_v6.10.08.Linux-ubuntu14-x86_64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v6.10.08.Linux-ubuntu14-x86_64-gcc4.8.tar.gz) | 109M |
-| Ubuntu 16 gcc5.4 | [root_v6.10.08.Linux-ubuntu16-x86_64-gcc5.4.tar.gz](https://root.cern.ch/download/root_v6.10.08.Linux-ubuntu16-x86_64-gcc5.4.tar.gz) | 110M |
-| OsX 10.11 clang80 | [root_v6.10.08.macosx64-10.11-clang80.dmg](https://root.cern.ch/download/root_v6.10.08.macosx64-10.11-clang80.dmg) | 112M |
-| OsX 10.11 clang80 | [root_v6.10.08.macosx64-10.11-clang80.tar.gz](https://root.cern.ch/download/root_v6.10.08.macosx64-10.11-clang80.tar.gz) | 111M |
-| OsX 10.12 clang81 | [root_v6.10.08.macosx64-10.12-clang81.dmg](https://root.cern.ch/download/root_v6.10.08.macosx64-10.12-clang81.dmg) | 112M |
-| OsX 10.12 clang81 | [root_v6.10.08.macosx64-10.12-clang81.tar.gz](https://root.cern.ch/download/root_v6.10.08.macosx64-10.12-clang81.tar.gz) | 111M |
-| OsX 10.13 clang90 | [root_v6.10.08.macosx64-10.13-clang90.dmg](https://root.cern.ch/download/root_v6.10.08.macosx64-10.13-clang90.dmg) | 115M |
-| OsX 10.13 clang90 | [root_v6.10.08.macosx64-10.13-clang90.tar.gz](https://root.cern.ch/download/root_v6.10.08.macosx64-10.13-clang90.tar.gz) | 114M |
+| CentOS Cern 7 gcc4.8 | [root_v6.10.08.Linux-centos7-x86_64-gcc4.8.tar.gz](https://root.cern/download/root_v6.10.08.Linux-centos7-x86_64-gcc4.8.tar.gz) | 124M |
+| Linux fedora22 gcc5.3 | [root_v6.10.08.Linux-fedora22-x86_64-gcc5.3.tar.gz](https://root.cern/download/root_v6.10.08.Linux-fedora22-x86_64-gcc5.3.tar.gz) | 110M |
+| Linux fedora24 gcc6.1 | [root_v6.10.08.Linux-fedora24-x86_64-gcc6.1.tar.gz](https://root.cern/download/root_v6.10.08.Linux-fedora24-x86_64-gcc6.1.tar.gz) | 107M |
+| Ubuntu 14 gcc4.8 | [root_v6.10.08.Linux-ubuntu14-x86_64-gcc4.8.tar.gz](https://root.cern/download/root_v6.10.08.Linux-ubuntu14-x86_64-gcc4.8.tar.gz) | 109M |
+| Ubuntu 16 gcc5.4 | [root_v6.10.08.Linux-ubuntu16-x86_64-gcc5.4.tar.gz](https://root.cern/download/root_v6.10.08.Linux-ubuntu16-x86_64-gcc5.4.tar.gz) | 110M |
+| OsX 10.11 clang80 | [root_v6.10.08.macosx64-10.11-clang80.dmg](https://root.cern/download/root_v6.10.08.macosx64-10.11-clang80.dmg) | 112M |
+| OsX 10.11 clang80 | [root_v6.10.08.macosx64-10.11-clang80.tar.gz](https://root.cern/download/root_v6.10.08.macosx64-10.11-clang80.tar.gz) | 111M |
+| OsX 10.12 clang81 | [root_v6.10.08.macosx64-10.12-clang81.dmg](https://root.cern/download/root_v6.10.08.macosx64-10.12-clang81.dmg) | 112M |
+| OsX 10.12 clang81 | [root_v6.10.08.macosx64-10.12-clang81.tar.gz](https://root.cern/download/root_v6.10.08.macosx64-10.12-clang81.tar.gz) | 111M |
+| OsX 10.13 clang90 | [root_v6.10.08.macosx64-10.13-clang90.dmg](https://root.cern/download/root_v6.10.08.macosx64-10.13-clang90.dmg) | 115M |
+| OsX 10.13 clang90 | [root_v6.10.08.macosx64-10.13-clang90.tar.gz](https://root.cern/download/root_v6.10.08.macosx64-10.13-clang90.tar.gz) | 114M |
 
 
 

--- a/_releases/release-61102.md
+++ b/_releases/release-61102.md
@@ -25,7 +25,7 @@ These are some of the highlights of the new features you can find in ROOT 6.11/0
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v6.11.02.source.tar.gz](https://root.cern.ch/download/root_v6.11.02.source.tar.gz) | 153M |
+| source | [root_v6.11.02.source.tar.gz](https://root.cern/download/root_v6.11.02.source.tar.gz) | 153M |
 
 
 ## Binary distributions
@@ -34,13 +34,13 @@ Note that this release supports osx 10.13 and XCode9 only if built from sources.
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| CentOS Cern 7 gcc4.8 | [root_v6.11.02.Linux-centos7-x86_64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v6.11.02.Linux-centos7-x86_64-gcc4.8.tar.gz) | 130M |
-| Linux fedora22 gcc5.3 | [root_v6.11.02.Linux-fedora22-x86_64-gcc5.3.tar.gz](https://root.cern.ch/download/root_v6.11.02.Linux-fedora22-x86_64-gcc5.3.tar.gz) | 117M |
-| Ubuntu 16 gcc5.4 | [root_v6.11.02.Linux-ubuntu16-x86_64-gcc5.4.tar.gz](https://root.cern.ch/download/root_v6.11.02.Linux-ubuntu16-x86_64-gcc5.4.tar.gz) | 117M |
-| OsX 10.11 clang80 | [root_v6.11.02.macosx64-10.11-clang80.dmg](https://root.cern.ch/download/root_v6.11.02.macosx64-10.11-clang80.dmg) | 116M |
-| OsX 10.11 clang80 | [root_v6.11.02.macosx64-10.11-clang80.tar.gz](https://root.cern.ch/download/root_v6.11.02.macosx64-10.11-clang80.tar.gz) | 116M |
-| OsX 10.12 clang81 | [root_v6.11.02.macosx64-10.12-clang81.dmg](https://root.cern.ch/download/root_v6.11.02.macosx64-10.12-clang81.dmg) | 119M |
-| OsX 10.12 clang81 | [root_v6.11.02.macosx64-10.12-clang81.tar.gz](https://root.cern.ch/download/root_v6.11.02.macosx64-10.12-clang81.tar.gz) | 119M |
+| CentOS Cern 7 gcc4.8 | [root_v6.11.02.Linux-centos7-x86_64-gcc4.8.tar.gz](https://root.cern/download/root_v6.11.02.Linux-centos7-x86_64-gcc4.8.tar.gz) | 130M |
+| Linux fedora22 gcc5.3 | [root_v6.11.02.Linux-fedora22-x86_64-gcc5.3.tar.gz](https://root.cern/download/root_v6.11.02.Linux-fedora22-x86_64-gcc5.3.tar.gz) | 117M |
+| Ubuntu 16 gcc5.4 | [root_v6.11.02.Linux-ubuntu16-x86_64-gcc5.4.tar.gz](https://root.cern/download/root_v6.11.02.Linux-ubuntu16-x86_64-gcc5.4.tar.gz) | 117M |
+| OsX 10.11 clang80 | [root_v6.11.02.macosx64-10.11-clang80.dmg](https://root.cern/download/root_v6.11.02.macosx64-10.11-clang80.dmg) | 116M |
+| OsX 10.11 clang80 | [root_v6.11.02.macosx64-10.11-clang80.tar.gz](https://root.cern/download/root_v6.11.02.macosx64-10.11-clang80.tar.gz) | 116M |
+| OsX 10.12 clang81 | [root_v6.11.02.macosx64-10.12-clang81.dmg](https://root.cern/download/root_v6.11.02.macosx64-10.12-clang81.dmg) | 119M |
+| OsX 10.12 clang81 | [root_v6.11.02.macosx64-10.12-clang81.tar.gz](https://root.cern/download/root_v6.11.02.macosx64-10.12-clang81.tar.gz) | 119M |
 
 ## Installations in CVMFS
 

--- a/_releases/release-61204.md
+++ b/_releases/release-61204.md
@@ -33,28 +33,28 @@ For all details, see the release notes:
 
 ## Release Notes
 
-The release notes for this release can be found [here](https://root.cern.ch/doc/v612/release-notes.html#release-6.1204).
+The release notes for this release can be found [here](https://root.cern/doc/v612/release-notes.html#release-6.1204).
 
 ## Source distribution
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v6.12.04.source.tar.gz](https://root.cern.ch/download/root_v6.12.04.source.tar.gz) | 155M |
+| source | [root_v6.12.04.source.tar.gz](https://root.cern/download/root_v6.12.04.source.tar.gz) | 155M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| CentOS Cern 7 gcc4.8 | [root_v6.12.04.Linux-centos7-x86_64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v6.12.04.Linux-centos7-x86_64-gcc4.8.tar.gz) | 134M |
-| Linux fedora26 gcc7.2 | [root_v6.12.04.Linux-fedora26-x86_64-gcc7.2.tar.gz](https://root.cern.ch/download/root_v6.12.04.Linux-fedora26-x86_64-gcc7.2.tar.gz) | 121M |
-| Linux fedora27 gcc7.2 | [root_v6.12.04.Linux-fedora27-x86_64-gcc7.2.tar.gz](https://root.cern.ch/download/root_v6.12.04.Linux-fedora27-x86_64-gcc7.2.tar.gz) | 121M |
-| Ubuntu 14 gcc4.8 | [root_v6.12.04.Linux-ubuntu14-x86_64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v6.12.04.Linux-ubuntu14-x86_64-gcc4.8.tar.gz) | 119M |
-| Ubuntu 16 gcc5.4 | [root_v6.12.04.Linux-ubuntu16-x86_64-gcc5.4.tar.gz](https://root.cern.ch/download/root_v6.12.04.Linux-ubuntu16-x86_64-gcc5.4.tar.gz) | 121M |
-| OsX 10.12 clang90 | [root_v6.12.04.macosx64-10.12-clang90.dmg](https://root.cern.ch/download/root_v6.12.04.macosx64-10.12-clang90.dmg) | 125M |
-| OsX 10.12 clang90 | [root_v6.12.04.macosx64-10.12-clang90.tar.gz](https://root.cern.ch/download/root_v6.12.04.macosx64-10.12-clang90.tar.gz) | 125M |
-| OsX 10.13 clang90 | [root_v6.12.04.macosx64-10.13-clang90.dmg](https://root.cern.ch/download/root_v6.12.04.macosx64-10.13-clang90.dmg) | 123M |
-| OsX 10.13 clang90 | [root_v6.12.04.macosx64-10.13-clang90.tar.gz](https://root.cern.ch/download/root_v6.12.04.macosx64-10.13-clang90.tar.gz) | 123M |
+| CentOS Cern 7 gcc4.8 | [root_v6.12.04.Linux-centos7-x86_64-gcc4.8.tar.gz](https://root.cern/download/root_v6.12.04.Linux-centos7-x86_64-gcc4.8.tar.gz) | 134M |
+| Linux fedora26 gcc7.2 | [root_v6.12.04.Linux-fedora26-x86_64-gcc7.2.tar.gz](https://root.cern/download/root_v6.12.04.Linux-fedora26-x86_64-gcc7.2.tar.gz) | 121M |
+| Linux fedora27 gcc7.2 | [root_v6.12.04.Linux-fedora27-x86_64-gcc7.2.tar.gz](https://root.cern/download/root_v6.12.04.Linux-fedora27-x86_64-gcc7.2.tar.gz) | 121M |
+| Ubuntu 14 gcc4.8 | [root_v6.12.04.Linux-ubuntu14-x86_64-gcc4.8.tar.gz](https://root.cern/download/root_v6.12.04.Linux-ubuntu14-x86_64-gcc4.8.tar.gz) | 119M |
+| Ubuntu 16 gcc5.4 | [root_v6.12.04.Linux-ubuntu16-x86_64-gcc5.4.tar.gz](https://root.cern/download/root_v6.12.04.Linux-ubuntu16-x86_64-gcc5.4.tar.gz) | 121M |
+| OsX 10.12 clang90 | [root_v6.12.04.macosx64-10.12-clang90.dmg](https://root.cern/download/root_v6.12.04.macosx64-10.12-clang90.dmg) | 125M |
+| OsX 10.12 clang90 | [root_v6.12.04.macosx64-10.12-clang90.tar.gz](https://root.cern/download/root_v6.12.04.macosx64-10.12-clang90.tar.gz) | 125M |
+| OsX 10.13 clang90 | [root_v6.12.04.macosx64-10.13-clang90.dmg](https://root.cern/download/root_v6.12.04.macosx64-10.13-clang90.dmg) | 123M |
+| OsX 10.13 clang90 | [root_v6.12.04.macosx64-10.13-clang90.tar.gz](https://root.cern/download/root_v6.12.04.macosx64-10.13-clang90.tar.gz) | 123M |
 
 
 

--- a/_releases/release-61206.md
+++ b/_releases/release-61206.md
@@ -17,29 +17,29 @@ New: support for C++17 with GCC 7.3.
 
 ## Release Notes
 
-The release notes for this release can be found [here](https://root.cern.ch/doc/v612/release-notes.html#release-6.1206).
+The release notes for this release can be found [here](https://root.cern/doc/v612/release-notes.html#release-6.1206).
 
 ## Source distribution
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v6.12.06.source.tar.gz](https://root.cern.ch/download/root_v6.12.06.source.tar.gz) | 155M |
+| source | [root_v6.12.06.source.tar.gz](https://root.cern/download/root_v6.12.06.source.tar.gz) | 155M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| CentOS Cern 7 gcc4.8 | [root_v6.12.06.Linux-centos7-x86_64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v6.12.06.Linux-centos7-x86_64-gcc4.8.tar.gz) | 134M |
-| Linux fedora26 gcc7.2 | [root_v6.12.06.Linux-fedora26-x86_64-gcc7.2.tar.gz](https://root.cern.ch/download/root_v6.12.06.Linux-fedora26-x86_64-gcc7.2.tar.gz) | 121M |
-| Linux fedora27 gcc7.2 | [root_v6.12.06.Linux-fedora27-x86_64-gcc7.2.tar.gz](https://root.cern.ch/download/root_v6.12.06.Linux-fedora27-x86_64-gcc7.2.tar.gz) | 121M |
-| Ubuntu 14 gcc4.8 | [root_v6.12.06.Linux-ubuntu14-x86_64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v6.12.06.Linux-ubuntu14-x86_64-gcc4.8.tar.gz) | 120M |
-| Ubuntu 16 gcc5.4 | [root_v6.12.06.Linux-ubuntu16-x86_64-gcc5.4.tar.gz](https://root.cern.ch/download/root_v6.12.06.Linux-ubuntu16-x86_64-gcc5.4.tar.gz) | 121M |
-| Ubuntu 17 gcc7.2 | [root_v6.12.06.Linux-ubuntu17-x86_64-gcc7.2.tar.gz](https://root.cern.ch/download/root_v6.12.06.Linux-ubuntu17-x86_64-gcc7.2.tar.gz) | 126M |
-| OsX 10.12 clang90 | [root_v6.12.06.macosx64-10.12-clang90.dmg](https://root.cern.ch/download/root_v6.12.06.macosx64-10.12-clang90.dmg) | 125M |
-| OsX 10.12 clang90 | [root_v6.12.06.macosx64-10.12-clang90.tar.gz](https://root.cern.ch/download/root_v6.12.06.macosx64-10.12-clang90.tar.gz) | 125M |
-| OsX 10.13 clang90 | [root_v6.12.06.macosx64-10.13-clang90.dmg](https://root.cern.ch/download/root_v6.12.06.macosx64-10.13-clang90.dmg) | 127M |
-| OsX 10.13 clang90 | [root_v6.12.06.macosx64-10.13-clang90.tar.gz](https://root.cern.ch/download/root_v6.12.06.macosx64-10.13-clang90.tar.gz) | 125M |
+| CentOS Cern 7 gcc4.8 | [root_v6.12.06.Linux-centos7-x86_64-gcc4.8.tar.gz](https://root.cern/download/root_v6.12.06.Linux-centos7-x86_64-gcc4.8.tar.gz) | 134M |
+| Linux fedora26 gcc7.2 | [root_v6.12.06.Linux-fedora26-x86_64-gcc7.2.tar.gz](https://root.cern/download/root_v6.12.06.Linux-fedora26-x86_64-gcc7.2.tar.gz) | 121M |
+| Linux fedora27 gcc7.2 | [root_v6.12.06.Linux-fedora27-x86_64-gcc7.2.tar.gz](https://root.cern/download/root_v6.12.06.Linux-fedora27-x86_64-gcc7.2.tar.gz) | 121M |
+| Ubuntu 14 gcc4.8 | [root_v6.12.06.Linux-ubuntu14-x86_64-gcc4.8.tar.gz](https://root.cern/download/root_v6.12.06.Linux-ubuntu14-x86_64-gcc4.8.tar.gz) | 120M |
+| Ubuntu 16 gcc5.4 | [root_v6.12.06.Linux-ubuntu16-x86_64-gcc5.4.tar.gz](https://root.cern/download/root_v6.12.06.Linux-ubuntu16-x86_64-gcc5.4.tar.gz) | 121M |
+| Ubuntu 17 gcc7.2 | [root_v6.12.06.Linux-ubuntu17-x86_64-gcc7.2.tar.gz](https://root.cern/download/root_v6.12.06.Linux-ubuntu17-x86_64-gcc7.2.tar.gz) | 126M |
+| OsX 10.12 clang90 | [root_v6.12.06.macosx64-10.12-clang90.dmg](https://root.cern/download/root_v6.12.06.macosx64-10.12-clang90.dmg) | 125M |
+| OsX 10.12 clang90 | [root_v6.12.06.macosx64-10.12-clang90.tar.gz](https://root.cern/download/root_v6.12.06.macosx64-10.12-clang90.tar.gz) | 125M |
+| OsX 10.13 clang90 | [root_v6.12.06.macosx64-10.13-clang90.dmg](https://root.cern/download/root_v6.12.06.macosx64-10.13-clang90.dmg) | 127M |
+| OsX 10.13 clang90 | [root_v6.12.06.macosx64-10.13-clang90.tar.gz](https://root.cern/download/root_v6.12.06.macosx64-10.13-clang90.tar.gz) | 125M |
 
 
 

--- a/_releases/release-61302.md
+++ b/_releases/release-61302.md
@@ -29,23 +29,23 @@ sidebar:
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v6.13.02.source.tar.gz](https://root.cern.ch/download/root_v6.13.02.source.tar.gz) | 155M |
+| source | [root_v6.13.02.source.tar.gz](https://root.cern/download/root_v6.13.02.source.tar.gz) | 155M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| CentOS Cern 7 gcc4.8 | [root_v6.13.02.Linux-centos7-x86_64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v6.13.02.Linux-centos7-x86_64-gcc4.8.tar.gz) | 134M |
-| Linux fedora26 gcc7.2 | [root_v6.13.02.Linux-fedora26-x86_64-gcc7.2.tar.gz](https://root.cern.ch/download/root_v6.13.02.Linux-fedora26-x86_64-gcc7.2.tar.gz) | 122M |
-| Linux fedora27 gcc7.2 | [root_v6.13.02.Linux-fedora27-x86_64-gcc7.2.tar.gz](https://root.cern.ch/download/root_v6.13.02.Linux-fedora27-x86_64-gcc7.2.tar.gz) | 122M |
-| Ubuntu 14 gcc4.8 | [root_v6.13.02.Linux-ubuntu14-x86_64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v6.13.02.Linux-ubuntu14-x86_64-gcc4.8.tar.gz) | 120M |
-| Ubuntu 16 gcc5.4 | [root_v6.13.02.Linux-ubuntu16-x86_64-gcc5.4.tar.gz](https://root.cern.ch/download/root_v6.13.02.Linux-ubuntu16-x86_64-gcc5.4.tar.gz) | 121M |
-| Ubuntu 17 gcc7.2 | [root_v6.13.02.Linux-ubuntu17-x86_64-gcc7.2.tar.gz](https://root.cern.ch/download/root_v6.13.02.Linux-ubuntu17-x86_64-gcc7.2.tar.gz) | 127M |
-| OsX 10.12 clang90 | [root_v6.13.02.macosx64-10.12-clang90.dmg](https://root.cern.ch/download/root_v6.13.02.macosx64-10.12-clang90.dmg) | 125M |
-| OsX 10.12 clang90 | [root_v6.13.02.macosx64-10.12-clang90.tar.gz](https://root.cern.ch/download/root_v6.13.02.macosx64-10.12-clang90.tar.gz) | 126M |
-| OsX 10.13 clang90 | [root_v6.13.02.macosx64-10.13-clang90.dmg](https://root.cern.ch/download/root_v6.13.02.macosx64-10.13-clang90.dmg) | 125M |
-| OsX 10.13 clang90 | [root_v6.13.02.macosx64-10.13-clang90.tar.gz](https://root.cern.ch/download/root_v6.13.02.macosx64-10.13-clang90.tar.gz) | 126M |
+| CentOS Cern 7 gcc4.8 | [root_v6.13.02.Linux-centos7-x86_64-gcc4.8.tar.gz](https://root.cern/download/root_v6.13.02.Linux-centos7-x86_64-gcc4.8.tar.gz) | 134M |
+| Linux fedora26 gcc7.2 | [root_v6.13.02.Linux-fedora26-x86_64-gcc7.2.tar.gz](https://root.cern/download/root_v6.13.02.Linux-fedora26-x86_64-gcc7.2.tar.gz) | 122M |
+| Linux fedora27 gcc7.2 | [root_v6.13.02.Linux-fedora27-x86_64-gcc7.2.tar.gz](https://root.cern/download/root_v6.13.02.Linux-fedora27-x86_64-gcc7.2.tar.gz) | 122M |
+| Ubuntu 14 gcc4.8 | [root_v6.13.02.Linux-ubuntu14-x86_64-gcc4.8.tar.gz](https://root.cern/download/root_v6.13.02.Linux-ubuntu14-x86_64-gcc4.8.tar.gz) | 120M |
+| Ubuntu 16 gcc5.4 | [root_v6.13.02.Linux-ubuntu16-x86_64-gcc5.4.tar.gz](https://root.cern/download/root_v6.13.02.Linux-ubuntu16-x86_64-gcc5.4.tar.gz) | 121M |
+| Ubuntu 17 gcc7.2 | [root_v6.13.02.Linux-ubuntu17-x86_64-gcc7.2.tar.gz](https://root.cern/download/root_v6.13.02.Linux-ubuntu17-x86_64-gcc7.2.tar.gz) | 127M |
+| OsX 10.12 clang90 | [root_v6.13.02.macosx64-10.12-clang90.dmg](https://root.cern/download/root_v6.13.02.macosx64-10.12-clang90.dmg) | 125M |
+| OsX 10.12 clang90 | [root_v6.13.02.macosx64-10.12-clang90.tar.gz](https://root.cern/download/root_v6.13.02.macosx64-10.12-clang90.tar.gz) | 126M |
+| OsX 10.13 clang90 | [root_v6.13.02.macosx64-10.13-clang90.dmg](https://root.cern/download/root_v6.13.02.macosx64-10.13-clang90.dmg) | 125M |
+| OsX 10.13 clang90 | [root_v6.13.02.macosx64-10.13-clang90.tar.gz](https://root.cern/download/root_v6.13.02.macosx64-10.13-clang90.tar.gz) | 126M |
 
 
 

--- a/_releases/release-61304.md
+++ b/_releases/release-61304.md
@@ -15,17 +15,17 @@ sidebar:
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v6.13.04.source.tar.gz](https://root.cern.ch/download/root_v6.13.04.source.tar.gz) | 155M |
+| source | [root_v6.13.04.source.tar.gz](https://root.cern/download/root_v6.13.04.source.tar.gz) | 155M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| OsX 10.12 clang90 | [root_v6.13.04.macosx64-10.12-clang90.dmg](https://root.cern.ch/download/root_v6.13.04.macosx64-10.12-clang90.dmg) | 124M |
-| OsX 10.12 clang90 | [root_v6.13.04.macosx64-10.12-clang90.tar.gz](https://root.cern.ch/download/root_v6.13.04.macosx64-10.12-clang90.tar.gz) | 123M |
-| OsX 10.13 clang91 | [root_v6.13.04.macosx64-10.13-clang91.dmg](https://root.cern.ch/download/root_v6.13.04.macosx64-10.13-clang91.dmg) | 125M |
-| OsX 10.13 clang91 | [root_v6.13.04.macosx64-10.13-clang91.tar.gz](https://root.cern.ch/download/root_v6.13.04.macosx64-10.13-clang91.tar.gz) | 125M |
+| OsX 10.12 clang90 | [root_v6.13.04.macosx64-10.12-clang90.dmg](https://root.cern/download/root_v6.13.04.macosx64-10.12-clang90.dmg) | 124M |
+| OsX 10.12 clang90 | [root_v6.13.04.macosx64-10.12-clang90.tar.gz](https://root.cern/download/root_v6.13.04.macosx64-10.12-clang90.tar.gz) | 123M |
+| OsX 10.13 clang91 | [root_v6.13.04.macosx64-10.13-clang91.dmg](https://root.cern/download/root_v6.13.04.macosx64-10.13-clang91.dmg) | 125M |
+| OsX 10.13 clang91 | [root_v6.13.04.macosx64-10.13-clang91.tar.gz](https://root.cern/download/root_v6.13.04.macosx64-10.13-clang91.tar.gz) | 125M |
 
 
 ## Git

--- a/_releases/release-61306.md
+++ b/_releases/release-61306.md
@@ -15,17 +15,17 @@ sidebar:
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v6.13.06.source.tar.gz](https://root.cern.ch/download/root_v6.13.06.source.tar.gz) | 155M |
+| source | [root_v6.13.06.source.tar.gz](https://root.cern/download/root_v6.13.06.source.tar.gz) | 155M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| OsX 10.12 clang90 | [root_v6.13.06.macosx64-10.12-clang90.dmg](https://root.cern.ch/download/root_v6.13.06.macosx64-10.12-clang90.dmg) | 124M |
-| OsX 10.12 clang90 | [root_v6.13.06.macosx64-10.12-clang90.tar.gz](https://root.cern.ch/download/root_v6.13.06.macosx64-10.12-clang90.tar.gz) | 123M |
-| OsX 10.13 clang90 | [root_v6.13.06.macosx64-10.13-clang90.dmg](https://root.cern.ch/download/root_v6.13.06.macosx64-10.13-clang90.dmg) | 124M |
-| OsX 10.13 clang90 | [root_v6.13.06.macosx64-10.13-clang90.tar.gz](https://root.cern.ch/download/root_v6.13.06.macosx64-10.13-clang90.tar.gz) | 124M |
+| OsX 10.12 clang90 | [root_v6.13.06.macosx64-10.12-clang90.dmg](https://root.cern/download/root_v6.13.06.macosx64-10.12-clang90.dmg) | 124M |
+| OsX 10.12 clang90 | [root_v6.13.06.macosx64-10.12-clang90.tar.gz](https://root.cern/download/root_v6.13.06.macosx64-10.12-clang90.tar.gz) | 123M |
+| OsX 10.13 clang90 | [root_v6.13.06.macosx64-10.13-clang90.dmg](https://root.cern/download/root_v6.13.06.macosx64-10.13-clang90.dmg) | 124M |
+| OsX 10.13 clang90 | [root_v6.13.06.macosx64-10.13-clang90.tar.gz](https://root.cern/download/root_v6.13.06.macosx64-10.13-clang90.tar.gz) | 124M |
 
 
 ## Git

--- a/_releases/release-61308.md
+++ b/_releases/release-61308.md
@@ -14,27 +14,27 @@ sidebar:
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v6.13.08.source.tar.gz](https://root.cern.ch/download/root_v6.13.08.source.tar.gz) | 155M |
+| source | [root_v6.13.08.source.tar.gz](https://root.cern/download/root_v6.13.08.source.tar.gz) | 155M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| CentOS Cern 7 gcc4.8 | [root_v6.13.08.Linux-centos7-x86_64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v6.13.08.Linux-centos7-x86_64-gcc4.8.tar.gz) | 139M |
-| Linux fedora26 gcc7.2 | [root_v6.13.08.Linux-fedora26-x86_64-gcc7.2.tar.gz](https://root.cern.ch/download/root_v6.13.08.Linux-fedora26-x86_64-gcc7.2.tar.gz) | 126M |
-| Linux fedora27 gcc7.2 | [root_v6.13.08.Linux-fedora27-x86_64-gcc7.2.tar.gz](https://root.cern.ch/download/root_v6.13.08.Linux-fedora27-x86_64-gcc7.2.tar.gz) | 126M |
-| Linux fedora28 gcc8.0 | [root_v6.13.08.Linux-fedora28-x86_64-gcc8.0.tar.gz](https://root.cern.ch/download/root_v6.13.08.Linux-fedora28-x86_64-gcc8.0.tar.gz) | 125M |
-| Ubuntu 14 gcc4.8 | [root_v6.13.08.Linux-ubuntu14-x86_64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v6.13.08.Linux-ubuntu14-x86_64-gcc4.8.tar.gz) | 124M |
-| Ubuntu 16 gcc5.4 | [root_v6.13.08.Linux-ubuntu16-x86_64-gcc5.4.tar.gz](https://root.cern.ch/download/root_v6.13.08.Linux-ubuntu16-x86_64-gcc5.4.tar.gz) | 125M |
-| Ubuntu 17 gcc7.2 | [root_v6.13.08.Linux-ubuntu17-x86_64-gcc7.2.tar.gz](https://root.cern.ch/download/root_v6.13.08.Linux-ubuntu17-x86_64-gcc7.2.tar.gz) | 131M |
-| Ubuntu 18 gcc7.3 | [root_v6.13.08.Linux-ubuntu18-x86_64-gcc7.3.tar.gz](https://root.cern.ch/download/root_v6.13.08.Linux-ubuntu18-x86_64-gcc7.3.tar.gz) | 131M |
-| OsX 10.12 clang90 | [root_v6.13.08.macosx64-10.12-clang90.dmg](https://root.cern.ch/download/root_v6.13.08.macosx64-10.12-clang90.dmg) | 124M |
-| OsX 10.12 clang90 | [root_v6.13.08.macosx64-10.12-clang90.tar.gz](https://root.cern.ch/download/root_v6.13.08.macosx64-10.12-clang90.tar.gz) | 123M |
-| OsX 10.13 clang91 | [root_v6.13.08.macosx64-10.13-clang91.dmg](https://root.cern.ch/download/root_v6.13.08.macosx64-10.13-clang91.dmg) | 125M |
-| OsX 10.13 clang91 | [root_v6.13.08.macosx64-10.13-clang91.tar.gz](https://root.cern.ch/download/root_v6.13.08.macosx64-10.13-clang91.tar.gz) | 125M |
-| win32.vc15 (dbg) | [root_v6.13.08.win32.vc15.debug.zip](https://root.cern.ch/download/root_v6.13.08.win32.vc15.debug.zip) | 265M |
-| win32.vc15 | [root_v6.13.08.win32.vc15.zip](https://root.cern.ch/download/root_v6.13.08.win32.vc15.zip) |  95M |
+| CentOS Cern 7 gcc4.8 | [root_v6.13.08.Linux-centos7-x86_64-gcc4.8.tar.gz](https://root.cern/download/root_v6.13.08.Linux-centos7-x86_64-gcc4.8.tar.gz) | 139M |
+| Linux fedora26 gcc7.2 | [root_v6.13.08.Linux-fedora26-x86_64-gcc7.2.tar.gz](https://root.cern/download/root_v6.13.08.Linux-fedora26-x86_64-gcc7.2.tar.gz) | 126M |
+| Linux fedora27 gcc7.2 | [root_v6.13.08.Linux-fedora27-x86_64-gcc7.2.tar.gz](https://root.cern/download/root_v6.13.08.Linux-fedora27-x86_64-gcc7.2.tar.gz) | 126M |
+| Linux fedora28 gcc8.0 | [root_v6.13.08.Linux-fedora28-x86_64-gcc8.0.tar.gz](https://root.cern/download/root_v6.13.08.Linux-fedora28-x86_64-gcc8.0.tar.gz) | 125M |
+| Ubuntu 14 gcc4.8 | [root_v6.13.08.Linux-ubuntu14-x86_64-gcc4.8.tar.gz](https://root.cern/download/root_v6.13.08.Linux-ubuntu14-x86_64-gcc4.8.tar.gz) | 124M |
+| Ubuntu 16 gcc5.4 | [root_v6.13.08.Linux-ubuntu16-x86_64-gcc5.4.tar.gz](https://root.cern/download/root_v6.13.08.Linux-ubuntu16-x86_64-gcc5.4.tar.gz) | 125M |
+| Ubuntu 17 gcc7.2 | [root_v6.13.08.Linux-ubuntu17-x86_64-gcc7.2.tar.gz](https://root.cern/download/root_v6.13.08.Linux-ubuntu17-x86_64-gcc7.2.tar.gz) | 131M |
+| Ubuntu 18 gcc7.3 | [root_v6.13.08.Linux-ubuntu18-x86_64-gcc7.3.tar.gz](https://root.cern/download/root_v6.13.08.Linux-ubuntu18-x86_64-gcc7.3.tar.gz) | 131M |
+| OsX 10.12 clang90 | [root_v6.13.08.macosx64-10.12-clang90.dmg](https://root.cern/download/root_v6.13.08.macosx64-10.12-clang90.dmg) | 124M |
+| OsX 10.12 clang90 | [root_v6.13.08.macosx64-10.12-clang90.tar.gz](https://root.cern/download/root_v6.13.08.macosx64-10.12-clang90.tar.gz) | 123M |
+| OsX 10.13 clang91 | [root_v6.13.08.macosx64-10.13-clang91.dmg](https://root.cern/download/root_v6.13.08.macosx64-10.13-clang91.dmg) | 125M |
+| OsX 10.13 clang91 | [root_v6.13.08.macosx64-10.13-clang91.tar.gz](https://root.cern/download/root_v6.13.08.macosx64-10.13-clang91.tar.gz) | 125M |
+| win32.vc15 (dbg) | [root_v6.13.08.win32.vc15.debug.zip](https://root.cern/download/root_v6.13.08.win32.vc15.debug.zip) | 265M |
+| win32.vc15 | [root_v6.13.08.win32.vc15.zip](https://root.cern/download/root_v6.13.08.win32.vc15.zip) |  95M |
 
 
 

--- a/_releases/release-61400.md
+++ b/_releases/release-61400.md
@@ -12,41 +12,41 @@ sidebar:
 ## Highlights
 
 - LZ4 compression is now the default: it's blazingly fast when reading ROOT files!
-- [ROOT::RDataFrame](https://root.cern.ch/doc/master/group__tutorial__dataframe.html) is now the recommended way for analyzing trees: simple, expressive and parallel!
+- [ROOT::RDataFrame](https://root.cern/doc/master/group__tutorial__dataframe.html) is now the recommended way for analyzing trees: simple, expressive and parallel!
 - Windows is back!
 - ...and this release is dedicated to our *ROOT Workshop in Sarajevo, 10-13 September 2018*: [come and register!](https://cern.ch/root2018)
 
 ## Release Notes
 
-The release notes for this release can be found [here](https://root.cern.ch/doc/v614/release-notes.html).
+The release notes for this release can be found [here](https://root.cern/doc/v614/release-notes.html).
 
 ## Source distribution
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v6.14.00.source.tar.gz](https://root.cern.ch/download/root_v6.14.00.source.tar.gz) | 155M |
+| source | [root_v6.14.00.source.tar.gz](https://root.cern/download/root_v6.14.00.source.tar.gz) | 155M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| CentOS Cern 7 gcc4.8 | [root_v6.14.00.Linux-centos7-x86_64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v6.14.00.Linux-centos7-x86_64-gcc4.8.tar.gz) | 139M |
-| Linux fedora26 gcc7.2 | [root_v6.14.00.Linux-fedora26-x86_64-gcc7.2.tar.gz](https://root.cern.ch/download/root_v6.14.00.Linux-fedora26-x86_64-gcc7.2.tar.gz) | 127M |
-| Linux fedora27 gcc7.2 | [root_v6.14.00.Linux-fedora27-x86_64-gcc7.2.tar.gz](https://root.cern.ch/download/root_v6.14.00.Linux-fedora27-x86_64-gcc7.2.tar.gz) | 127M |
-| Linux fedora28 gcc8.0 | [root_v6.14.00.Linux-fedora28-x86_64-gcc8.0.tar.gz](https://root.cern.ch/download/root_v6.14.00.Linux-fedora28-x86_64-gcc8.0.tar.gz) | 126M |
-| Ubuntu 14 gcc4.8 | [root_v6.14.00.Linux-ubuntu14-x86_64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v6.14.00.Linux-ubuntu14-x86_64-gcc4.8.tar.gz) | 124M |
-| Ubuntu 16 gcc5.4 | [root_v6.14.00.Linux-ubuntu16-x86_64-gcc5.4.tar.gz](https://root.cern.ch/download/root_v6.14.00.Linux-ubuntu16-x86_64-gcc5.4.tar.gz) | 125M |
-| Ubuntu 17 gcc7.2 | [root_v6.14.00.Linux-ubuntu17-x86_64-gcc7.2.tar.gz](https://root.cern.ch/download/root_v6.14.00.Linux-ubuntu17-x86_64-gcc7.2.tar.gz) | 131M |
-| Ubuntu 18 gcc7.3 | [root_v6.14.00.Linux-ubuntu18-x86_64-gcc7.3.tar.gz](https://root.cern.ch/download/root_v6.14.00.Linux-ubuntu18-x86_64-gcc7.3.tar.gz) | 132M |
-| Mac OS X 10.12 clang90 | [root_v6.14.00.macosx64-10.12-clang90.dmg](https://root.cern.ch/download/root_v6.14.00.macosx64-10.12-clang90.dmg) | 124M |
-| Mac OS X 10.12 clang90 | [root_v6.14.00.macosx64-10.12-clang90.tar.gz](https://root.cern.ch/download/root_v6.14.00.macosx64-10.12-clang90.tar.gz) | 124M |
-| Mac OS X 10.13 clang91 | [root_v6.14.00.macosx64-10.13-clang91.dmg](https://root.cern.ch/download/root_v6.14.00.macosx64-10.13-clang91.dmg) | 126M |
-| Mac OS X 10.13 clang91 | [root_v6.14.00.macosx64-10.13-clang91.tar.gz](https://root.cern.ch/download/root_v6.14.00.macosx64-10.13-clang91.tar.gz) | 125M |
-| **preview** Windows Visual Studio 2017 (dbg) | [root_v6.14.00.win32.vc15.debug.exe](https://root.cern.ch/download/root_v6.14.00.win32.vc15.debug.exe) | 164M |
-| **preview** Windows Visual Studio 2017 (dbg) | [root_v6.14.00.win32.vc15.debug.zip](https://root.cern.ch/download/root_v6.14.00.win32.vc15.debug.zip) | 265M |
-| **preview** Windows Visual Studio 2017 | [root_v6.14.00.win32.vc15.exe](https://root.cern.ch/download/root_v6.14.00.win32.vc15.exe) |  70M |
-| **preview** Windows Visual Studio 2017 | [root_v6.14.00.win32.vc15.zip](https://root.cern.ch/download/root_v6.14.00.win32.vc15.zip) |  95M |
+| CentOS Cern 7 gcc4.8 | [root_v6.14.00.Linux-centos7-x86_64-gcc4.8.tar.gz](https://root.cern/download/root_v6.14.00.Linux-centos7-x86_64-gcc4.8.tar.gz) | 139M |
+| Linux fedora26 gcc7.2 | [root_v6.14.00.Linux-fedora26-x86_64-gcc7.2.tar.gz](https://root.cern/download/root_v6.14.00.Linux-fedora26-x86_64-gcc7.2.tar.gz) | 127M |
+| Linux fedora27 gcc7.2 | [root_v6.14.00.Linux-fedora27-x86_64-gcc7.2.tar.gz](https://root.cern/download/root_v6.14.00.Linux-fedora27-x86_64-gcc7.2.tar.gz) | 127M |
+| Linux fedora28 gcc8.0 | [root_v6.14.00.Linux-fedora28-x86_64-gcc8.0.tar.gz](https://root.cern/download/root_v6.14.00.Linux-fedora28-x86_64-gcc8.0.tar.gz) | 126M |
+| Ubuntu 14 gcc4.8 | [root_v6.14.00.Linux-ubuntu14-x86_64-gcc4.8.tar.gz](https://root.cern/download/root_v6.14.00.Linux-ubuntu14-x86_64-gcc4.8.tar.gz) | 124M |
+| Ubuntu 16 gcc5.4 | [root_v6.14.00.Linux-ubuntu16-x86_64-gcc5.4.tar.gz](https://root.cern/download/root_v6.14.00.Linux-ubuntu16-x86_64-gcc5.4.tar.gz) | 125M |
+| Ubuntu 17 gcc7.2 | [root_v6.14.00.Linux-ubuntu17-x86_64-gcc7.2.tar.gz](https://root.cern/download/root_v6.14.00.Linux-ubuntu17-x86_64-gcc7.2.tar.gz) | 131M |
+| Ubuntu 18 gcc7.3 | [root_v6.14.00.Linux-ubuntu18-x86_64-gcc7.3.tar.gz](https://root.cern/download/root_v6.14.00.Linux-ubuntu18-x86_64-gcc7.3.tar.gz) | 132M |
+| Mac OS X 10.12 clang90 | [root_v6.14.00.macosx64-10.12-clang90.dmg](https://root.cern/download/root_v6.14.00.macosx64-10.12-clang90.dmg) | 124M |
+| Mac OS X 10.12 clang90 | [root_v6.14.00.macosx64-10.12-clang90.tar.gz](https://root.cern/download/root_v6.14.00.macosx64-10.12-clang90.tar.gz) | 124M |
+| Mac OS X 10.13 clang91 | [root_v6.14.00.macosx64-10.13-clang91.dmg](https://root.cern/download/root_v6.14.00.macosx64-10.13-clang91.dmg) | 126M |
+| Mac OS X 10.13 clang91 | [root_v6.14.00.macosx64-10.13-clang91.tar.gz](https://root.cern/download/root_v6.14.00.macosx64-10.13-clang91.tar.gz) | 125M |
+| **preview** Windows Visual Studio 2017 (dbg) | [root_v6.14.00.win32.vc15.debug.exe](https://root.cern/download/root_v6.14.00.win32.vc15.debug.exe) | 164M |
+| **preview** Windows Visual Studio 2017 (dbg) | [root_v6.14.00.win32.vc15.debug.zip](https://root.cern/download/root_v6.14.00.win32.vc15.debug.zip) | 265M |
+| **preview** Windows Visual Studio 2017 | [root_v6.14.00.win32.vc15.exe](https://root.cern/download/root_v6.14.00.win32.vc15.exe) |  70M |
+| **preview** Windows Visual Studio 2017 | [root_v6.14.00.win32.vc15.zip](https://root.cern/download/root_v6.14.00.win32.vc15.zip) |  95M |
 
 
 

--- a/_releases/release-61402.md
+++ b/_releases/release-61402.md
@@ -16,35 +16,35 @@ This is the first bug-fix release for the v6.14 release series. It fixes a coupl
 
 ## Release Notes
 
-The release notes for this release can be found [here](https://root.cern.ch/doc/v614/release-notes.html#release-6.1402).
+The release notes for this release can be found [here](https://root.cern/doc/v614/release-notes.html#release-6.1402).
 
 ## Source distribution
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v6.14.02.source.tar.gz](https://root.cern.ch/download/root_v6.14.02.source.tar.gz) | 155M |
+| source | [root_v6.14.02.source.tar.gz](https://root.cern/download/root_v6.14.02.source.tar.gz) | 155M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| CentOS Cern 7 gcc4.8 | [root_v6.14.02.Linux-centos7-x86_64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v6.14.02.Linux-centos7-x86_64-gcc4.8.tar.gz) | 140M |
-| Linux fedora26 gcc7.2 | [root_v6.14.02.Linux-fedora26-x86_64-gcc7.2.tar.gz](https://root.cern.ch/download/root_v6.14.02.Linux-fedora26-x86_64-gcc7.2.tar.gz) | 128M |
-| Linux fedora27 gcc7.2 | [root_v6.14.02.Linux-fedora27-x86_64-gcc7.2.tar.gz](https://root.cern.ch/download/root_v6.14.02.Linux-fedora27-x86_64-gcc7.2.tar.gz) | 128M |
-| Linux fedora28 gcc8.1 | [root_v6.14.02.Linux-fedora28-x86_64-gcc8.1.tar.gz](https://root.cern.ch/download/root_v6.14.02.Linux-fedora28-x86_64-gcc8.1.tar.gz) | 127M |
-| Ubuntu 14 gcc4.8 | [root_v6.14.02.Linux-ubuntu14-x86_64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v6.14.02.Linux-ubuntu14-x86_64-gcc4.8.tar.gz) | 125M |
-| Ubuntu 16 gcc5.4 | [root_v6.14.02.Linux-ubuntu16-x86_64-gcc5.4.tar.gz](https://root.cern.ch/download/root_v6.14.02.Linux-ubuntu16-x86_64-gcc5.4.tar.gz) | 127M |
-| Ubuntu 17 gcc7.2 | [root_v6.14.02.Linux-ubuntu17-x86_64-gcc7.2.tar.gz](https://root.cern.ch/download/root_v6.14.02.Linux-ubuntu17-x86_64-gcc7.2.tar.gz) | 132M |
-| Ubuntu 18 gcc7.3 | [root_v6.14.02.Linux-ubuntu18-x86_64-gcc7.3.tar.gz](https://root.cern.ch/download/root_v6.14.02.Linux-ubuntu18-x86_64-gcc7.3.tar.gz) | 133M |
-| OsX 10.12 clang90 | [root_v6.14.02.macosx64-10.12-clang90.dmg](https://root.cern.ch/download/root_v6.14.02.macosx64-10.12-clang90.dmg) | 126M |
-| OsX 10.12 clang90 | [root_v6.14.02.macosx64-10.12-clang90.tar.gz](https://root.cern.ch/download/root_v6.14.02.macosx64-10.12-clang90.tar.gz) | 125M |
-| OsX 10.13 clang91 | [root_v6.14.02.macosx64-10.13-clang91.dmg](https://root.cern.ch/download/root_v6.14.02.macosx64-10.13-clang91.dmg) | 127M |
-| OsX 10.13 clang91 | [root_v6.14.02.macosx64-10.13-clang91.tar.gz](https://root.cern.ch/download/root_v6.14.02.macosx64-10.13-clang91.tar.gz) | 126M |
-| **preview** Windows Visual Studio 2017 (dbg) | [root_v6.14.02.win32.vc15.debug.exe](https://root.cern.ch/download/root_v6.14.02.win32.vc15.debug.exe) | 167M |
-| **preview** Windows Visual Studio 2017 (dbg) | [root_v6.14.02.win32.vc15.debug.zip](https://root.cern.ch/download/root_v6.14.02.win32.vc15.debug.zip) | 271M |
-| **preview** Windows Visual Studio 2017 | [root_v6.14.02.win32.vc15.exe](https://root.cern.ch/download/root_v6.14.02.win32.vc15.exe) |  73M |
-| **preview** Windows Visual Studio 2017 | [root_v6.14.02.win32.vc15.zip](https://root.cern.ch/download/root_v6.14.02.win32.vc15.zip) |  98M |
+| CentOS Cern 7 gcc4.8 | [root_v6.14.02.Linux-centos7-x86_64-gcc4.8.tar.gz](https://root.cern/download/root_v6.14.02.Linux-centos7-x86_64-gcc4.8.tar.gz) | 140M |
+| Linux fedora26 gcc7.2 | [root_v6.14.02.Linux-fedora26-x86_64-gcc7.2.tar.gz](https://root.cern/download/root_v6.14.02.Linux-fedora26-x86_64-gcc7.2.tar.gz) | 128M |
+| Linux fedora27 gcc7.2 | [root_v6.14.02.Linux-fedora27-x86_64-gcc7.2.tar.gz](https://root.cern/download/root_v6.14.02.Linux-fedora27-x86_64-gcc7.2.tar.gz) | 128M |
+| Linux fedora28 gcc8.1 | [root_v6.14.02.Linux-fedora28-x86_64-gcc8.1.tar.gz](https://root.cern/download/root_v6.14.02.Linux-fedora28-x86_64-gcc8.1.tar.gz) | 127M |
+| Ubuntu 14 gcc4.8 | [root_v6.14.02.Linux-ubuntu14-x86_64-gcc4.8.tar.gz](https://root.cern/download/root_v6.14.02.Linux-ubuntu14-x86_64-gcc4.8.tar.gz) | 125M |
+| Ubuntu 16 gcc5.4 | [root_v6.14.02.Linux-ubuntu16-x86_64-gcc5.4.tar.gz](https://root.cern/download/root_v6.14.02.Linux-ubuntu16-x86_64-gcc5.4.tar.gz) | 127M |
+| Ubuntu 17 gcc7.2 | [root_v6.14.02.Linux-ubuntu17-x86_64-gcc7.2.tar.gz](https://root.cern/download/root_v6.14.02.Linux-ubuntu17-x86_64-gcc7.2.tar.gz) | 132M |
+| Ubuntu 18 gcc7.3 | [root_v6.14.02.Linux-ubuntu18-x86_64-gcc7.3.tar.gz](https://root.cern/download/root_v6.14.02.Linux-ubuntu18-x86_64-gcc7.3.tar.gz) | 133M |
+| OsX 10.12 clang90 | [root_v6.14.02.macosx64-10.12-clang90.dmg](https://root.cern/download/root_v6.14.02.macosx64-10.12-clang90.dmg) | 126M |
+| OsX 10.12 clang90 | [root_v6.14.02.macosx64-10.12-clang90.tar.gz](https://root.cern/download/root_v6.14.02.macosx64-10.12-clang90.tar.gz) | 125M |
+| OsX 10.13 clang91 | [root_v6.14.02.macosx64-10.13-clang91.dmg](https://root.cern/download/root_v6.14.02.macosx64-10.13-clang91.dmg) | 127M |
+| OsX 10.13 clang91 | [root_v6.14.02.macosx64-10.13-clang91.tar.gz](https://root.cern/download/root_v6.14.02.macosx64-10.13-clang91.tar.gz) | 126M |
+| **preview** Windows Visual Studio 2017 (dbg) | [root_v6.14.02.win32.vc15.debug.exe](https://root.cern/download/root_v6.14.02.win32.vc15.debug.exe) | 167M |
+| **preview** Windows Visual Studio 2017 (dbg) | [root_v6.14.02.win32.vc15.debug.zip](https://root.cern/download/root_v6.14.02.win32.vc15.debug.zip) | 271M |
+| **preview** Windows Visual Studio 2017 | [root_v6.14.02.win32.vc15.exe](https://root.cern/download/root_v6.14.02.win32.vc15.exe) |  73M |
+| **preview** Windows Visual Studio 2017 | [root_v6.14.02.win32.vc15.zip](https://root.cern/download/root_v6.14.02.win32.vc15.zip) |  98M |
 
 
 

--- a/_releases/release-61404.md
+++ b/_releases/release-61404.md
@@ -17,35 +17,35 @@ We have seen branch data that LZ4 did not compress well; until those cases are o
 
 ## Release Notes
 
-The release notes for this release can be found [here](https://root.cern.ch/doc/v614/release-notes.html#release-6.1404).
+The release notes for this release can be found [here](https://root.cern/doc/v614/release-notes.html#release-6.1404).
 
 ## Source distribution
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v6.14.04.source.tar.gz](https://root.cern.ch/download/root_v6.14.04.source.tar.gz) | 155M |
+| source | [root_v6.14.04.source.tar.gz](https://root.cern/download/root_v6.14.04.source.tar.gz) | 155M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| CentOS Cern 7 gcc4.8 | [root_v6.14.04.Linux-centos7-x86_64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v6.14.04.Linux-centos7-x86_64-gcc4.8.tar.gz) | 141M |
-| Linux fedora26 gcc7.2 | [root_v6.14.04.Linux-fedora26-x86_64-gcc7.2.tar.gz](https://root.cern.ch/download/root_v6.14.04.Linux-fedora26-x86_64-gcc7.2.tar.gz) | 128M |
-| Linux fedora27 gcc7.2 | [root_v6.14.04.Linux-fedora27-x86_64-gcc7.2.tar.gz](https://root.cern.ch/download/root_v6.14.04.Linux-fedora27-x86_64-gcc7.2.tar.gz) | 128M |
-| Linux fedora28 gcc8.1 | [root_v6.14.04.Linux-fedora28-x86_64-gcc8.1.tar.gz](https://root.cern.ch/download/root_v6.14.04.Linux-fedora28-x86_64-gcc8.1.tar.gz) | 127M |
-| Ubuntu 14 gcc4.8 | [root_v6.14.04.Linux-ubuntu14-x86_64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v6.14.04.Linux-ubuntu14-x86_64-gcc4.8.tar.gz) | 125M |
-| Ubuntu 16 gcc5.4 | [root_v6.14.04.Linux-ubuntu16-x86_64-gcc5.4.tar.gz](https://root.cern.ch/download/root_v6.14.04.Linux-ubuntu16-x86_64-gcc5.4.tar.gz) | 127M |
-| Ubuntu 17 gcc7.2 | [root_v6.14.04.Linux-ubuntu17-x86_64-gcc7.2.tar.gz](https://root.cern.ch/download/root_v6.14.04.Linux-ubuntu17-x86_64-gcc7.2.tar.gz) | 133M |
-| Ubuntu 18 gcc7.3 | [root_v6.14.04.Linux-ubuntu18-x86_64-gcc7.3.tar.gz](https://root.cern.ch/download/root_v6.14.04.Linux-ubuntu18-x86_64-gcc7.3.tar.gz) | 133M |
-| OsX 10.12 clang90 | [root_v6.14.04.macosx64-10.12-clang90.dmg](https://root.cern.ch/download/root_v6.14.04.macosx64-10.12-clang90.dmg) | 126M |
-| OsX 10.12 clang90 | [root_v6.14.04.macosx64-10.12-clang90.tar.gz](https://root.cern.ch/download/root_v6.14.04.macosx64-10.12-clang90.tar.gz) | 125M |
-| OsX 10.13 clang91 | [root_v6.14.04.macosx64-10.13-clang91.dmg](https://root.cern.ch/download/root_v6.14.04.macosx64-10.13-clang91.dmg) | 126M |
-| OsX 10.13 clang91 | [root_v6.14.04.macosx64-10.13-clang91.tar.gz](https://root.cern.ch/download/root_v6.14.04.macosx64-10.13-clang91.tar.gz) | 126M |
-| **preview** Windows Visual Studio 2017 (dbg) | [root_v6.14.04.win32.vc15.debug.exe](https://root.cern.ch/download/root_v6.14.04.win32.vc15.debug.exe) | 181M |
-| **preview** Windows Visual Studio 2017 (dbg) | [root_v6.14.04.win32.vc15.debug.zip](https://root.cern.ch/download/root_v6.14.04.win32.vc15.debug.zip) | 294M |
-| **preview** Windows Visual Studio 2017 | [root_v6.14.04.win32.vc15.exe](https://root.cern.ch/download/root_v6.14.04.win32.vc15.exe) |  79M |
-| **preview** Windows Visual Studio 2017 | [root_v6.14.04.win32.vc15.zip](https://root.cern.ch/download/root_v6.14.04.win32.vc15.zip) |  108M |
+| CentOS Cern 7 gcc4.8 | [root_v6.14.04.Linux-centos7-x86_64-gcc4.8.tar.gz](https://root.cern/download/root_v6.14.04.Linux-centos7-x86_64-gcc4.8.tar.gz) | 141M |
+| Linux fedora26 gcc7.2 | [root_v6.14.04.Linux-fedora26-x86_64-gcc7.2.tar.gz](https://root.cern/download/root_v6.14.04.Linux-fedora26-x86_64-gcc7.2.tar.gz) | 128M |
+| Linux fedora27 gcc7.2 | [root_v6.14.04.Linux-fedora27-x86_64-gcc7.2.tar.gz](https://root.cern/download/root_v6.14.04.Linux-fedora27-x86_64-gcc7.2.tar.gz) | 128M |
+| Linux fedora28 gcc8.1 | [root_v6.14.04.Linux-fedora28-x86_64-gcc8.1.tar.gz](https://root.cern/download/root_v6.14.04.Linux-fedora28-x86_64-gcc8.1.tar.gz) | 127M |
+| Ubuntu 14 gcc4.8 | [root_v6.14.04.Linux-ubuntu14-x86_64-gcc4.8.tar.gz](https://root.cern/download/root_v6.14.04.Linux-ubuntu14-x86_64-gcc4.8.tar.gz) | 125M |
+| Ubuntu 16 gcc5.4 | [root_v6.14.04.Linux-ubuntu16-x86_64-gcc5.4.tar.gz](https://root.cern/download/root_v6.14.04.Linux-ubuntu16-x86_64-gcc5.4.tar.gz) | 127M |
+| Ubuntu 17 gcc7.2 | [root_v6.14.04.Linux-ubuntu17-x86_64-gcc7.2.tar.gz](https://root.cern/download/root_v6.14.04.Linux-ubuntu17-x86_64-gcc7.2.tar.gz) | 133M |
+| Ubuntu 18 gcc7.3 | [root_v6.14.04.Linux-ubuntu18-x86_64-gcc7.3.tar.gz](https://root.cern/download/root_v6.14.04.Linux-ubuntu18-x86_64-gcc7.3.tar.gz) | 133M |
+| OsX 10.12 clang90 | [root_v6.14.04.macosx64-10.12-clang90.dmg](https://root.cern/download/root_v6.14.04.macosx64-10.12-clang90.dmg) | 126M |
+| OsX 10.12 clang90 | [root_v6.14.04.macosx64-10.12-clang90.tar.gz](https://root.cern/download/root_v6.14.04.macosx64-10.12-clang90.tar.gz) | 125M |
+| OsX 10.13 clang91 | [root_v6.14.04.macosx64-10.13-clang91.dmg](https://root.cern/download/root_v6.14.04.macosx64-10.13-clang91.dmg) | 126M |
+| OsX 10.13 clang91 | [root_v6.14.04.macosx64-10.13-clang91.tar.gz](https://root.cern/download/root_v6.14.04.macosx64-10.13-clang91.tar.gz) | 126M |
+| **preview** Windows Visual Studio 2017 (dbg) | [root_v6.14.04.win32.vc15.debug.exe](https://root.cern/download/root_v6.14.04.win32.vc15.debug.exe) | 181M |
+| **preview** Windows Visual Studio 2017 (dbg) | [root_v6.14.04.win32.vc15.debug.zip](https://root.cern/download/root_v6.14.04.win32.vc15.debug.zip) | 294M |
+| **preview** Windows Visual Studio 2017 | [root_v6.14.04.win32.vc15.exe](https://root.cern/download/root_v6.14.04.win32.vc15.exe) |  79M |
+| **preview** Windows Visual Studio 2017 | [root_v6.14.04.win32.vc15.zip](https://root.cern/download/root_v6.14.04.win32.vc15.zip) |  108M |
 
 
 

--- a/_releases/release-61406.md
+++ b/_releases/release-61406.md
@@ -16,35 +16,35 @@ MacOS 10.14 / Xcode 10 is now supported, and several bugs have been fixed.
 
 ## Release Notes
 
-The release notes for this release can be found [here](https://root.cern.ch/doc/v614/release-notes.html#release-6.1406).
+The release notes for this release can be found [here](https://root.cern/doc/v614/release-notes.html#release-6.1406).
 
 ## Source distribution
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| source | [root_v6.14.06.source.tar.gz](https://root.cern.ch/download/root_v6.14.06.source.tar.gz) | 155M |
+| source | [root_v6.14.06.source.tar.gz](https://root.cern/download/root_v6.14.06.source.tar.gz) | 155M |
 
 
 ## Binary distributions
 
 | Platform       | Files | Size |
 |-----------|-------|-----|
-| CentOS Cern 7 gcc4.8 | [root_v6.14.06.Linux-centos7-x86_64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v6.14.06.Linux-centos7-x86_64-gcc4.8.tar.gz) | 141M |
-| Linux fedora27 gcc7.3 | [root_v6.14.06.Linux-fedora27-x86_64-gcc7.3.tar.gz](https://root.cern.ch/download/root_v6.14.06.Linux-fedora27-x86_64-gcc7.3.tar.gz) | 132M |
-| Linux fedora28 gcc8.2 | [root_v6.14.06.Linux-fedora28-x86_64-gcc8.2.tar.gz](https://root.cern.ch/download/root_v6.14.06.Linux-fedora28-x86_64-gcc8.2.tar.gz) | 131M |
-| Ubuntu 14 gcc4.8 | [root_v6.14.06.Linux-ubuntu14-x86_64-gcc4.8.tar.gz](https://root.cern.ch/download/root_v6.14.06.Linux-ubuntu14-x86_64-gcc4.8.tar.gz) | 141M |
-| Ubuntu 16 gcc5.4 | [root_v6.14.06.Linux-ubuntu16-x86_64-gcc5.4.tar.gz](https://root.cern.ch/download/root_v6.14.06.Linux-ubuntu16-x86_64-gcc5.4.tar.gz) | 142M |
-| Ubuntu 18 gcc7.3 | [root_v6.14.06.Linux-ubuntu18-x86_64-gcc7.3.tar.gz](https://root.cern.ch/download/root_v6.14.06.Linux-ubuntu18-x86_64-gcc7.3.tar.gz) | 149M |
-| OsX 10.12 clang90 | [root_v6.14.06.macosx64-10.12-clang90.dmg](https://root.cern.ch/download/root_v6.14.06.macosx64-10.12-clang90.dmg) | 126M |
-| OsX 10.12 clang90 | [root_v6.14.06.macosx64-10.12-clang90.tar.gz](https://root.cern.ch/download/root_v6.14.06.macosx64-10.12-clang90.tar.gz) | 125M |
-| OsX 10.13 clang100 | [root_v6.14.06.macosx64-10.13-clang100.dmg](https://root.cern.ch/download/root_v6.14.06.macosx64-10.13-clang100.dmg) | 128M |
-| OsX 10.13 clang100 | [root_v6.14.06.macosx64-10.13-clang100.tar.gz](https://root.cern.ch/download/root_v6.14.06.macosx64-10.13-clang100.tar.gz) | 127M |
-| OsX 10.14 clang100 | [root_v6.14.06.macosx64-10.14-clang100.dmg](https://root.cern.ch/download/root_v6.14.06.macosx64-10.14-clang100.dmg) | 128M |
-| OsX 10.14 clang100 | [root_v6.14.06.macosx64-10.14-clang100.tar.gz](https://root.cern.ch/download/root_v6.14.06.macosx64-10.14-clang100.tar.gz) | 127M |
-| **preview** Windows Visual Studio 2017 (dbg) | [root_v6.14.06.win32.vc15.debug.exe](https://root.cern.ch/download/root_v6.14.06.win32.vc15.debug.exe) | 182M |
-| **preview** Windows Visual Studio 2017 (dbg) | [root_v6.14.06.win32.vc15.debug.zip](https://root.cern.ch/download/root_v6.14.06.win32.vc15.debug.zip) | 294M |
-| **preview** Windows Visual Studio 2017 | [root_v6.14.06.win32.vc15.exe](https://root.cern.ch/download/root_v6.14.06.win32.vc15.exe) |  79M |
-| **preview** Windows Visual Studio 2017 | [root_v6.14.06.win32.vc15.zip](https://root.cern.ch/download/root_v6.14.06.win32.vc15.zip) | 108M |
+| CentOS Cern 7 gcc4.8 | [root_v6.14.06.Linux-centos7-x86_64-gcc4.8.tar.gz](https://root.cern/download/root_v6.14.06.Linux-centos7-x86_64-gcc4.8.tar.gz) | 141M |
+| Linux fedora27 gcc7.3 | [root_v6.14.06.Linux-fedora27-x86_64-gcc7.3.tar.gz](https://root.cern/download/root_v6.14.06.Linux-fedora27-x86_64-gcc7.3.tar.gz) | 132M |
+| Linux fedora28 gcc8.2 | [root_v6.14.06.Linux-fedora28-x86_64-gcc8.2.tar.gz](https://root.cern/download/root_v6.14.06.Linux-fedora28-x86_64-gcc8.2.tar.gz) | 131M |
+| Ubuntu 14 gcc4.8 | [root_v6.14.06.Linux-ubuntu14-x86_64-gcc4.8.tar.gz](https://root.cern/download/root_v6.14.06.Linux-ubuntu14-x86_64-gcc4.8.tar.gz) | 141M |
+| Ubuntu 16 gcc5.4 | [root_v6.14.06.Linux-ubuntu16-x86_64-gcc5.4.tar.gz](https://root.cern/download/root_v6.14.06.Linux-ubuntu16-x86_64-gcc5.4.tar.gz) | 142M |
+| Ubuntu 18 gcc7.3 | [root_v6.14.06.Linux-ubuntu18-x86_64-gcc7.3.tar.gz](https://root.cern/download/root_v6.14.06.Linux-ubuntu18-x86_64-gcc7.3.tar.gz) | 149M |
+| OsX 10.12 clang90 | [root_v6.14.06.macosx64-10.12-clang90.dmg](https://root.cern/download/root_v6.14.06.macosx64-10.12-clang90.dmg) | 126M |
+| OsX 10.12 clang90 | [root_v6.14.06.macosx64-10.12-clang90.tar.gz](https://root.cern/download/root_v6.14.06.macosx64-10.12-clang90.tar.gz) | 125M |
+| OsX 10.13 clang100 | [root_v6.14.06.macosx64-10.13-clang100.dmg](https://root.cern/download/root_v6.14.06.macosx64-10.13-clang100.dmg) | 128M |
+| OsX 10.13 clang100 | [root_v6.14.06.macosx64-10.13-clang100.tar.gz](https://root.cern/download/root_v6.14.06.macosx64-10.13-clang100.tar.gz) | 127M |
+| OsX 10.14 clang100 | [root_v6.14.06.macosx64-10.14-clang100.dmg](https://root.cern/download/root_v6.14.06.macosx64-10.14-clang100.dmg) | 128M |
+| OsX 10.14 clang100 | [root_v6.14.06.macosx64-10.14-clang100.tar.gz](https://root.cern/download/root_v6.14.06.macosx64-10.14-clang100.tar.gz) | 127M |
+| **preview** Windows Visual Studio 2017 (dbg) | [root_v6.14.06.win32.vc15.debug.exe](https://root.cern/download/root_v6.14.06.win32.vc15.debug.exe) | 182M |
+| **preview** Windows Visual Studio 2017 (dbg) | [root_v6.14.06.win32.vc15.debug.zip](https://root.cern/download/root_v6.14.06.win32.vc15.debug.zip) | 294M |
+| **preview** Windows Visual Studio 2017 | [root_v6.14.06.win32.vc15.exe](https://root.cern/download/root_v6.14.06.win32.vc15.exe) |  79M |
+| **preview** Windows Visual Studio 2017 | [root_v6.14.06.win32.vc15.zip](https://root.cern/download/root_v6.14.06.win32.vc15.zip) | 108M |
 
 
 

--- a/about/license.md
+++ b/about/license.md
@@ -8,7 +8,7 @@ sidebar:
 The ROOT system is being made available under the [LGPL 2.1](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.html){:target="_blank"}
 or (at your option) any later version, which allows ROOT to be used in a wide range of open and closed environments. The LGPL is copied verbatim below.
 
-The optional [MathMore](https://root.cern.ch/mathmore-library) library uses the GSL library which is licensed under the
+The optional [MathMore](https://root.cern/mathmore-library) library uses the GSL library which is licensed under the
 [GPL](https://www.gnu.org/licenses/gpl-3.0.en.html){:target="_blank"} and hence the MathMore library is only available under
 the GPL (to exclude MathMore from ROOT run configure with the `-Dmathmore=OFF` option).
 

--- a/contribute/coding_conventions/index.md
+++ b/contribute/coding_conventions/index.md
@@ -9,7 +9,7 @@ toc_sticky: true
 
 ## Naming conventions
 
-For naming conventions we follow the [Taligent](https://root.cern.ch/TaligentDocs/TaligentOnline/DocumentRoot/1.0/Docs/books/WM/WM_63.html#HEADING77){:target="_blank"}
+For naming conventions we follow the [Taligent](https://root.cern/TaligentDocs/TaligentOnline/DocumentRoot/1.0/Docs/books/WM/WM_63.html#HEADING77){:target="_blank"}
 rules. They have written a very large body of C++ and their rules seem well thought out.
 No need to invent something new. The only addition/change we made is to append
 an `_t` to `typedef`s and simple `struct`s, e.g.:
@@ -22,7 +22,7 @@ Addherence to the rules is mandatory.  After a while one really gets used to the
 
 ## Class definition conventions
 
-Also here the [Taligent guide](https://root.cern.ch/TaligentDocs/TaligentOnline/DocumentRoot/1.0/Docs/books/WM/WM_69.html){:target="_blank"}
+Also here the [Taligent guide](https://root.cern/TaligentDocs/TaligentOnline/DocumentRoot/1.0/Docs/books/WM/WM_69.html){:target="_blank"}
 is quite reasonable. Of course, no class data member should ever be public. Make the data
 fields always private. Or protected, if you want to grant an inherited class direct
 access.
@@ -312,5 +312,5 @@ unpad-paren
 
 ## Where to go from here
 For the rest read the
-[Taligent Guide](https://root.cern.ch/TaligentDocs/TaligentOnline/DocumentRoot/1.0/Docs/books/WM/WM_1.html){:target="_blank"}
+[Taligent Guide](https://root.cern/TaligentDocs/TaligentOnline/DocumentRoot/1.0/Docs/books/WM/WM_1.html){:target="_blank"}
 and use common sense.

--- a/for_developers/continous_integration-testing/rootbinder_checklist.md
+++ b/for_developers/continous_integration-testing/rootbinder_checklist.md
@@ -14,9 +14,9 @@ steps to be taken are the following:
 ## What if something goes wrong
 
 It is possible that something goes wrong and the link to the interactive demo has to be
-interrupted. In this case the file https://root.cern.ch/notebooks/rootbinder.html has to be
+interrupted. In this case the file https://root.cern/notebooks/rootbinder.html has to be
 modified so to redirect to a page which clarifies the current status of the demo,
-for example: https://root.cern.ch/rootbinder-unreachable .
+for example: https://root.cern/rootbinder-unreachable .
 
 ## Preparation of the ROOT tarball
 
@@ -25,7 +25,7 @@ for example: https://root.cern.ch/rootbinder-unreachable .
 * Start the docker container: `docker run -t -i NAMEOFTHEIMAGE`
   * The list of images is available with the command `docker images`
 * Build the desired version of ROOT calling the build directory "root"
-* Make a compressed tarball of root and copy it to https://root.cern.ch/notebooks/rootbinderdata
+* Make a compressed tarball of root and copy it to https://root.cern/notebooks/rootbinderdata
 
 ## Test and preparation of the image in Binder
 

--- a/for_developers/index.md
+++ b/for_developers/index.md
@@ -44,7 +44,7 @@ ROOT externals coming from the central installations in AFS or CVMFS.
    - [Jenkins How To](continous_integration-testing/jenkins_how_to)
    - [CDash](https://cdash.cern.ch/index.php?project=ROOT)
    - [Coverity](https://coverity.cern.ch/login/login.htm)
-   - [GitWeb](https://root.cern.ch/gitweb/?p=root.git;a=summary)
+   - [GitWeb](https://root.cern/gitweb/?p=root.git;a=summary)
    - [Jira](https://sft.its.cern.ch/jira/projects/ROOT?selectedItem=com.atlassian.jira.jira-projects-plugin%3Asummary-page)
    - [ROOTBinder Checklist](continous_integration-testing/rootbinder_checklist)
 
@@ -56,4 +56,4 @@ the [Reference Guide](https://root.cern/doc/master/){:target="_blank"}.
 Jekyll is used for generating the ROOT web site.
 
 ### [Benchmarks](https://rootbnch-grafana-test.cern.ch)
-### [ROOT Logos](https://root.cern.ch/img/logos/ROOT_Logo/)
+### [ROOT Logos](https://root.cern/img/logos/ROOT_Logo/)

--- a/for_developers/release_checklist/index.md
+++ b/for_developers/release_checklist/index.md
@@ -33,7 +33,7 @@ sidebar:
       - `git push origin vX-YY-00-patches`
       - `git push origin vX-YY-ZZ`
   11. Tag ROOTTEST repository
-  12. Make source tar file and copy to ftp area on root.cern.ch
+  12. Make source tar file and copy to ftp area on root.cern
       - Run from the build directory `$ make distsrc` _[not on a MacOS machine](https://superuser.com/questions/318809/linux-os-x-tar-incompatibility-tarballs-created-on-os-x-give-errors-when-unt){:target="_blank"}_
       - `scp ../root_vX.YY.ZZ.source.tar.gz sftnight@root:/home/www/root/download`
   13. Produce binary tarfiles

--- a/for_developers/setup_externals_from_afs-cvmfs/index.md
+++ b/for_developers/setup_externals_from_afs-cvmfs/index.md
@@ -28,7 +28,7 @@ In this case we can use the script that is used by jenkins. The script expects 4
 - BUILDTYPE is the type of the build. E.g. Release, Debug
 - EXTERNALS is the label for the set of versions of the externals. Typically 'ROOT-date', but 'ROOT-latest' is a safe bet.
 ```
-git clone https://root.cern.ch/git/rootspi.git
+git clone https://root.cern/git/rootspi.git
 source rootspi/jenkins/jk-setup.sh slc6 icc14 Release ROOT-latest
 ```
 

--- a/get_started/code_examples.md
+++ b/get_started/code_examples.md
@@ -10,11 +10,11 @@ as part of more complex programs. They are separated in two categories: C++ or p
 and Jupyter notebooks.
 
 The tutorials are available for all major ROOT releases.
-**[These](https://root.cern.ch/doc/master/group__Tutorials.html){:target="_blank"}** are the links for their
+**[These](https://root.cern/doc/master/group__Tutorials.html){:target="_blank"}** are the links for their
 latest version. Most tutorials are also available as ROOTBook which can
 be visualized in [NBViewer](https://nbviewer.jupyter.org/){:target="_blank"} or tried interactively in
 [SWAN](https://swan.web.cern.ch){:target="_blank"}. Such tutorials are marked with these badges:
-<img src="https://root.cern.ch/doc/master/notebook.gif" alt="View in nbviewer" style="height:1em">
+<img src="https://root.cern/doc/master/notebook.gif" alt="View in nbviewer" style="height:1em">
 <img src="https://swanserver.web.cern.ch/swanserver/images/badge_swan_white_150.png" alt="Open in SWAN" style="height:1em">
 
 Once you have [properly setup the ROOT environment]({{'manual/first_steps_with_root' | relative_url }}){:target="_blank"},
@@ -23,7 +23,7 @@ You can then [execute/read the macros]({{'manual/first_steps_with_root/#root-mac
 there to learn from the examples. Do not hesitate to comment out/ add code to these tutorials
 macros to learn interactively how ROOT works.
 Among the long list of tutorials you may want to start with:
-[histograms](https://root.cern.ch/doc/master/group__tutorial__hist.html){:target="_blank"},
-[graphs](https://root.cern.ch/doc/master/group__tutorial__graphs.html){:target="_blank"},
-[graphics](https://root.cern.ch/doc/master/group__tutorial__graphics.html){:target="_blank"} and
-[trees](https://root.cern.ch/doc/master/group__tutorial__tree.html){:target="_blank"}.
+[histograms](https://root.cern/doc/master/group__tutorial__hist.html){:target="_blank"},
+[graphs](https://root.cern/doc/master/group__tutorial__graphs.html){:target="_blank"},
+[graphics](https://root.cern/doc/master/group__tutorial__graphics.html){:target="_blank"} and
+[trees](https://root.cern/doc/master/group__tutorial__tree.html){:target="_blank"}.

--- a/get_started/courses.md
+++ b/get_started/courses.md
@@ -15,7 +15,7 @@ This page lists a number of ROOT tutorials and courses. Some are made by third p
 *   CERN Summer Students' Introductory Tutorial ([2018](https://indico.cern.ch/event/734958/){:target="_blank"}, [2017](https://indico.cern.ch/event/648140/){:target="_blank"}, [2016](https://indico.cern.ch/event/536772/){:target="_blank"}, [2015](https://indico.cern.ch/event/395198/){:target="_blank"} )
 *   [First Steps With ROOT](https://root.cern/d/first-steps-root){:target="_blank"} **← Old Drupal Book**
 *   [Introductory Tutorials (approx 2 hours)](https://root.cern/d/introductory-tutorials){:target="_blank"} **← Old Drupal Book**
-*   [Lectures at the CERN School of Computing](https://root.cern.ch/download/ROOT_CSC11-Handout.pdf) [(CSC)](https://csc.web.cern.ch/CSC/){:target="_blank"}
+*   [Lectures at the CERN School of Computing](https://root.cern/download/ROOT_CSC11-Handout.pdf) [(CSC)](https://csc.web.cern.ch/CSC/){:target="_blank"}
 *   [Bill Seligman's ROOT Tutorial](https://www.nevis.columbia.edu/~seligman/root-class){:target="_blank"}
 
 ## <a id="Intermediate" name="Intermediate"></a>Intermediate
@@ -35,7 +35,7 @@ These are general ROOT tutorials covering the basics of ROOT like Histograms, Tr
 
 ## Preparing ROOT courses for the CERN technical training
 
-*   [ROOT courses proposal](https://root.cern.ch/root-training-proposal){:target="_blank"}
+*   [ROOT courses proposal](https://root.cern/root-training-proposal){:target="_blank"}
 *   [Working document for the courses](https://docs.google.com/spreadsheets/d/16GqoK2BvWGoX7vLgytz02LmJys7u2Mrzhfpdeg6yZGI){:target="_blank"}
 
 

--- a/install/all_releases/index.md
+++ b/install/all_releases/index.md
@@ -33,4 +33,4 @@ Release notes can be found on the respective release page.
 
 Release notes for old releases can be found [here]({{ '/install/all_releases/old_release_notes' | relative_url }}).
 
-All releases files can be download from [here](https://root.cern.ch/download/).
+All releases files can be download from [here](https://root.cern/download/).

--- a/install/all_releases/old_release_notes.md
+++ b/install/all_releases/old_release_notes.md
@@ -9,8 +9,8 @@ For recent releases, the release notes can be found on their respective
 [release page]({{ '/install/all_releases' | relative_url }}).
 
 
-  - [ROOT Version v6-06-00 Patch Release Notes](https://root.cern.ch/doc/v606/release-notes.html#patch-releases)
-  - [ROOT Version v6-04-00 Patch Release Notes](https://root.cern.ch/doc/v604/release-notes.html#patch-releases)
+  - [ROOT Version v6-06-00 Patch Release Notes](https://root.cern/doc/v606/release-notes.html#patch-releases)
+  - [ROOT Version v6-04-00 Patch Release Notes](https://root.cern/doc/v604/release-notes.html#patch-releases)
   - [ROOT Version v6-02-00 Patch Release Notes]({{ '/install/all_releases/root-version-v6-02-00-patch-release-notes' | relative_url }})
   - [ROOT Version v5-34-00 Patch Release Notes]({{ '/install/all_releases/root-version-v5-34-00-patch-release-notes' | relative_url }})
   - [ROOT Version v5-32-00 Patch Release Notes]({{ '/install/all_releases/root-version-v5-32-00-patch-release-notes' | relative_url }})

--- a/install/all_releases/root-version-v5-10-00-patch-release-notes.md
+++ b/install/all_releases/root-version-v5-10-00-patch-release-notes.md
@@ -12,7 +12,7 @@ sidebar:
 <p>Binaries are currently not available for patch releases.</p>
 
 <p>To get the source of the head of the v5-10-00-patches branch do:</p>
-<code>svn co <a href="http://root.cern.ch/svn/root/branches/v5-10-00-patches" title="http://root.cern.ch/svn/root/branches/v5-10-00-patches">http://root.cern.ch/svn/root/branches/v5-10-00-patches</a> root </code>
+<code>svn co <a href="http://root.cern/svn/root/branches/v5-10-00-patches" title="http://root.cern/svn/root/branches/v5-10-00-patches">http://root.cern/svn/root/branches/v5-10-00-patches</a> root </code>
 
 <p>After obtaining the source read the file <a href="/get-root-sources">README/INSTALL</a>&nbsp; <span style="color:#B22222;">(broken)</span>.</p>
 

--- a/install/all_releases/root-version-v5-14-00-patch-release-notes.md
+++ b/install/all_releases/root-version-v5-14-00-patch-release-notes.md
@@ -14,10 +14,10 @@ sidebar:
 <p>Binaries are currently not available for patch releases.</p>
 
 <p>The complete source tree for all systems (21.4 MB) is available here:</p>
-<code><a href="ftp://root.cern.ch/root/root_v5.14.00i.source.tar.gz">ftp://root.cern.ch/root/root_v5.14.00i.source.tar.gz</a> </code>
+<code><a href="ftp://root.cern/root/root_v5.14.00i.source.tar.gz">ftp://root.cern/root/root_v5.14.00i.source.tar.gz</a> </code>
 
 <p>Alternatively get the source from <a href="/git-primer">Subversion</a> using:</p>
-<code> svn co <a href="http://root.cern.ch/svn/root/tags/v5-14-00i" title="http://root.cern.ch/svn/root/tags/v5-14-00i">http://root.cern.ch/svn/root/tags/v5-14-00i</a> root </code>
+<code> svn co <a href="http://root.cern/svn/root/tags/v5-14-00i" title="http://root.cern/svn/root/tags/v5-14-00i">http://root.cern/svn/root/tags/v5-14-00i</a> root </code>
 
 <p>After obtaining the source read the file <a href="/drupal/content/installing-root-source" target="_blank">README/INSTALL</a>.</p>
 

--- a/install/all_releases/root-version-v5-18-00-patch-release-notes.md
+++ b/install/all_releases/root-version-v5-18-00-patch-release-notes.md
@@ -14,15 +14,15 @@ sidebar:
 <p>Binaries are currently not available for patch releases.</p>
 
 <p>The complete source tree for all systems (23.5 MB) is available here:</p>
-<code><a href="ftp://root.cern.ch/root/root_v5.18.00f.source.tar.gz" target="_blank">ftp://root.cern.ch/root/root_v5.18.00f.source.tar.gz</a> </code>
+<code><a href="ftp://root.cern/root/root_v5.18.00f.source.tar.gz" target="_blank">ftp://root.cern/root/root_v5.18.00f.source.tar.gz</a> </code>
 
 <p>Alternatively get the source from <a href="/git-primer" target="_blank">Subversion</a> <span style="color:#B22222;">(broken)</span> using:</p>
-<code> svn co <a href="http://root.cern.ch/svn/root/tags/v5-18-00f" target="_blank" title="http://root.cern.ch/svn/root/tags/v5-18-00f">http://root.cern.ch/svn/root/tags/v5-18-00f</a> root </code>
+<code> svn co <a href="http://root.cern/svn/root/tags/v5-18-00f" target="_blank" title="http://root.cern/svn/root/tags/v5-18-00f">http://root.cern/svn/root/tags/v5-18-00f</a> root </code>
 
 <p>After obtaining the source read the file README/INSTALL <span style="color:#B22222;">(broken)</span> (in short just do: cd root; ./configure; make).</p>
 
 <p>To get the source of the head of the v5-18-00-patches branch do:</p>
-<code> svn co <a href="http://root.cern.ch/svn/root/branches/v5-18-00-patches" target="_blank" title="http://root.cern.ch/svn/root/branches/v5-18-00-patches">http://root.cern.ch/svn/root/branches/v5-18-00-patches</a> root </code>
+<code> svn co <a href="http://root.cern/svn/root/branches/v5-18-00-patches" target="_blank" title="http://root.cern/svn/root/branches/v5-18-00-patches">http://root.cern/svn/root/branches/v5-18-00-patches</a> root </code>
 
 <h2>Changes in the head of the v5-18-00-patches branch</h2>
 
@@ -161,7 +161,7 @@ sidebar:
 	</li>
 	<li>TDirectory
 	<ul>
-		<li>Fix in GetDirectory(), that did not work when the file name has the form: <a href="http://root.cern.ch/pippa.root:/LL" target="_blank">http://root.cern.ch/pippa.root:/LL</a>.</li>
+		<li>Fix in GetDirectory(), that did not work when the file name has the form: <a href="http://root.cern/pippa.root:/LL" target="_blank">http://root.cern/pippa.root:/LL</a>.</li>
 	</ul>
 	</li>
 	<li>CINT

--- a/install/all_releases/root-version-v5-20-00-patch-release-notes.md
+++ b/install/all_releases/root-version-v5-20-00-patch-release-notes.md
@@ -10,7 +10,7 @@ sidebar:
 
 <div class="content">
 <p>To get the source of the head of the v5-20-00-patches branch do:</p>
-<code>svn co <a href="http://root.cern.ch/svn/root/branches/v5-20-00-patches" title="http://root.cern.ch/svn/root/branches/v5-20-00-patches">http://root.cern.ch/svn/root/branches/v5-20-00-patches</a> root </code>
+<code>svn co <a href="http://root.cern/svn/root/branches/v5-20-00-patches" title="http://root.cern/svn/root/branches/v5-20-00-patches">http://root.cern/svn/root/branches/v5-20-00-patches</a> root </code>
 
 <p>After obtaining the source read the file <a href="/get-root-sources" target="_blank">README/INSTALL</a> <span style="color:#B22222;">(broken)</span> (in short just do: cd root; ./configure; make).</p>
 

--- a/install/all_releases/root-version-v5-22-00-patch-release-notes.md
+++ b/install/all_releases/root-version-v5-22-00-patch-release-notes.md
@@ -17,15 +17,15 @@ sidebar:
 <code>/afs/cern.ch/sw/lcg/app/releases/ROOT/5.22.00j/ </code>
 
 <p>The complete source tree for all systems (23.5 MB) is available here:</p>
-<code> <a href="ftp://root.cern.ch/root/root_v5.22.00j.source.tar.gz" target="_blank">ftp://root.cern.ch/root/root_v5.22.00j.source.tar.gz</a> </code>
+<code> <a href="ftp://root.cern/root/root_v5.22.00j.source.tar.gz" target="_blank">ftp://root.cern/root/root_v5.22.00j.source.tar.gz</a> </code>
 
 <p>Alternatively get the source from <a href="/git-primer" target="_blank">Subversion</a> <span style="color:#B22222;">(broken)</span> using:</p>
-<code> svn co <a href="http://root.cern.ch/svn/root/tags/v5-22-00j" target="_blank" title="http://root.cern.ch/svn/root/tags/v5-22-00j">http://root.cern.ch/svn/root/tags/v5-22-00j</a> root </code>
+<code> svn co <a href="http://root.cern/svn/root/tags/v5-22-00j" target="_blank" title="http://root.cern/svn/root/tags/v5-22-00j">http://root.cern/svn/root/tags/v5-22-00j</a> root </code>
 
-<p>After obtaining the source read the file <a href="https://root.cern.ch/build-root-old-method" target="_blank">README/INSTALL</a> <span style="color:#B22222;">(broken) </span>(in short just do: cd root; ./configure; make).</p>
+<p>After obtaining the source read the file <a href="https://root.cern/build-root-old-method" target="_blank">README/INSTALL</a> <span style="color:#B22222;">(broken) </span>(in short just do: cd root; ./configure; make).</p>
 
 <p>To get the source of the head of the v5-22-00-patches branch do:</p>
-<code> svn co <a href="http://root.cern.ch/svn/root/branches/v5-22-00-patches" target="_blank" title="http://root.cern.ch/svn/root/branches/v5-22-00-patches">http://root.cern.ch/svn/root/branches/v5-22-00-patches</a> root </code>
+<code> svn co <a href="http://root.cern/svn/root/branches/v5-22-00-patches" target="_blank" title="http://root.cern/svn/root/branches/v5-22-00-patches">http://root.cern/svn/root/branches/v5-22-00-patches</a> root </code>
 
 <h2>Changes in the head of the v5-22-00-patches branch</h2>
 
@@ -68,7 +68,7 @@ sidebar:
 <ul>
 	<li>Xrootd
 	<ul>
-		<li>Import fixes to build on MacOS X 10.4 (<a href="http://root.cern.ch/viewvc?view=rev&amp;revision=32679" target="_blank">#32679</a>,&nbsp; <a href="http://root.cern.ch/viewvc?view=rev&amp;revision=32680" target="_blank">#32680</a>, <a href="http://root.cern.ch/viewvc?view=rev&amp;revision=32683" target="_blank">#32683</a>, <a href="http://root.cern.ch/viewvc?view=rev&amp;revision=32707" target="_blank">#32707</a>)</li>
+		<li>Import fixes to build on MacOS X 10.4 (<a href="http://root.cern/viewvc?view=rev&amp;revision=32679" target="_blank">#32679</a>,&nbsp; <a href="http://root.cern/viewvc?view=rev&amp;revision=32680" target="_blank">#32680</a>, <a href="http://root.cern/viewvc?view=rev&amp;revision=32683" target="_blank">#32683</a>, <a href="http://root.cern/viewvc?view=rev&amp;revision=32707" target="_blank">#32707</a>)</li>
 	</ul>
 	</li>
 	<li>Meta
@@ -89,17 +89,17 @@ sidebar:
 	<li>Xrootd
 	<ul>
 		<li>New version (v20100205-0000) containing several fixes needed in particular by ATLAS; this includes the new SSL module for authentication needed by Castor.</li>
-		<li>Import&nbsp; crucial fix <a href="http://root.cern.ch/viewvc?view=rev&amp;revision=32322" target="_blank">#32322</a> on for the krb5 security module</li>
+		<li>Import&nbsp; crucial fix <a href="http://root.cern/viewvc?view=rev&amp;revision=32322" target="_blank">#32322</a> on for the krb5 security module</li>
 	</ul>
 	</li>
 	<li>Krb5auth
 	<ul>
-		<li>Import patches <a href="http://root.cern.ch/viewvc?view=rev&amp;revision=29438" target="_blank">#29438</a> and <a href="http://root.cern.ch/viewvc?view=rev&amp;revision=29474" target="_blank">#29474</a> in krb5auth to fix building issues with current linux distribution (e.g. kubuntu)</li>
+		<li>Import patches <a href="http://root.cern/viewvc?view=rev&amp;revision=29438" target="_blank">#29438</a> and <a href="http://root.cern/viewvc?view=rev&amp;revision=29474" target="_blank">#29474</a> in krb5auth to fix building issues with current linux distribution (e.g. kubuntu)</li>
 	</ul>
 	</li>
 	<li>Netx
 	<ul>
-		<li>Import the relevant parts of patch <a href="http://root.cern.ch/viewvc?view=rev&amp;revision=30949" target="_blank">#30949</a> adding the possibility to set on the fly (via the option field of the URL) the new read-ahead policies explicitely introduced in XrdClient for ATLAS.</li>
+		<li>Import the relevant parts of patch <a href="http://root.cern/viewvc?view=rev&amp;revision=30949" target="_blank">#30949</a> adding the possibility to set on the fly (via the option field of the URL) the new read-ahead policies explicitely introduced in XrdClient for ATLAS.</li>
 	</ul>
 	</li>
 	<li>I/O

--- a/install/all_releases/root-version-v5-24-00-patch-release-notes.md
+++ b/install/all_releases/root-version-v5-24-00-patch-release-notes.md
@@ -17,15 +17,15 @@ sidebar:
 <code>/afs/cern.ch/sw/lcg/app/releases/ROOT/5.24.00b/ </code>
 
 <p>The complete source tree for all systems (23.5 MB) is available here:</p>
-<code> <a href="ftp://root.cern.ch/root/root_v5.24.00b.source.tar.gz" target="_blank">ftp://root.cern.ch/root/root_v5.24.00b.source.tar.gz</a> </code>
+<code> <a href="ftp://root.cern/root/root_v5.24.00b.source.tar.gz" target="_blank">ftp://root.cern/root/root_v5.24.00b.source.tar.gz</a> </code>
 
 <p>Alternatively get the source from <a href="/git-primer" target="_blank">Subversion</a> <span style="color:#B22222;">(broken)</span> using:</p>
-<code> svn co <a href="http://root.cern.ch/svn/root/tags/v5-24-00b" target="_blank" title="http://root.cern.ch/svn/root/tags/v5-24-00b">http://root.cern.ch/svn/root/tags/v5-24-00b</a> root </code>
+<code> svn co <a href="http://root.cern/svn/root/tags/v5-24-00b" target="_blank" title="http://root.cern/svn/root/tags/v5-24-00b">http://root.cern/svn/root/tags/v5-24-00b</a> root </code>
 
 <p>After obtaining the source read the file README/INSTALL (in short just do: cd root; ./configure; make).</p>
 
 <p>To get the source of the head of the v5-24-00-patches branch do:</p>
-<code> svn co <a href="http://root.cern.ch/svn/root/branches/v5-24-00-patches" target="_blank" title="http://root.cern.ch/svn/root/branches/v5-24-00-patches">http://root.cern.ch/svn/root/branches/v5-24-00-patches</a> root </code>
+<code> svn co <a href="http://root.cern/svn/root/branches/v5-24-00-patches" target="_blank" title="http://root.cern/svn/root/branches/v5-24-00-patches">http://root.cern/svn/root/branches/v5-24-00-patches</a> root </code>
 
 <h2>Changes in the head of the v5-24-00-patches branch</h2>
 
@@ -228,7 +228,7 @@ sidebar:
 	<ul>
 		<li>Fix a bug in the constructor of FeldmanCousins.cxx</li>
 		<li>Improve the LikelihoodInterval::LowerLimit() and UpperLimit()</li>
-		<li>Fix RooStatUtils::SetParameters (see <a href="http://root.cern.ch/viewvc?view=rev&amp;revision=29521" target="_blank" title="http://root.cern.ch/viewvc?view=rev&amp;revision=29521">http://root.cern.ch/viewvc?view=rev&amp;revision=29521</a> )</li>
+		<li>Fix RooStatUtils::SetParameters (see <a href="http://root.cern/viewvc?view=rev&amp;revision=29521" target="_blank" title="http://root.cern/viewvc?view=rev&amp;revision=29521">http://root.cern/viewvc?view=rev&amp;revision=29521</a> )</li>
 		<li>Fix a problem in ProfileLikelihoodCalculator::GetHypoTest() when there are no nuisance parameters&nbsp;</li>
 	</ul>
 	</li>

--- a/install/all_releases/root-version-v5-26-00-patch-release-notes.md
+++ b/install/all_releases/root-version-v5-26-00-patch-release-notes.md
@@ -17,15 +17,15 @@ sidebar:
 <code>/afs/cern.ch/sw/lcg/app/releases/ROOT/5.26.00g/ </code>
 
 <p>The complete source tree for all systems (23.5 MB) is available here:</p>
-<code> <a href="ftp://root.cern.ch/root/root_v5.26.00g.source.tar.gz" target="_blank">ftp://root.cern.ch/root/root_v5.26.00g.source.tar.gz</a> </code>
+<code> <a href="ftp://root.cern/root/root_v5.26.00g.source.tar.gz" target="_blank">ftp://root.cern/root/root_v5.26.00g.source.tar.gz</a> </code>
 
 <p>Alternatively get the source from <a href="/git-primer" target="_blank">Subversion</a> <span style="color:#B22222;">(broken)</span> using:</p>
-<code> svn co <a href="http://root.cern.ch/svn/root/tags/v5-26-00g" target="_blank" title="http://root.cern.ch/svn/root/tags/v5-26-00g">http://root.cern.ch/svn/root/tags/v5-26-00g</a> root </code>
+<code> svn co <a href="http://root.cern/svn/root/tags/v5-26-00g" target="_blank" title="http://root.cern/svn/root/tags/v5-26-00g">http://root.cern/svn/root/tags/v5-26-00g</a> root </code>
 
 <p>After obtaining the source read the file <a href="/node/103" target="_blank">README/INSTALL</a> (in short just do: cd root; ./configure; make).</p>
 
 <p>To get the source of the head of the v5-26-00-patches branch do:</p>
-<code> svn co <a href="http://root.cern.ch/svn/root/branches/v5-26-00-patches" target="_blank" title="http://root.cern.ch/svn/root/branches/v5-26-00-patches">http://root.cern.ch/svn/root/branches/v5-26-00-patches</a> root </code>
+<code> svn co <a href="http://root.cern/svn/root/branches/v5-26-00-patches" target="_blank" title="http://root.cern/svn/root/branches/v5-26-00-patches">http://root.cern/svn/root/branches/v5-26-00-patches</a> root </code>
 
 <h2>Changes in the head of the v5-26-00-patches branch</h2>
 
@@ -38,7 +38,7 @@ sidebar:
 	<li>Proof
 	<ul>
 		<li>Import patches #41393 and #41399 fixing possible issues with PATH and LD_LIBRARY_PATH settings for proofserv.</li>
-		<li>Adapt patch <a href="http://root.cern.ch/viewvc?rev=39078&amp;root=root&amp;view=rev" target="_blank">#39078</a> to bypass a compilation problem with gcc 4.5.2 on linux.</li>
+		<li>Adapt patch <a href="http://root.cern/viewvc?rev=39078&amp;root=root&amp;view=rev" target="_blank">#39078</a> to bypass a compilation problem with gcc 4.5.2 on linux.</li>
 	</ul>
 	</li>
 </ul>
@@ -53,7 +53,7 @@ sidebar:
 	</li>
 	<li>xrootd
 	<ul>
-		<li>Backport in xrootd of <a href="http://root.cern.ch/viewvc/trunk/net/xrootd/src/xrootd/src/XrdSecsss/XrdSecProtocolsss.cc?r1=37905&amp;r2=37998" target="_blank">this fix</a> for ATLAS.</li>
+		<li>Backport in xrootd of <a href="http://root.cern/viewvc/trunk/net/xrootd/src/xrootd/src/XrdSecsss/XrdSecProtocolsss.cc?r1=37905&amp;r2=37998" target="_blank">this fix</a> for ATLAS.</li>
 	</ul>
 	</li>
 </ul>
@@ -68,14 +68,14 @@ sidebar:
 	</li>
 	<li>Proof
 	<ul>
-		<li>In TProofPlayerRemote::IsClient, import fix <a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=36440" target="_blank">#36440</a> adding a missing protection to fix a crash in submerger mode when the output list contained TProofOutputFile objects.</li>
-		<li>In TProof, import fix <a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=35965" target="_blank">#35965</a> to correctly update the number of submergers when workers die (it should fix an issue experienced by ALICE).</li>
+		<li>In TProofPlayerRemote::IsClient, import fix <a href="http://root.cern/viewcvs?view=rev&amp;revision=36440" target="_blank">#36440</a> adding a missing protection to fix a crash in submerger mode when the output list contained TProofOutputFile objects.</li>
+		<li>In TProof, import fix <a href="http://root.cern/viewcvs?view=rev&amp;revision=35965" target="_blank">#35965</a> to correctly update the number of submergers when workers die (it should fix an issue experienced by ALICE).</li>
 	</ul>
 	</li>
 	<li>Hist
 	<ul>
-		<li>Import fix <a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=36552" target="_blank">#36552</a> fixing TH1::IntegralAndError()</li>
-		<li>Import fix <a href="http://root.cern.ch/viewvc?rev=39628&amp;root=root&amp;view=rev" target="_blank">#39628</a> in TH1::LabelsInflate or Deflate (bug <a href="https://savannah.cern.ch/bugs/?83066" target="_blank">#83066</a>).</li>
+		<li>Import fix <a href="http://root.cern/viewcvs?view=rev&amp;revision=36552" target="_blank">#36552</a> fixing TH1::IntegralAndError()</li>
+		<li>Import fix <a href="http://root.cern/viewvc?rev=39628&amp;root=root&amp;view=rev" target="_blank">#39628</a> in TH1::LabelsInflate or Deflate (bug <a href="https://savannah.cern.ch/bugs/?83066" target="_blank">#83066</a>).</li>
 	</ul>
 	</li>
 	<li>Xrootd
@@ -105,7 +105,7 @@ sidebar:
 	</li>
 	<li>Net
 	<ul>
-		<li>In TFileStager::IsStaged, Import fix <a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=32312" target="_blank">#32312</a>: always close files after testing.</li>
+		<li>In TFileStager::IsStaged, Import fix <a href="http://root.cern/viewcvs?view=rev&amp;revision=32312" target="_blank">#32312</a>: always close files after testing.</li>
 	</ul>
 	</li>
 	<li>Proof
@@ -115,7 +115,7 @@ sidebar:
 	</li>
 	<li>Math
 	<ul>
-		<li>Fix a problem in both Minuit2Minimizer and TMInuitMinimizer when re-defining a parameter (see ROOT&nbsp;Forum post&nbsp;<a href="http://root.cern.ch/phpBB2/viewtopic.php?t=9947" target="_blank">9947</a>).</li>
+		<li>Fix a problem in both Minuit2Minimizer and TMInuitMinimizer when re-defining a parameter (see ROOT&nbsp;Forum post&nbsp;<a href="http://root.cern/phpBB2/viewtopic.php?t=9947" target="_blank">9947</a>).</li>
 	</ul>
 	</li>
 </ul>
@@ -138,7 +138,7 @@ sidebar:
 	</li>
 	<li>Proof
 	<ul>
-		<li>Import change <a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=33437" target="_blank">#33437</a> and <a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=34714" target="_blank">#34714</a>: fixing an issue with binary location when configuring with '--prefix='.</li>
+		<li>Import change <a href="http://root.cern/viewcvs?view=rev&amp;revision=33437" target="_blank">#33437</a> and <a href="http://root.cern/viewcvs?view=rev&amp;revision=34714" target="_blank">#34714</a>: fixing an issue with binary location when configuring with '--prefix='.</li>
 	</ul>
 	</li>
 </ul>
@@ -251,30 +251,30 @@ sidebar:
 	</li>
 	<li>Proof
 	<ul>
-		<li>In XrdProofdAdmin, import fix <a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=32808" target="_blank">#32808</a>: fix bug preventing a correct check of the exported paths</li>
-		<li>In TProofServ, import fix <a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=32812" target="_blank">#32812</a> and <a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=32814" target="_blank">#32814</a>: fix bug affecting the behaviour of kBuildPackage for packages in the global directories</li>
-		<li>In TXProofMgr, import fix <a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=32815" target="_blank">#32815</a>: disable TXSocket handling while sending / receiving files; this fixes occasional freeze in TXProofMgr::GetFile / TXProofMgr::PutFile due to a screw up of the synchronization in the TXSocket pipe</li>
-		<li>In TProofMgr, import fix <a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=32874" target="_blank">#32874</a>: avoid contacting the DNS when initializing TProofMgr as base class of TProofMgrLite: it is not needed and it may introduce long startup delays</li>
-		<li>In TProof, import fix <a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=32833" target="_blank">#32833</a>:<span style="font-family: monospace;"> </span>fix a problem counting valid nodes in sequential or 'masteronly' mode,<span style="font-family: monospace;"> </span>generating the fake error message "GoParallel: attaching to candidate!"</li>
-		<li>In TProofLite, import changes (<a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=32897" target="_blank">#32897</a>, <a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=32898" target="_blank">#32898</a> and <a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=32900" target="_blank">#32900)</a> to fix a problem with the unix sock path length affecting MacOS X</li>
-		<li>In&nbsp; XrdProofdManager, XrdProofdProofServMgr import fix&nbsp; <a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=32953" target="_blank">#32953</a> to fix a problem with the unix sock path length affecting MacOS X</li>
-		<li>In&nbsp; XrdProofdProofServMgr import fix&nbsp; <a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=33003" target="_blank">#33003</a> to fix a problem with open file descriptors potentially showing up in the case of very fast daemon restarts (and many users).</li>
-		<li>In TProofServ import fix <a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=33009" target="_blank">#33009</a>: in Reset(), check that the directory make sense; fixes an issue with a fake error message in PROOF-Lite when issuing TProof::SetParallel().</li>
-		<li>In TProofPlayerLite import fix <a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=33015" target="_blank">#33015</a>: properly initialize the merging progress counter; fixes problem with negative values for '<em>workers still sending</em>' in PROOF-Lite .</li>
-		<li>In TProofLite import fixes <a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=33027" target="_blank">#33027</a> and <a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=33035" target="_blank">#33035</a>: fix possible segvs when processing a dataset where none of the files had been validated and/or when starting a query right after.</li>
-		<li>In TProof import fix <a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=33153" target="_blank">#33153</a>: fix an issue with the parsing of the option field when forcing the creation of a new session, e.g. TProof::Open("&lt;master&gt;/?N") .</li>
-		<li>In TProofServ import fix <a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=33418" target="_blank">#33418</a>: make sure that information used internally in the option field on the master (about the aclic option) is not sent to workers while issuing the Process message.</li>
-		<li>In TXProofMgr import fix <a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=33639" target="_blank">#33639</a>:<span style="font-family: monospace;"> </span>fix problem affecting TProofMgr::Find.</li>
-		<li>Import fix <a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=33640" target="_blank">#33640</a>: fix a few issues affecting the usage of tree friends in PROOF and a bug<span style="font-family: monospace;"> </span>affecting the locality check for files in TDSet.<span style="font-family: monospace;"> </span></li>
-		<li>In TProof::ClearData() import fix <a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=33639" target="_blank">#33641</a>:<span style="font-family: monospace;"> f</span>ix problem observed when the dataset repository is empty<span style="font-family: monospace;"> </span></li>
-		<li>In TProof import fix <a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=33648" target="_blank">#33648</a>: fix an issue with the workers names in TSlaveInfo in PROOF-Lite .<span style="font-family: monospace;"> </span></li>
-		<li>In TPacketizerAdaptive and TPacketizer, import part of fix <a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=33781" target="_blank">#33781</a>: fix a subtle bug affecting the (possibly rare) case when not all entries are required and # entries does not correspond to an complete subset of files (e.g. # entries = 1001000 with files of 100000 entries each).</li>
+		<li>In XrdProofdAdmin, import fix <a href="http://root.cern/viewcvs?view=rev&amp;revision=32808" target="_blank">#32808</a>: fix bug preventing a correct check of the exported paths</li>
+		<li>In TProofServ, import fix <a href="http://root.cern/viewcvs?view=rev&amp;revision=32812" target="_blank">#32812</a> and <a href="http://root.cern/viewcvs?view=rev&amp;revision=32814" target="_blank">#32814</a>: fix bug affecting the behaviour of kBuildPackage for packages in the global directories</li>
+		<li>In TXProofMgr, import fix <a href="http://root.cern/viewcvs?view=rev&amp;revision=32815" target="_blank">#32815</a>: disable TXSocket handling while sending / receiving files; this fixes occasional freeze in TXProofMgr::GetFile / TXProofMgr::PutFile due to a screw up of the synchronization in the TXSocket pipe</li>
+		<li>In TProofMgr, import fix <a href="http://root.cern/viewcvs?view=rev&amp;revision=32874" target="_blank">#32874</a>: avoid contacting the DNS when initializing TProofMgr as base class of TProofMgrLite: it is not needed and it may introduce long startup delays</li>
+		<li>In TProof, import fix <a href="http://root.cern/viewcvs?view=rev&amp;revision=32833" target="_blank">#32833</a>:<span style="font-family: monospace;"> </span>fix a problem counting valid nodes in sequential or 'masteronly' mode,<span style="font-family: monospace;"> </span>generating the fake error message "GoParallel: attaching to candidate!"</li>
+		<li>In TProofLite, import changes (<a href="http://root.cern/viewcvs?view=rev&amp;revision=32897" target="_blank">#32897</a>, <a href="http://root.cern/viewcvs?view=rev&amp;revision=32898" target="_blank">#32898</a> and <a href="http://root.cern/viewcvs?view=rev&amp;revision=32900" target="_blank">#32900)</a> to fix a problem with the unix sock path length affecting MacOS X</li>
+		<li>In&nbsp; XrdProofdManager, XrdProofdProofServMgr import fix&nbsp; <a href="http://root.cern/viewcvs?view=rev&amp;revision=32953" target="_blank">#32953</a> to fix a problem with the unix sock path length affecting MacOS X</li>
+		<li>In&nbsp; XrdProofdProofServMgr import fix&nbsp; <a href="http://root.cern/viewcvs?view=rev&amp;revision=33003" target="_blank">#33003</a> to fix a problem with open file descriptors potentially showing up in the case of very fast daemon restarts (and many users).</li>
+		<li>In TProofServ import fix <a href="http://root.cern/viewcvs?view=rev&amp;revision=33009" target="_blank">#33009</a>: in Reset(), check that the directory make sense; fixes an issue with a fake error message in PROOF-Lite when issuing TProof::SetParallel().</li>
+		<li>In TProofPlayerLite import fix <a href="http://root.cern/viewcvs?view=rev&amp;revision=33015" target="_blank">#33015</a>: properly initialize the merging progress counter; fixes problem with negative values for '<em>workers still sending</em>' in PROOF-Lite .</li>
+		<li>In TProofLite import fixes <a href="http://root.cern/viewcvs?view=rev&amp;revision=33027" target="_blank">#33027</a> and <a href="http://root.cern/viewcvs?view=rev&amp;revision=33035" target="_blank">#33035</a>: fix possible segvs when processing a dataset where none of the files had been validated and/or when starting a query right after.</li>
+		<li>In TProof import fix <a href="http://root.cern/viewcvs?view=rev&amp;revision=33153" target="_blank">#33153</a>: fix an issue with the parsing of the option field when forcing the creation of a new session, e.g. TProof::Open("&lt;master&gt;/?N") .</li>
+		<li>In TProofServ import fix <a href="http://root.cern/viewcvs?view=rev&amp;revision=33418" target="_blank">#33418</a>: make sure that information used internally in the option field on the master (about the aclic option) is not sent to workers while issuing the Process message.</li>
+		<li>In TXProofMgr import fix <a href="http://root.cern/viewcvs?view=rev&amp;revision=33639" target="_blank">#33639</a>:<span style="font-family: monospace;"> </span>fix problem affecting TProofMgr::Find.</li>
+		<li>Import fix <a href="http://root.cern/viewcvs?view=rev&amp;revision=33640" target="_blank">#33640</a>: fix a few issues affecting the usage of tree friends in PROOF and a bug<span style="font-family: monospace;"> </span>affecting the locality check for files in TDSet.<span style="font-family: monospace;"> </span></li>
+		<li>In TProof::ClearData() import fix <a href="http://root.cern/viewcvs?view=rev&amp;revision=33639" target="_blank">#33641</a>:<span style="font-family: monospace;"> f</span>ix problem observed when the dataset repository is empty<span style="font-family: monospace;"> </span></li>
+		<li>In TProof import fix <a href="http://root.cern/viewcvs?view=rev&amp;revision=33648" target="_blank">#33648</a>: fix an issue with the workers names in TSlaveInfo in PROOF-Lite .<span style="font-family: monospace;"> </span></li>
+		<li>In TPacketizerAdaptive and TPacketizer, import part of fix <a href="http://root.cern/viewcvs?view=rev&amp;revision=33781" target="_blank">#33781</a>: fix a subtle bug affecting the (possibly rare) case when not all entries are required and # entries does not correspond to an complete subset of files (e.g. # entries = 1001000 with files of 100000 entries each).</li>
 	</ul>
 	</li>
 	<li>Xrootd
 	<ul>
-		<li>Import fixes to build on MacOS X 10.4 (<a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=32679" target="_blank">#32679</a>, <a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=32680" target="_blank">#32680</a>, <a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=32683" target="_blank">#32683</a>, <a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=32707" target="_blank">#32707</a>)</li>
-		<li>Import fixes <a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=32800" target="_blank">#32800</a>:
+		<li>Import fixes to build on MacOS X 10.4 (<a href="http://root.cern/viewcvs?view=rev&amp;revision=32679" target="_blank">#32679</a>, <a href="http://root.cern/viewcvs?view=rev&amp;revision=32680" target="_blank">#32680</a>, <a href="http://root.cern/viewcvs?view=rev&amp;revision=32683" target="_blank">#32683</a>, <a href="http://root.cern/viewcvs?view=rev&amp;revision=32707" target="_blank">#32707</a>)</li>
+		<li>Import fixes <a href="http://root.cern/viewcvs?view=rev&amp;revision=32800" target="_blank">#32800</a>:
 		<ul>
 			<li>Tiny fix in XrdSecProtocolkrb5.cc (remove a redundant unlock)</li>
 			<li>Improvements in 'xrdgsiproxy':
@@ -285,7 +285,7 @@ sidebar:
 			</li>
 		</ul>
 		</li>
-		<li>Import fixes <a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=33677" target="_blank">#33677</a> fixing a fake authentication failure with proxies created by voms-proxy-init when the input certificates are PKCS12-formatted</li>
+		<li>Import fixes <a href="http://root.cern/viewcvs?view=rev&amp;revision=33677" target="_blank">#33677</a> fixing a fake authentication failure with proxies created by voms-proxy-init when the input certificates are PKCS12-formatted</li>
 	</ul>
 	</li>
 	<li>GUI
@@ -333,7 +333,7 @@ sidebar:
 	</li>
 	<li>Proof
 	<ul>
-		<li>Import patch <a href="http://root.cern.ch/viewvc?view=rev&amp;revision=32237" target="_blank">#32237</a> to fix a problem occuring when submergers cannot open the required sockets (output was not always sent ot the master).</li>
+		<li>Import patch <a href="http://root.cern/viewvc?view=rev&amp;revision=32237" target="_blank">#32237</a> to fix a problem occuring when submergers cannot open the required sockets (output was not always sent ot the master).</li>
 	</ul>
 	</li>
 	<li>Xrootd
@@ -358,7 +358,7 @@ sidebar:
 <ul>
 	<li>Core
 	<ul>
-		<li>Hide editline's symbols to prevent clashes with readline (r31990, <a href="http://root.cern.ch/phpBB2/viewtopic.php?p=41352" target="_blank">Forum post 41352</a>).</li>
+		<li>Hide editline's symbols to prevent clashes with readline (r31990, <a href="http://root.cern/phpBB2/viewtopic.php?p=41352" target="_blank">Forum post 41352</a>).</li>
 		<li>Fix in rootcint when using the -p option (<strong>[Bad link]</strong>).</li>
 	</ul>
 	</li>
@@ -382,15 +382,15 @@ sidebar:
 	</li>
 	<li>Graf
 	<ul>
-		<li>TLatex: revert <a href="http://root.cern.ch/viewvc?view=rev&amp;revision=29285" target="_blank" title="http://root.cern.ch/viewvc?view=rev&amp;revision=29285">http://root.cern.ch/viewvc?view=rev&amp;revision=29285</a> this fix had side effects. Indexes on Greek characters did not work.</li>
+		<li>TLatex: revert <a href="http://root.cern/viewvc?view=rev&amp;revision=29285" target="_blank" title="http://root.cern/viewvc?view=rev&amp;revision=29285">http://root.cern/viewvc?view=rev&amp;revision=29285</a> this fix had side effects. Indexes on Greek characters did not work.</li>
 	</ul>
 	</li>
 	<li>Proof
 	<ul>
-		<li>Fix memory leaks in TProofServ::HandleProcess and TEventIterTree (fix <a href="http://root.cern.ch/viewvc?view=rev&amp;revision=31946" target="_blank">#31946</a>)</li>
-		<li>Fix double deletion in TProofServ::HandleSubMerger and memory leak in TEventIterUnit (fix <a href="http://root.cern.ch/viewvc?view=rev&amp;revision=32003" target="_blank">#32003</a>)</li>
-		<li>Fix a problem with real-time notification during dataset verification (fix <a href="http://root.cern.ch/viewvc?view=rev&amp;revision=32031" target="_blank">#32031</a>)</li>
-		<li>XrdProofd plugin (fixes <a href="http://root.cern.ch/viewvc?view=rev&amp;revision=31934" target="_blank">#31934</a>, <a href="http://root.cern.ch/viewvc?view=rev&amp;revision=31935" target="_blank">#31935</a> and <a href="http://root.cern.ch/viewvc?view=rev&amp;revision=31937" target="_blank">#31937</a>):
+		<li>Fix memory leaks in TProofServ::HandleProcess and TEventIterTree (fix <a href="http://root.cern/viewvc?view=rev&amp;revision=31946" target="_blank">#31946</a>)</li>
+		<li>Fix double deletion in TProofServ::HandleSubMerger and memory leak in TEventIterUnit (fix <a href="http://root.cern/viewvc?view=rev&amp;revision=32003" target="_blank">#32003</a>)</li>
+		<li>Fix a problem with real-time notification during dataset verification (fix <a href="http://root.cern/viewvc?view=rev&amp;revision=32031" target="_blank">#32031</a>)</li>
+		<li>XrdProofd plugin (fixes <a href="http://root.cern/viewvc?view=rev&amp;revision=31934" target="_blank">#31934</a>, <a href="http://root.cern/viewvc?view=rev&amp;revision=31935" target="_blank">#31935</a> and <a href="http://root.cern/viewvc?view=rev&amp;revision=31937" target="_blank">#31937</a>):
 		<ul>
 			<li>Fix an issue with return codes of sending methods preventing a proper detection of failures by masters and/or clients</li>
 			<li>Fix an issue with the garbage collection of inter-daemon connections</li>
@@ -407,7 +407,7 @@ sidebar:
 	<li>PyROOT
 	<ul>
 		<li>Fix <a href="http://savannah.cern.ch/bugs/?59945" target="_blank">#59945</a> and <a href="https://savannah.cern.ch/bugs/?61105" target="_blank">#61105</a>.</li>
-		<li>Properly handle the extra thread created in PyROOT to process events (r31983 and r31996, <a href="http://root.cern.ch/phpBB2/viewtopic.php?t=9640" target="_blank">Forum post 9640</a> and <a href="http://root.cern.ch/phpBB2/viewtopic.php?t=7748" target="_blank">7748</a>).</li>
+		<li>Properly handle the extra thread created in PyROOT to process events (r31983 and r31996, <a href="http://root.cern/phpBB2/viewtopic.php?t=9640" target="_blank">Forum post 9640</a> and <a href="http://root.cern/phpBB2/viewtopic.php?t=7748" target="_blank">7748</a>).</li>
 	</ul>
 	</li>
 </ul>

--- a/install/all_releases/root-version-v5-27-06-patch-release-notes.md
+++ b/install/all_releases/root-version-v5-27-06-patch-release-notes.md
@@ -13,15 +13,15 @@ sidebar:
 <p>A new development version ROOT v5-27-06d has been released Feb 16, 2011.</p>
 
 <p>The complete source tree for all systems (23.5 MB) is available here:</p>
-<code><a href="ftp://root.cern.ch/root/root_v5.27.06d.source.tar.gz" target="_blank">ftp://root.cern.ch/root/root_v5.27.06d.source.tar.gz</a> </code>
+<code><a href="ftp://root.cern/root/root_v5.27.06d.source.tar.gz" target="_blank">ftp://root.cern/root/root_v5.27.06d.source.tar.gz</a> </code>
 
 <p>Alternatively get the source from <a href="/git-primer" target="_blank">Subversion</a> <span style="color:#B22222;">(broken)</span>using:</p>
-<code> svn co <a href="http://root.cern.ch/svn/root/tags/v5-27-06d" target="_blank" title="http://root.cern.ch/svn/root/tags/v5-27-06d">http://root.cern.ch/svn/root/tags/v5-27-06d</a> root </code>
+<code> svn co <a href="http://root.cern/svn/root/tags/v5-27-06d" target="_blank" title="http://root.cern/svn/root/tags/v5-27-06d">http://root.cern/svn/root/tags/v5-27-06d</a> root </code>
 
 <p>After obtaining the source read the file <a href="/node/103" target="_blank">README/INSTALL</a> (in short just do: cd root; ./configure; make).</p>
 
 <p>To get the source of the head of the v5-27-06-patches branch do:</p>
-<code> svn co <a href="http://root.cern.ch/svn/root/branches/v5-27-06-patches" target="_blank" title="http://root.cern.ch/svn/root/branches/v5-27-06-patches">http://root.cern.ch/svn/root/branches/v5-27-06-patches</a> root </code>
+<code> svn co <a href="http://root.cern/svn/root/branches/v5-27-06-patches" target="_blank" title="http://root.cern/svn/root/branches/v5-27-06-patches">http://root.cern/svn/root/branches/v5-27-06-patches</a> root </code>
 
 <h2>Changes in the head of the v5-27-06-patches branch</h2>
 
@@ -43,8 +43,8 @@ sidebar:
 	</li>
 	<li>Proof
 	<ul>
-		<li>Import patches <a href="http://root.cern.ch/viewvc?rev=41393&amp;root=root&amp;view=rev" target="_blank">#41393</a> and <a href="http://root.cern.ch/viewvc?rev=41399&amp;root=root&amp;view=rev" target="_blank">#41399</a> fixing possible issues with PATH and LD_LIBRARY_PATH settings for proofserv.</li>
-		<li>Adapt patch <a href="http://root.cern.ch/viewvc?rev=39078&amp;root=root&amp;view=rev" target="_blank">#39078</a> to bypass a compilation problem with gcc 4.5.2 on linux.</li>
+		<li>Import patches <a href="http://root.cern/viewvc?rev=41393&amp;root=root&amp;view=rev" target="_blank">#41393</a> and <a href="http://root.cern/viewvc?rev=41399&amp;root=root&amp;view=rev" target="_blank">#41399</a> fixing possible issues with PATH and LD_LIBRARY_PATH settings for proofserv.</li>
+		<li>Adapt patch <a href="http://root.cern/viewvc?rev=39078&amp;root=root&amp;view=rev" target="_blank">#39078</a> to bypass a compilation problem with gcc 4.5.2 on linux.</li>
 	</ul>
 	</li>
 </ul>
@@ -59,7 +59,7 @@ sidebar:
 	</li>
 	<li>Proof
 	<ul>
-		<li>Import patch <a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=37976" target="_blank">#37976</a> fixing an issue with worker names in PROOF-Lite.</li>
+		<li>Import patch <a href="http://root.cern/viewcvs?view=rev&amp;revision=37976" target="_blank">#37976</a> fixing an issue with worker names in PROOF-Lite.</li>
 		<li>Import patches improving debug options in packetizers</li>
 	</ul>
 	</li>
@@ -75,24 +75,24 @@ sidebar:
 <ul>
 	<li>Proof
 	<ul>
-		<li>Import patch <a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=36520" target="_blank">#36520</a> adding support for group manager and the {env,rootrc} settings on the fly reconfiguration; the patch also adds support for selective definition of env and rootrc variables, allowing for different values for different users, groups, SVN versions or ROOT versions.</li>
-		<li>Import patch <a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=36526" target="_blank">#36526</a> adding the possibility for the user to disable the use of submergers when set by default by the administrator (to disable set the parameter PROOF_UseMergers to -1).</li>
-		<li>Import patches <a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=36537" target="_blank">#36537</a> and <a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=36592" target="_blank">#36592</a> improving diagnostics in case of segviolations or bad allocation and also fixing an issue with submergers freezing the session when was stopped because a large memory footprint.</li>
-		<li>Import fix <a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=36540" target="_blank">#36540</a> to correctly set TProof::IsValid on the client is invalidated after an idle timeout.</li>
-		<li>Import fix <a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=36553" target="_blank">#36553</a> fixing an issue with DeactivateWorker("*").</li>
-		<li>Import fix <a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=36876" target="_blank">#36876</a> fixing an issue in TPacketizerFile</li>
-		<li>Import fix <a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=36881" target="_blank">#36881</a> to consistently check both Proof.Sandbox and ProofLite.Sandbox for sandbox non-default location as done in TProofLite, and to add missing a protection on a pointer which could possibly be null after a search.</li>
-		<li>Import fix <a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=36933" target="_blank">#36933</a> for better diagnostic for worker (de-)activation problems</li>
-		<li>Import fix <a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=37225" target="_blank">#37225</a> to remove an unused library dependency possibly creating problems when building against an external xrootd</li>
-		<li>Import fix <a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=37396" target="_blank">#37396</a> fixing a problem with the registration of missing files in the 'MissingFiles' list. This also adds two new methods to TProof: ShowMissingFiles() to facilitate the display of the list of missing files; and GetMissingFiles() to get a TFileCollection (dataset) with the missing files for further processing.</li>
+		<li>Import patch <a href="http://root.cern/viewcvs?view=rev&amp;revision=36520" target="_blank">#36520</a> adding support for group manager and the {env,rootrc} settings on the fly reconfiguration; the patch also adds support for selective definition of env and rootrc variables, allowing for different values for different users, groups, SVN versions or ROOT versions.</li>
+		<li>Import patch <a href="http://root.cern/viewcvs?view=rev&amp;revision=36526" target="_blank">#36526</a> adding the possibility for the user to disable the use of submergers when set by default by the administrator (to disable set the parameter PROOF_UseMergers to -1).</li>
+		<li>Import patches <a href="http://root.cern/viewcvs?view=rev&amp;revision=36537" target="_blank">#36537</a> and <a href="http://root.cern/viewcvs?view=rev&amp;revision=36592" target="_blank">#36592</a> improving diagnostics in case of segviolations or bad allocation and also fixing an issue with submergers freezing the session when was stopped because a large memory footprint.</li>
+		<li>Import fix <a href="http://root.cern/viewcvs?view=rev&amp;revision=36540" target="_blank">#36540</a> to correctly set TProof::IsValid on the client is invalidated after an idle timeout.</li>
+		<li>Import fix <a href="http://root.cern/viewcvs?view=rev&amp;revision=36553" target="_blank">#36553</a> fixing an issue with DeactivateWorker("*").</li>
+		<li>Import fix <a href="http://root.cern/viewcvs?view=rev&amp;revision=36876" target="_blank">#36876</a> fixing an issue in TPacketizerFile</li>
+		<li>Import fix <a href="http://root.cern/viewcvs?view=rev&amp;revision=36881" target="_blank">#36881</a> to consistently check both Proof.Sandbox and ProofLite.Sandbox for sandbox non-default location as done in TProofLite, and to add missing a protection on a pointer which could possibly be null after a search.</li>
+		<li>Import fix <a href="http://root.cern/viewcvs?view=rev&amp;revision=36933" target="_blank">#36933</a> for better diagnostic for worker (de-)activation problems</li>
+		<li>Import fix <a href="http://root.cern/viewcvs?view=rev&amp;revision=37225" target="_blank">#37225</a> to remove an unused library dependency possibly creating problems when building against an external xrootd</li>
+		<li>Import fix <a href="http://root.cern/viewcvs?view=rev&amp;revision=37396" target="_blank">#37396</a> fixing a problem with the registration of missing files in the 'MissingFiles' list. This also adds two new methods to TProof: ShowMissingFiles() to facilitate the display of the list of missing files; and GetMissingFiles() to get a TFileCollection (dataset) with the missing files for further processing.</li>
 		<li>Do TProof::ClearPackages via the manager (as done already for TProof::ClearPackage) so that all worker nodes are affected, even in the case of a reduced worker assignment (Alice savannah <a href="https://savannah.cern.ch/bugs/index.php?76265" target="_blank">#76265</a>).</li>
 		<li>Fix issue in the packetizers determining the files and ranges to process when the first event and the number of events are within 1 unit of the boundary between files (Alice savannah <a href="https://savannah.cern.ch/bugs/index.php?75820" target="_blank">#75820</a>).</li>
-		<li>Import fix <a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=37664" target="_blank">#37664</a> fixing a crash when running vs servers not having the fix for the missing file (&lt;= 5.27/06b)</li>
-		<li>Import fix <a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=36191" target="_blank">#36191</a> adding information about the directory for data in TSlaveInfo</li>
-		<li>Import fix <a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=37894" target="_blank">#37894</a> adding support for option ':lite:' to TProof::GetDataSets; this allows to fill the map with only the summary information about the datasets (the header of TFileCollections), significantly increasing the speed and the memory footprint when the number of datasets is very large. Should solve Savannah issue #77303</li>
-		<li>Import fix <a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=37934" target="_blank">#37934</a> in TDataSetManagerFile::NotifyUpdate, improving handling of the case when the file with the global list of datasets does not exist. Fixes an error occurring in new installations or with new dataset directories.</li>
-		<li>Import change <a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=37942" target="_blank">#37942</a> in TProof::Load, adding support for multiple-file specification.</li>
-		<li>Import patch <a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=37969" target="_blank">#37969</a> fixing a bug affecting the order in which query results are registered when two queries started within the same second.</li>
+		<li>Import fix <a href="http://root.cern/viewcvs?view=rev&amp;revision=37664" target="_blank">#37664</a> fixing a crash when running vs servers not having the fix for the missing file (&lt;= 5.27/06b)</li>
+		<li>Import fix <a href="http://root.cern/viewcvs?view=rev&amp;revision=36191" target="_blank">#36191</a> adding information about the directory for data in TSlaveInfo</li>
+		<li>Import fix <a href="http://root.cern/viewcvs?view=rev&amp;revision=37894" target="_blank">#37894</a> adding support for option ':lite:' to TProof::GetDataSets; this allows to fill the map with only the summary information about the datasets (the header of TFileCollections), significantly increasing the speed and the memory footprint when the number of datasets is very large. Should solve Savannah issue #77303</li>
+		<li>Import fix <a href="http://root.cern/viewcvs?view=rev&amp;revision=37934" target="_blank">#37934</a> in TDataSetManagerFile::NotifyUpdate, improving handling of the case when the file with the global list of datasets does not exist. Fixes an error occurring in new installations or with new dataset directories.</li>
+		<li>Import change <a href="http://root.cern/viewcvs?view=rev&amp;revision=37942" target="_blank">#37942</a> in TProof::Load, adding support for multiple-file specification.</li>
+		<li>Import patch <a href="http://root.cern/viewcvs?view=rev&amp;revision=37969" target="_blank">#37969</a> fixing a bug affecting the order in which query results are registered when two queries started within the same second.</li>
 	</ul>
 	</li>
 	<li>TTree
@@ -102,7 +102,7 @@ sidebar:
 	</li>
 	<li>Hist
 	<ul>
-		<li>Import fix <a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=36552" target="_blank">#36552</a> fixing TH1::IntegralAndError()</li>
+		<li>Import fix <a href="http://root.cern/viewcvs?view=rev&amp;revision=36552" target="_blank">#36552</a> fixing TH1::IntegralAndError()</li>
 	</ul>
 	</li>
 </ul>
@@ -112,7 +112,7 @@ sidebar:
 <ul>
 	<li>IO
 	<ul>
-		<li>In TStreamerInfo::BuildCheck, import missing protection (patch fix <a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=36461" target="_blank">#36461</a>).</li>
+		<li>In TStreamerInfo::BuildCheck, import missing protection (patch fix <a href="http://root.cern/viewcvs?view=rev&amp;revision=36461" target="_blank">#36461</a>).</li>
 	</ul>
 	</li>
 	<li>Tree
@@ -128,23 +128,23 @@ sidebar:
 	</li>
 	<li>Proof
 	<ul>
-		<li>In TProofPlayerRemote::IsClient, import fix <a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=36440" target="_blank">#36440</a> adding a missing protection to fix a crash in submerger mode when the output list contained TProofOutputFile objects.</li>
-		<li>In TProof, import fix <a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=35965" target="_blank">#35965</a> to correctly update the number of submergers when workers die (it should fix an issue experienced by ALICE).</li>
-		<li>Import patch <a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=36475" target="_blank">#36475</a> adding the possibility to control the resident and virtual memory of a proofserv using 'ulimit', which has less limitations and more flexibility than setrlimit.</li>
-		<li>Import patch <a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=36480" target="_blank">#36480</a> adding the possibility to deactivate a worker (i.e. remove it from the active list) during Collect in the case a failure status is received; this is used by EnablePackage to deactivate a worker where the requested packages could not be enabled properly.</li>
-		<li>Import patch <a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=36491" target="_blank">#36491</a> fixing an issue preventing correct worker-to-filenode matching and the 'ForceLocal' option to work properly.</li>
-		<li>Import patch <a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=36504" target="_blank">#36504</a> fixing an issue with submergers in the case a worker is removed during the query.</li>
-		<li>Import patch <a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=36512" target="_blank">#36512</a> fixing an issue with the idle timeout (it was applied also during worker setup).</li>
+		<li>In TProofPlayerRemote::IsClient, import fix <a href="http://root.cern/viewcvs?view=rev&amp;revision=36440" target="_blank">#36440</a> adding a missing protection to fix a crash in submerger mode when the output list contained TProofOutputFile objects.</li>
+		<li>In TProof, import fix <a href="http://root.cern/viewcvs?view=rev&amp;revision=35965" target="_blank">#35965</a> to correctly update the number of submergers when workers die (it should fix an issue experienced by ALICE).</li>
+		<li>Import patch <a href="http://root.cern/viewcvs?view=rev&amp;revision=36475" target="_blank">#36475</a> adding the possibility to control the resident and virtual memory of a proofserv using 'ulimit', which has less limitations and more flexibility than setrlimit.</li>
+		<li>Import patch <a href="http://root.cern/viewcvs?view=rev&amp;revision=36480" target="_blank">#36480</a> adding the possibility to deactivate a worker (i.e. remove it from the active list) during Collect in the case a failure status is received; this is used by EnablePackage to deactivate a worker where the requested packages could not be enabled properly.</li>
+		<li>Import patch <a href="http://root.cern/viewcvs?view=rev&amp;revision=36491" target="_blank">#36491</a> fixing an issue preventing correct worker-to-filenode matching and the 'ForceLocal' option to work properly.</li>
+		<li>Import patch <a href="http://root.cern/viewcvs?view=rev&amp;revision=36504" target="_blank">#36504</a> fixing an issue with submergers in the case a worker is removed during the query.</li>
+		<li>Import patch <a href="http://root.cern/viewcvs?view=rev&amp;revision=36512" target="_blank">#36512</a> fixing an issue with the idle timeout (it was applied also during worker setup).</li>
 	</ul>
 	</li>
 	<li>Xrootd
 	<ul>
-		<li>Import patch <a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=36472" target="_blank">#36472</a> setting a more reasonable value for the default client transition time (8 hours instead of 5 mins). This should solve a sort of crisis affecting many xrootd sites with slow backends.</li>
+		<li>Import patch <a href="http://root.cern/viewcvs?view=rev&amp;revision=36472" target="_blank">#36472</a> setting a more reasonable value for the default client transition time (8 hours instead of 5 mins). This should solve a sort of crisis affecting many xrootd sites with slow backends.</li>
 	</ul>
 	</li>
 	<li>Netx
 	<ul>
-		<li>Import patch <a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=36474" target="_blank">#36474</a> makinng sure that the default value transition timeout is set correctly.</li>
+		<li>Import patch <a href="http://root.cern/viewcvs?view=rev&amp;revision=36474" target="_blank">#36474</a> makinng sure that the default value transition timeout is set correctly.</li>
 	</ul>
 	</li>
 </ul>

--- a/install/all_releases/root-version-v5-28-00-patch-release-notes.md
+++ b/install/all_releases/root-version-v5-28-00-patch-release-notes.md
@@ -14,37 +14,37 @@ sidebar:
 <code>/afs/cern.ch/sw/lcg/app/releases/ROOT/5.28.00h/ </code>
 
 <p>The complete source tree for all systems (23.5 MB) is available here:</p>
-<code> <a href="ftp://root.cern.ch/root/root_v5.28.00h.source.tar.gz" target="_blank">ftp://root.cern.ch/root/root_v5.28.00h.source.tar.gz</a> </code>
+<code> <a href="ftp://root.cern/root/root_v5.28.00h.source.tar.gz" target="_blank">ftp://root.cern/root/root_v5.28.00h.source.tar.gz</a> </code>
 
 <p>Alternatively get the source from <a href="/git-primer" target="_blank">Subversion</a> <span style="color:#B22222;">(broken)</span> using:</p>
-<code> svn co <a href="http://root.cern.ch/svn/root/tags/v5-28-00h" target="_blank" title="http://root.cern.ch/svn/root/tags/v5-28-00h">http://root.cern.ch/svn/root/tags/v5-28-00h</a> root </code>
+<code> svn co <a href="http://root.cern/svn/root/tags/v5-28-00h" target="_blank" title="http://root.cern/svn/root/tags/v5-28-00h">http://root.cern/svn/root/tags/v5-28-00h</a> root </code>
 
 <p>After obtaining the source read the file <a href="/node/103" target="_blank">README/INSTALL</a> <span style="color:#B22222;">(broken)</span> (in short just do: cd root; ./configure; make).</p>
 
 <p>To get the source of the head of the v5-28-00-patches branch do:</p>
-<code> svn co <a href="http://root.cern.ch/svn/root/branches/v5-28-00-patches" target="_blank" title="http://root.cern.ch/svn/root/branches/v5-28-00-patches">http://root.cern.ch/svn/root/branches/v5-28-00-patches</a> root </code>
+<code> svn co <a href="http://root.cern/svn/root/branches/v5-28-00-patches" target="_blank" title="http://root.cern/svn/root/branches/v5-28-00-patches">http://root.cern/svn/root/branches/v5-28-00-patches</a> root </code>
 
 <h2>Changes in the head of the v5-28-00-patches branch</h2>
 
 <ul>
 	<li>Cint
 	<ul>
-		<li>Import patch <a href="http://root.cern.ch/viewvc?rev=42805&amp;root=root&amp;view=rev" target="_blank">#42805</a> fixing the problem <a href="https://savannah.cern.ch/bugs/index.php?83909" target="_blank">#83909</a> which leading to failure of the auto-dictionary generator when dealing with class template inside a namespace.</li>
+		<li>Import patch <a href="http://root.cern/viewvc?rev=42805&amp;root=root&amp;view=rev" target="_blank">#42805</a> fixing the problem <a href="https://savannah.cern.ch/bugs/index.php?83909" target="_blank">#83909</a> which leading to failure of the auto-dictionary generator when dealing with class template inside a namespace.</li>
 	</ul>
 	</li>
 	<li>Core
 	<ul>
-		<li>Import patch <a href="http://root.cern.ch/viewvc?rev=42757&amp;root=root&amp;view=rev" target="_blank">#42757</a> fixing memory leak due to multiple allocations of gLibraryVersion.</li>
+		<li>Import patch <a href="http://root.cern/viewvc?rev=42757&amp;root=root&amp;view=rev" target="_blank">#42757</a> fixing memory leak due to multiple allocations of gLibraryVersion.</li>
 		<li>Add missing implementation for TGenericClassInfo::GetDirectoryAutoAdd.</li>
 	</ul>
 	</li>
 	<li>Proof
 	<ul>
-		<li>Adapt patch <a href="http://root.cern.ch/viewvc?rev=42671&amp;root=root&amp;view=rev" target="_blank">#42671</a> fixing a problem with TProof::Load reported in the PROOF forum, caused by the fact that the additional files were not copied in the master sandbox but left in the cache.</li>
-		<li>Import patch <a href="http://root.cern.ch/viewvc?rev=42904&amp;root=root&amp;view=rev" target="_blank">#42904</a> in TProofOutputFile changing the default mode for merging histograms in TFileMerger, to reduce the memory footprint.</li>
-		<li>Import patch <a href="http://root.cern.ch/viewvc?rev=40744&amp;root=root&amp;view=rev" target="_blank">#40744</a> fixing usage of enums in the PDB macro in TProofMonSenderML and TProofMonSenderSQL.</li>
-		<li>Adapt/import patches <a href="http://root.cern.ch/viewvc?rev=38922&amp;root=root&amp;view=rev" target="_blank">#38922</a> and <a href="http://root.cern.ch/viewvc?rev=42921&amp;root=root&amp;view=rev" target="_blank">#42921</a> to add the possibility to disable reconnections via the variable TXSocket.Reconnect (0 disable reconnections; default is 1) .</li>
-		<li>Import patch <a href="http://root.cern.ch/viewvc?rev=43245&amp;root=root&amp;view=rev" target="_blank">#43245</a> fixing an issue with forcing local copies of files before merging (bit not always honored).</li>
+		<li>Adapt patch <a href="http://root.cern/viewvc?rev=42671&amp;root=root&amp;view=rev" target="_blank">#42671</a> fixing a problem with TProof::Load reported in the PROOF forum, caused by the fact that the additional files were not copied in the master sandbox but left in the cache.</li>
+		<li>Import patch <a href="http://root.cern/viewvc?rev=42904&amp;root=root&amp;view=rev" target="_blank">#42904</a> in TProofOutputFile changing the default mode for merging histograms in TFileMerger, to reduce the memory footprint.</li>
+		<li>Import patch <a href="http://root.cern/viewvc?rev=40744&amp;root=root&amp;view=rev" target="_blank">#40744</a> fixing usage of enums in the PDB macro in TProofMonSenderML and TProofMonSenderSQL.</li>
+		<li>Adapt/import patches <a href="http://root.cern/viewvc?rev=38922&amp;root=root&amp;view=rev" target="_blank">#38922</a> and <a href="http://root.cern/viewvc?rev=42921&amp;root=root&amp;view=rev" target="_blank">#42921</a> to add the possibility to disable reconnections via the variable TXSocket.Reconnect (0 disable reconnections; default is 1) .</li>
+		<li>Import patch <a href="http://root.cern/viewvc?rev=43245&amp;root=root&amp;view=rev" target="_blank">#43245</a> fixing an issue with forcing local copies of files before merging (bit not always honored).</li>
 	</ul>
 	</li>
 	<li>TTree
@@ -59,12 +59,12 @@ sidebar:
 <ul>
 	<li>Proof
 	<ul>
-		<li>Import patches <a href="http://root.cern.ch/viewvc?rev=40912&amp;root=root&amp;view=rev" target="_blank">#40912</a> and <a href="http://root.cern.ch/viewvc?rev=40923&amp;root=root&amp;view=rev" target="_blank">#40923</a> adding the possibility to skip the checks for the data directories during session startup, as they may significantly slowdown the startup process is the medium is busy.</li>
-		<li>Import patches <a href="http://root.cern.ch/viewvc?rev=41313&amp;root=root&amp;view=rev" target="_blank">#41313</a>, <a href="http://root.cern.ch/viewvc?rev=41336&amp;root=root&amp;view=rev" target="_blank">#41336</a>, <a href="http://root.cern.ch/viewvc?rev=41355&amp;root=root&amp;view=rev" target="_blank">#41355</a>, <a href="http://root.cern.ch/viewvc?rev=41378&amp;root=root&amp;view=rev" target="_blank">#41378</a> and <a href="http://root.cern.ch/viewvc?rev=41383&amp;root=root&amp;view=rev" target="_blank">#41383</a> fixing unprivileged multi-user support and access control.</li>
-		<li>Import patches <a href="http://root.cern.ch/viewvc?rev=41393&amp;root=root&amp;view=rev" target="_blank">#41393</a> and <a href="http://root.cern.ch/viewvc?rev=41399&amp;root=root&amp;view=rev" target="_blank">#41399</a> fixing possible issues with PATH and LD_LIBRARY_PATH settings for proofserv.</li>
-		<li>Import patches <a href="http://root.cern.ch/viewvc?rev=40576&amp;root=root&amp;view=rev" target="_blank">#40576</a>, <a href="http://root.cern.ch/viewvc?rev=40699&amp;root=root&amp;view=rev" target="_blank">#40699</a> and <a href="http://root.cern.ch/viewvc?rev=40758&amp;root=root&amp;view=rev" target="_blank">#40758</a> with the improvements in PROOF monitoring.</li>
-		<li>Import patch <a href="http://root.cern.ch/viewvc?rev=41493&amp;root=root&amp;view=rev" target="_blank">#41493</a> fixing return codes on TProof::EnablePackage(...) failures.</li>
-		<li>Import patches <a href="http://root.cern.ch/viewvc?rev=41785&amp;root=root&amp;view=rev" target="_blank">#41785</a> and <a href="http://root.cern.ch/viewvc?rev=41786&amp;root=root&amp;view=rev" target="_blank">#41786</a> fixing an issue with packetizers preventing proper entry range processing and the file ordering in datasets.</li>
+		<li>Import patches <a href="http://root.cern/viewvc?rev=40912&amp;root=root&amp;view=rev" target="_blank">#40912</a> and <a href="http://root.cern/viewvc?rev=40923&amp;root=root&amp;view=rev" target="_blank">#40923</a> adding the possibility to skip the checks for the data directories during session startup, as they may significantly slowdown the startup process is the medium is busy.</li>
+		<li>Import patches <a href="http://root.cern/viewvc?rev=41313&amp;root=root&amp;view=rev" target="_blank">#41313</a>, <a href="http://root.cern/viewvc?rev=41336&amp;root=root&amp;view=rev" target="_blank">#41336</a>, <a href="http://root.cern/viewvc?rev=41355&amp;root=root&amp;view=rev" target="_blank">#41355</a>, <a href="http://root.cern/viewvc?rev=41378&amp;root=root&amp;view=rev" target="_blank">#41378</a> and <a href="http://root.cern/viewvc?rev=41383&amp;root=root&amp;view=rev" target="_blank">#41383</a> fixing unprivileged multi-user support and access control.</li>
+		<li>Import patches <a href="http://root.cern/viewvc?rev=41393&amp;root=root&amp;view=rev" target="_blank">#41393</a> and <a href="http://root.cern/viewvc?rev=41399&amp;root=root&amp;view=rev" target="_blank">#41399</a> fixing possible issues with PATH and LD_LIBRARY_PATH settings for proofserv.</li>
+		<li>Import patches <a href="http://root.cern/viewvc?rev=40576&amp;root=root&amp;view=rev" target="_blank">#40576</a>, <a href="http://root.cern/viewvc?rev=40699&amp;root=root&amp;view=rev" target="_blank">#40699</a> and <a href="http://root.cern/viewvc?rev=40758&amp;root=root&amp;view=rev" target="_blank">#40758</a> with the improvements in PROOF monitoring.</li>
+		<li>Import patch <a href="http://root.cern/viewvc?rev=41493&amp;root=root&amp;view=rev" target="_blank">#41493</a> fixing return codes on TProof::EnablePackage(...) failures.</li>
+		<li>Import patches <a href="http://root.cern/viewvc?rev=41785&amp;root=root&amp;view=rev" target="_blank">#41785</a> and <a href="http://root.cern/viewvc?rev=41786&amp;root=root&amp;view=rev" target="_blank">#41786</a> fixing an issue with packetizers preventing proper entry range processing and the file ordering in datasets.</li>
 	</ul>
 	</li>
 	<li>Build System
@@ -79,7 +79,7 @@ sidebar:
 <ul>
 	<li>Core
 	<ul>
-		<li>Import patch <a href="http://root.cern.ch/viewvc?rev=40534&amp;root=root&amp;view=rev" target="_blank">#40534</a> to silence spurious warnings when removing objects from TObjectTable.</li>
+		<li>Import patch <a href="http://root.cern/viewvc?rev=40534&amp;root=root&amp;view=rev" target="_blank">#40534</a> to silence spurious warnings when removing objects from TObjectTable.</li>
 		<li>Allow home directory to be specified via HOME shell var in case there is no correct passwd file entry, fixes issue <a href="http://savannah.cern.ch/bugs/?83268" target="_blank">83268</a></li>
 	</ul>
 	</li>
@@ -97,9 +97,9 @@ sidebar:
 	</li>
 	<li>Proof
 	<ul>
-		<li>Import new version 0.9.6 of afdsmgrd (patch <a href="http://root.cern.ch/viewvc?rev=40573&amp;root=root&amp;view=rev" target="_blank">#40573</a>) with improvements needed by ALICE.</li>
-		<li>Import patch <a href="http://root.cern.ch/viewvc?rev=40659&amp;root=root&amp;view=rev" target="_blank">#40659</a> fixing a possible seg violation when exiting ROOT.</li>
-		<li>Import patch <a href="http://root.cern.ch/viewvc?rev=40660&amp;root=root&amp;view=rev" target="_blank">#40660</a> restoring operability of the dynamic startup (broken by patch 36553).</li>
+		<li>Import new version 0.9.6 of afdsmgrd (patch <a href="http://root.cern/viewvc?rev=40573&amp;root=root&amp;view=rev" target="_blank">#40573</a>) with improvements needed by ALICE.</li>
+		<li>Import patch <a href="http://root.cern/viewvc?rev=40659&amp;root=root&amp;view=rev" target="_blank">#40659</a> fixing a possible seg violation when exiting ROOT.</li>
+		<li>Import patch <a href="http://root.cern/viewvc?rev=40660&amp;root=root&amp;view=rev" target="_blank">#40660</a> restoring operability of the dynamic startup (broken by patch 36553).</li>
 	</ul>
 	</li>
 </ul>
@@ -109,26 +109,26 @@ sidebar:
 <ul>
 	<li>TTree
 	<ul>
-		<li>Import fix <a href="http://root.cern.ch/viewvc?rev=40077&amp;root=root&amp;view=rev" target="_blank">#40077</a> to prevent the use of non-existent memory when reading in an object that is part of an STL collection and which used to contains an embedded object (and this data member has been removed)(bug <a href="https://savannah.cern.ch/bugs/?83793" target="_blank">#83793</a>).</li>
+		<li>Import fix <a href="http://root.cern/viewvc?rev=40077&amp;root=root&amp;view=rev" target="_blank">#40077</a> to prevent the use of non-existent memory when reading in an object that is part of an STL collection and which used to contains an embedded object (and this data member has been removed)(bug <a href="https://savannah.cern.ch/bugs/?83793" target="_blank">#83793</a>).</li>
 	</ul>
 	</li>
 	<li>Hist
 	<ul>
-		<li>Import fix <a href="http://root.cern.ch/viewvc?rev=39628&amp;root=root&amp;view=rev" target="_blank">#39628</a> in TH1::LabelsInflate or Deflate (bug <a href="https://savannah.cern.ch/bugs/?83066" target="_blank">#83066</a>).</li>
+		<li>Import fix <a href="http://root.cern/viewvc?rev=39628&amp;root=root&amp;view=rev" target="_blank">#39628</a> in TH1::LabelsInflate or Deflate (bug <a href="https://savannah.cern.ch/bugs/?83066" target="_blank">#83066</a>).</li>
 	</ul>
 	</li>
 	<li>Proof
 	<ul>
-		<li>Import new version of afdsmgrd (patch <a href="http://root.cern.ch/viewvc?rev=39968&amp;root=root&amp;view=rev" target="_blank">#39968</a>) with a fix needed by ALICE.</li>
-		<li>Import patch <a href="http://root.cern.ch/viewvc?rev=39442&amp;root=root&amp;view=rev" target="_blank">#39442</a> and <a href="http://root.cern.ch/viewvc?rev=40186&amp;root=root&amp;view=rev" target="_blank">#40186</a> improving histogram merging by using TH1::Add when the axis are equal; this is much faster than TH1::Merge and uses less memory.</li>
-		<li>Import patch <a href="http://root.cern.ch/viewvc?rev=40017&amp;root=root&amp;view=rev" target="_blank">#40017</a>&nbsp;making the query exit status available for monitoring and in the output list.</li>
-		<li>Import patch <a href="http://root.cern.ch/viewvc?rev=37663&amp;root=root&amp;view=rev" target="_blank">#37663</a>&nbsp;consolidating the behavior of TProof::ClearPackages.</li>
-		<li>Import patch <a href="http://root.cern.ch/viewvc?rev=40359&amp;root=root&amp;view=rev" target="_blank">#40359</a>&nbsp; fixing an issue showing up in PROOF-Lite when merging via files.</li>
+		<li>Import new version of afdsmgrd (patch <a href="http://root.cern/viewvc?rev=39968&amp;root=root&amp;view=rev" target="_blank">#39968</a>) with a fix needed by ALICE.</li>
+		<li>Import patch <a href="http://root.cern/viewvc?rev=39442&amp;root=root&amp;view=rev" target="_blank">#39442</a> and <a href="http://root.cern/viewvc?rev=40186&amp;root=root&amp;view=rev" target="_blank">#40186</a> improving histogram merging by using TH1::Add when the axis are equal; this is much faster than TH1::Merge and uses less memory.</li>
+		<li>Import patch <a href="http://root.cern/viewvc?rev=40017&amp;root=root&amp;view=rev" target="_blank">#40017</a>&nbsp;making the query exit status available for monitoring and in the output list.</li>
+		<li>Import patch <a href="http://root.cern/viewvc?rev=37663&amp;root=root&amp;view=rev" target="_blank">#37663</a>&nbsp;consolidating the behavior of TProof::ClearPackages.</li>
+		<li>Import patch <a href="http://root.cern/viewvc?rev=40359&amp;root=root&amp;view=rev" target="_blank">#40359</a>&nbsp; fixing an issue showing up in PROOF-Lite when merging via files.</li>
 	</ul>
 	</li>
 	<li>Netx/Xrootd
 	<ul>
-		<li>Import patches <a href="http://root.cern.ch/viewvc?rev=40435&amp;root=root&amp;view=rev" target="_blank">#40435</a> and <a href="http://root.cern.ch/viewvc?rev=40436&amp;root=root&amp;view=rev" target="_blank">#40436</a> &nbsp; to fix the issues preventing proper notification of XrdClient authentication errors.</li>
+		<li>Import patches <a href="http://root.cern/viewvc?rev=40435&amp;root=root&amp;view=rev" target="_blank">#40435</a> and <a href="http://root.cern/viewvc?rev=40436&amp;root=root&amp;view=rev" target="_blank">#40436</a> &nbsp; to fix the issues preventing proper notification of XrdClient authentication errors.</li>
 	</ul>
 	</li>
 </ul>
@@ -143,14 +143,14 @@ sidebar:
 	</li>
 	<li>Proof
 	<ul>
-		<li>Import patch <a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=39152" target="_blank">#39152</a> improving solidity of file name matching in TPacketizerFile.</li>
-		<li>Import patch <a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=39171" target="_blank">#39171</a> fixing merging of TProofOutputFiles with submergers (see <a href="http://root.cern.ch/phpBB3/viewtopic.php?f=13&amp;t=12598" target="_blank" title="http://root.cern.ch/phpBB3/viewtopic.php?f=13&amp;t=12598">http://root.cern.ch/phpBB3/viewtopic.php?f=13&amp;t=12598</a>).</li>
-		<li>Import patch <a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=39173" target="_blank">#39173</a> to include transmission of the orginal weight to TProofDraw is 'DrawSelect' operations. See <a href="http://root.cern.ch/phpBB3/viewtopic.php?f=13&amp;t=12728" target="_blank" title="http://root.cern.ch/phpBB3/viewtopic.php?f=13&amp;t=12728">http://root.cern.ch/phpBB3/viewtopic.php?f=13&amp;t=12728</a> .</li>
-		<li>Import patch <a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=39309" target="_blank">#39309</a> importing version 0.9.3 of afdsmgrd.</li>
-		<li>Import patch <a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=39579" target="_blank">#39579</a> avoid a segmentation fault when reading file where the AutoFlush mechanism has been disabled and the TTreeCache is requested nonetheless.</li>
-		<li>Import patch <a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=39580" target="_blank">#39580</a> fixing an issue with connections via a SSH tunnel.</li>
-		<li>Import patch <a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=39585" target="_blank">#39585</a> and <a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=39835" target="_blank">#39835</a> fixing an issue preventing the correct handling of a 'Stop' request.</li>
-		<li>Import patch <a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=39835" target="_blank">#39835</a> fixing an issue screwing up the number of events to be processed when specified; the patch also fixes an issue with the option 'ForceLocal' on 'file:///' URLs.</li>
+		<li>Import patch <a href="http://root.cern/viewcvs?view=rev&amp;revision=39152" target="_blank">#39152</a> improving solidity of file name matching in TPacketizerFile.</li>
+		<li>Import patch <a href="http://root.cern/viewcvs?view=rev&amp;revision=39171" target="_blank">#39171</a> fixing merging of TProofOutputFiles with submergers (see <a href="http://root.cern/phpBB3/viewtopic.php?f=13&amp;t=12598" target="_blank" title="http://root.cern/phpBB3/viewtopic.php?f=13&amp;t=12598">http://root.cern/phpBB3/viewtopic.php?f=13&amp;t=12598</a>).</li>
+		<li>Import patch <a href="http://root.cern/viewcvs?view=rev&amp;revision=39173" target="_blank">#39173</a> to include transmission of the orginal weight to TProofDraw is 'DrawSelect' operations. See <a href="http://root.cern/phpBB3/viewtopic.php?f=13&amp;t=12728" target="_blank" title="http://root.cern/phpBB3/viewtopic.php?f=13&amp;t=12728">http://root.cern/phpBB3/viewtopic.php?f=13&amp;t=12728</a> .</li>
+		<li>Import patch <a href="http://root.cern/viewcvs?view=rev&amp;revision=39309" target="_blank">#39309</a> importing version 0.9.3 of afdsmgrd.</li>
+		<li>Import patch <a href="http://root.cern/viewcvs?view=rev&amp;revision=39579" target="_blank">#39579</a> avoid a segmentation fault when reading file where the AutoFlush mechanism has been disabled and the TTreeCache is requested nonetheless.</li>
+		<li>Import patch <a href="http://root.cern/viewcvs?view=rev&amp;revision=39580" target="_blank">#39580</a> fixing an issue with connections via a SSH tunnel.</li>
+		<li>Import patch <a href="http://root.cern/viewcvs?view=rev&amp;revision=39585" target="_blank">#39585</a> and <a href="http://root.cern/viewcvs?view=rev&amp;revision=39835" target="_blank">#39835</a> fixing an issue preventing the correct handling of a 'Stop' request.</li>
+		<li>Import patch <a href="http://root.cern/viewcvs?view=rev&amp;revision=39835" target="_blank">#39835</a> fixing an issue screwing up the number of events to be processed when specified; the patch also fixes an issue with the option 'ForceLocal' on 'file:///' URLs.</li>
 	</ul>
 	</li>
 	<li>Core
@@ -193,8 +193,8 @@ sidebar:
 	<li>Proof
 	<ul>
 		<li>Import the dataset stager daemon (afdsmgrd).</li>
-		<li>Import patch <a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=39074" target="_blank">#39074</a> in TProof and TProofServ, fixing an issue affecting the result of subsequent worker activation/deactivation requests when worker ordinal numbers were not in increasing order; the patch also adds support for block requests and for a return code with the result of the action.</li>
-		<li>Import patch <a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=39088" target="_blank">#39088</a> fixing some issues in TPacketizerUnit, particularly visible in clusters with inhomogeneous machines.</li>
+		<li>Import patch <a href="http://root.cern/viewcvs?view=rev&amp;revision=39074" target="_blank">#39074</a> in TProof and TProofServ, fixing an issue affecting the result of subsequent worker activation/deactivation requests when worker ordinal numbers were not in increasing order; the patch also adds support for block requests and for a return code with the result of the action.</li>
+		<li>Import patch <a href="http://root.cern/viewcvs?view=rev&amp;revision=39088" target="_blank">#39088</a> fixing some issues in TPacketizerUnit, particularly visible in clusters with inhomogeneous machines.</li>
 	</ul>
 	</li>
 	<li>CINT
@@ -246,7 +246,7 @@ sidebar:
 	<ul>
 		<li>Improve performance of the BranchRef mechanism (by avoid duplicate reading of the RefTable)</li>
 		<li>Prevent segmentation fault when re-using a TTree object to read from a file (fixes issue <a href="https://savannah.cern.ch/bugs/index.php?79648" target="_blank">#79648</a>).</li>
-		<li>Fix the reading of THashList when stored in TTree (see <a href="http://root.cern.ch/phpBB3/viewtopic.php?p=53684" target="_blank">this report</a> in the forum.)</li>
+		<li>Fix the reading of THashList when stored in TTree (see <a href="http://root.cern/phpBB3/viewtopic.php?p=53684" target="_blank">this report</a> in the forum.)</li>
 		<li>Fix a typo in the code generated by MakeProxy that prevented the dictionary generation for some of the STL containers used in the proxy.</li>
 		<li>Fix the reading of file produced by v4.00/08 where some of the (rarely used) baskets were not completely initialized properly.</li>
 		<li>Honor the flag TSelector::kAbortFile in TTree::Process.</li>
@@ -254,19 +254,19 @@ sidebar:
 	</li>
 	<li>Proof
 	<ul>
-		<li>Import patch <a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=38226" target="_blank">#38226</a> in test/stressProof.cxx, fixing the order in which objects are destroyed at the end of the test.</li>
-		<li>Import patch <a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=38538" target="_blank">#38538</a> fixing a problem with the interrupt of sockets turning 'bad'. Should solve some of the cases were slow response was experienced.</li>
-		<li>Import patches <a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=38570" target="_blank">#38570</a>,<a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=38574" target="_blank">#38574</a> adding support for log file truncation.</li>
-		<li>Import patches <a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=38572" target="_blank">#38572</a>,<a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=38575" target="_blank">#38575</a>&nbsp;to filter out PROOF internal objects when displaying or printing the output list.</li>
-		<li>Import patches <a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=38580" target="_blank">#38580</a>,<a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=38581" target="_blank">#38581</a>, <a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=38588" target="_blank">#38588</a>, <a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=38632" target="_blank">#38632</a>, <a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=38765" target="_blank">#38765</a> fixing a problem with log path transmission when the node dies early or not even starts.</li>
-		<li>Import patches <a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=38220" target="_blank">#38220</a>, <a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=38221" target="_blank">#38221</a>, <a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=38222" target="_blank">#38222</a>, <a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=38227" target="_blank">#38227</a>, <a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=38228" target="_blank">#38228</a>, <a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=38577" target="_blank">#38577</a>, <a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=38593" target="_blank">#38593</a>, <a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=38594" target="_blank">#38594</a> , <a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=38600" target="_blank">#38600</a> adding the possibility to access the files on the workers via the same port used by PROOF.</li>
-		<li>Import patches <a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=38616" target="_blank">#38616</a> fixing a bug while checking the first event against the file event ranges; the bug was introduced in 5.28/00 and the effect was that any specification of the number of entries to process was ignored.</li>
-		<li>Import patches <a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=38618" target="_blank">#38618</a> fixing an issue with setting the default output file name when merging files with TProofOutputFile.</li>
-		<li>Import patch <a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=38691" target="_blank">#38691</a> in TProofOutputFile, fixing issue affecting the case when temporary files are created on a shared file system other than the one with the sandboxes. This case, which seems to be a rather common one, should be now fully supported.</li>
-		<li>Import patches <a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=38758" target="_blank">#38758</a> and <a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=38760" target="_blank">#38760</a> adding missing calls to closedir() and TSystem::FreeDirectory. This solves the problem of open file descriptors in for xproofd after a scan of a dataset directory tree.</li>
-		<li>Import patch <a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=38810" target="_blank">#38810</a> to correctly honour the TSelector::kAbortFile settings during processing. This patch also fixes other related issues, in particular with the reporting of the non-processed {files, events} in the final 'MissingFiles' list.</li>
-		<li>Import patches <a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=38709" target="_blank">#38709</a> and <a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=38779" target="_blank">#38779</a> improving the monitoring to send additional information about memory usage during the query, the name and size (# of files) of the dataset processed (if any). It also adds the possibility to send the information to multiple monitoring collectors. Documentation updated at <a href="http://root.cern.ch/drupal/content/enabling-query-monitoring" target="_blank" title="http://root.cern.ch/drupal/content/enabling-query-monitoring">http://root.cern.ch/drupal/content/enabling-query-monitoring</a> <span style="color:#B22222;">(broken)</span>.</li>
-		<li>Import patch <a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=38720" target="_blank">#38720</a> fix a problem in pq2-ana-dist with the labels of the distribution histogram, occurring when machines are represented by IPs instead of FQD names</li>
+		<li>Import patch <a href="http://root.cern/viewcvs?view=rev&amp;revision=38226" target="_blank">#38226</a> in test/stressProof.cxx, fixing the order in which objects are destroyed at the end of the test.</li>
+		<li>Import patch <a href="http://root.cern/viewcvs?view=rev&amp;revision=38538" target="_blank">#38538</a> fixing a problem with the interrupt of sockets turning 'bad'. Should solve some of the cases were slow response was experienced.</li>
+		<li>Import patches <a href="http://root.cern/viewcvs?view=rev&amp;revision=38570" target="_blank">#38570</a>,<a href="http://root.cern/viewcvs?view=rev&amp;revision=38574" target="_blank">#38574</a> adding support for log file truncation.</li>
+		<li>Import patches <a href="http://root.cern/viewcvs?view=rev&amp;revision=38572" target="_blank">#38572</a>,<a href="http://root.cern/viewcvs?view=rev&amp;revision=38575" target="_blank">#38575</a>&nbsp;to filter out PROOF internal objects when displaying or printing the output list.</li>
+		<li>Import patches <a href="http://root.cern/viewcvs?view=rev&amp;revision=38580" target="_blank">#38580</a>,<a href="http://root.cern/viewcvs?view=rev&amp;revision=38581" target="_blank">#38581</a>, <a href="http://root.cern/viewcvs?view=rev&amp;revision=38588" target="_blank">#38588</a>, <a href="http://root.cern/viewcvs?view=rev&amp;revision=38632" target="_blank">#38632</a>, <a href="http://root.cern/viewcvs?view=rev&amp;revision=38765" target="_blank">#38765</a> fixing a problem with log path transmission when the node dies early or not even starts.</li>
+		<li>Import patches <a href="http://root.cern/viewcvs?view=rev&amp;revision=38220" target="_blank">#38220</a>, <a href="http://root.cern/viewcvs?view=rev&amp;revision=38221" target="_blank">#38221</a>, <a href="http://root.cern/viewcvs?view=rev&amp;revision=38222" target="_blank">#38222</a>, <a href="http://root.cern/viewcvs?view=rev&amp;revision=38227" target="_blank">#38227</a>, <a href="http://root.cern/viewcvs?view=rev&amp;revision=38228" target="_blank">#38228</a>, <a href="http://root.cern/viewcvs?view=rev&amp;revision=38577" target="_blank">#38577</a>, <a href="http://root.cern/viewcvs?view=rev&amp;revision=38593" target="_blank">#38593</a>, <a href="http://root.cern/viewcvs?view=rev&amp;revision=38594" target="_blank">#38594</a> , <a href="http://root.cern/viewcvs?view=rev&amp;revision=38600" target="_blank">#38600</a> adding the possibility to access the files on the workers via the same port used by PROOF.</li>
+		<li>Import patches <a href="http://root.cern/viewcvs?view=rev&amp;revision=38616" target="_blank">#38616</a> fixing a bug while checking the first event against the file event ranges; the bug was introduced in 5.28/00 and the effect was that any specification of the number of entries to process was ignored.</li>
+		<li>Import patches <a href="http://root.cern/viewcvs?view=rev&amp;revision=38618" target="_blank">#38618</a> fixing an issue with setting the default output file name when merging files with TProofOutputFile.</li>
+		<li>Import patch <a href="http://root.cern/viewcvs?view=rev&amp;revision=38691" target="_blank">#38691</a> in TProofOutputFile, fixing issue affecting the case when temporary files are created on a shared file system other than the one with the sandboxes. This case, which seems to be a rather common one, should be now fully supported.</li>
+		<li>Import patches <a href="http://root.cern/viewcvs?view=rev&amp;revision=38758" target="_blank">#38758</a> and <a href="http://root.cern/viewcvs?view=rev&amp;revision=38760" target="_blank">#38760</a> adding missing calls to closedir() and TSystem::FreeDirectory. This solves the problem of open file descriptors in for xproofd after a scan of a dataset directory tree.</li>
+		<li>Import patch <a href="http://root.cern/viewcvs?view=rev&amp;revision=38810" target="_blank">#38810</a> to correctly honour the TSelector::kAbortFile settings during processing. This patch also fixes other related issues, in particular with the reporting of the non-processed {files, events} in the final 'MissingFiles' list.</li>
+		<li>Import patches <a href="http://root.cern/viewcvs?view=rev&amp;revision=38709" target="_blank">#38709</a> and <a href="http://root.cern/viewcvs?view=rev&amp;revision=38779" target="_blank">#38779</a> improving the monitoring to send additional information about memory usage during the query, the name and size (# of files) of the dataset processed (if any). It also adds the possibility to send the information to multiple monitoring collectors. Documentation updated at <a href="http://root.cern/drupal/content/enabling-query-monitoring" target="_blank" title="http://root.cern/drupal/content/enabling-query-monitoring">http://root.cern/drupal/content/enabling-query-monitoring</a> <span style="color:#B22222;">(broken)</span>.</li>
+		<li>Import patch <a href="http://root.cern/viewcvs?view=rev&amp;revision=38720" target="_blank">#38720</a> fix a problem in pq2-ana-dist with the labels of the distribution histogram, occurring when machines are represented by IPs instead of FQD names</li>
 	</ul>
 	</li>
 	<li>GUI
@@ -313,7 +313,7 @@ sidebar:
 	<ul>
 		<li>Fix lookup of functions with prototype when one of the parameters is of function pointer type (r38251, <a href="https://savannah.cern.ch/bugs/index.php?78657" target="_blank">#78657</a>).</li>
 		<li>Don't try to invoke destructors of unnamed structs (r38253, <a href="https://savannah.cern.ch/bugs/index.php?78837" target="_blank">#78837</a>).</li>
-		<li>Don't prepend prec_stl to headers included for automatic dictionaries (r38272, vector&lt;vector&lt;int&gt; &gt; at <a href="http://root.cern.ch/phpBB3/viewtopic.php?f=3&amp;t=12121" target="_blank">forum</a>).</li>
+		<li>Don't prepend prec_stl to headers included for automatic dictionaries (r38272, vector&lt;vector&lt;int&gt; &gt; at <a href="http://root.cern/phpBB3/viewtopic.php?f=3&amp;t=12121" target="_blank">forum</a>).</li>
 		<li>Fix <span class="geshifilter"><code class="cpp geshifilter-cpp"><span style="color: #339900;">#pragma link C++ class NameSpace::*;</span></code></span> which before was only creating a dictionary for the first class (r38281).</li>
 		<li>Do not treat a failure in opening a shared library as an interpreter error (r38377, <a href="https://savannah.cern.ch/bugs/index.php?78511" target="_blank">#78511</a>).</li>
 		<li>Cintex
@@ -332,15 +332,15 @@ sidebar:
 	</li>
 	<li>TTree
 	<ul>
-		<li>Fix the issue with TTree::Draw, SetMakeClass and collection reported in <a href="http://root.cern.ch/phpBB3/viewtopic.php?t=12237" target="_blank">this forum post</a>.</li>
+		<li>Fix the issue with TTree::Draw, SetMakeClass and collection reported in <a href="http://root.cern/phpBB3/viewtopic.php?t=12237" target="_blank">this forum post</a>.</li>
 		<li>Fix the case of a split collection containing at least one data member which is an instance of class with one or more base classes that can not be split (for example std::vector<int>). See savannah <a href="https://savannah.cern.ch/bugs/?79235" target="_blank">#79235</a>.</int></li>
 	</ul>
 	</li>
 	<li>Proof
 	<ul>
-		<li>Import fix <a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=38215" target="_blank">#38215</a> adding a missing protection in TFileInfo::Print().</li>
-		<li>Import patches <a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=38347" target="_blank">#38347</a> and <a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=38348" target="_blank">#38348</a> in PROOF-Lite fixing a problem with passing the 'varexp' and 'selection' strings for processing, preventing correct usage of the operators '|' and '||' in TTreeFormula, and making sure that the required dataset is registered when such option is specified in TProofOutputFile.</li>
-		<li>Import patch <a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=38380" target="_blank">#38380</a> fixing a possible truncation in the TProofOutputFile constructor when 'Proof.Localroot' is defined.</li>
+		<li>Import fix <a href="http://root.cern/viewcvs?view=rev&amp;revision=38215" target="_blank">#38215</a> adding a missing protection in TFileInfo::Print().</li>
+		<li>Import patches <a href="http://root.cern/viewcvs?view=rev&amp;revision=38347" target="_blank">#38347</a> and <a href="http://root.cern/viewcvs?view=rev&amp;revision=38348" target="_blank">#38348</a> in PROOF-Lite fixing a problem with passing the 'varexp' and 'selection' strings for processing, preventing correct usage of the operators '|' and '||' in TTreeFormula, and making sure that the required dataset is registered when such option is specified in TProofOutputFile.</li>
+		<li>Import patch <a href="http://root.cern/viewcvs?view=rev&amp;revision=38380" target="_blank">#38380</a> fixing a possible truncation in the TProofOutputFile constructor when 'Proof.Localroot' is defined.</li>
 	</ul>
 	</li>
 </ul>
@@ -366,7 +366,7 @@ sidebar:
 		<li>Fixes in TRef::SetAction(). Fixes <a href="https://savannah.cern.ch/bugs/?77570" target="_blank">77570</a> and <a href="https://savannah.cern.ch/bugs/?77725" target="_blank">77725</a>.</li>
 		<li>Fix initialization of noTree in hadd (<a href="https://savannah.cern.ch/bugs/?77981" target="_blank">77981</a>).</li>
 		<li>Avoid unneeded TROOT::LoadMacro() call when loading a plugin.</li>
-		<li>Import patch <a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=38102" target="_blank">#38109</a> fixing a the MD5 initialization in TFileInfo.</li>
+		<li>Import patch <a href="http://root.cern/viewcvs?view=rev&amp;revision=38102" target="_blank">#38109</a> fixing a the MD5 initialization in TFileInfo.</li>
 		<li>Fix in TList::Delete(), check for 0 before dereferencing. Fixes issue <a href="https://savannah.cern.ch/bugs/?78529" target="_blank">78529</a>.</li>
 	</ul>
 	</li>
@@ -379,7 +379,7 @@ sidebar:
 		<li>Provide default argument for set's second template parameter (<a href="https://savannah.cern.ch/bugs/index.php?76671" target="_blank">bug #76671</a>, r37737).</li>
 		<li>Fix parsing of spaces-in-structs (r37746, r37748).</li>
 		<li>Enable Qt CINT dictionary for current (4.7) versions (r37747).</li>
-		<li>Fix #inclusion of ROOT headers in automatic dictionary generator (<a href="http://root.cern.ch/phpBB3/viewtopic.php?f=3&amp;t=11933" target="_blank">forum</a>, r37774).</li>
+		<li>Fix #inclusion of ROOT headers in automatic dictionary generator (<a href="http://root.cern/phpBB3/viewtopic.php?f=3&amp;t=11933" target="_blank">forum</a>, r37774).</li>
 		<li>More fixes to parsing spaces in type names in declarations (r37777).</li>
 		<li>Function arguments of type pointer to function returning <tt>long xyz</tt> lost their <tt>long</tt> part: fixed (r37783, r37785).</li>
 		<li>Unloading libraries was sometimes causing errors with the (re-)initialization of unrelated libraries (r38154).</li>
@@ -407,31 +407,31 @@ sidebar:
 	</li>
 	<li>Graf
 	<ul>
-		<li>Revision <a href="http://root.cern.ch/viewvc?view=rev&amp;revision=37541" target="_blank">#37541</a> created a problem with COL option displayed in LogZ.</li>
+		<li>Revision <a href="http://root.cern/viewvc?view=rev&amp;revision=37541" target="_blank">#37541</a> created a problem with COL option displayed in LogZ.</li>
 	</ul>
 	</li>
 	<li>Proof
 	<ul>
-		<li>Import fix <a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=37664" target="_blank">#37664</a> fixing a crash when running vs servers not having the fix for the missing files list (&lt; 5.28/00)</li>
-		<li>Import fix <a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=37894" target="_blank">#37894</a> adding support for option ':lite:' to TProof::GetDataSets; this allows to fill the map with only the summary information about the datasets (the header of TFileCollections), significantly increasing the speed and the memory footprint when the number of datasets is very large. Should solve Savannah issue #77303</li>
-		<li>Import fix <a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=37897" target="_blank">#37897</a> adding support for '.' in user names in dataset paths (see Savannah issue #77378)</li>
-		<li>Import fix <a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=37934" target="_blank">#37934</a> in TDataSetManagerFile::NotifyUpdate, improving handling of the case when the file with the global list of datasets does not exist. Fixes an error occurring in new installations or with new dataset directories.</li>
-		<li>Import change <a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=37942" target="_blank">#37942</a> in TProof::Load, adding support for multiple-file specification. See also <a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=37976" target="_blank">#37976</a>.</li>
-		<li>Import patch <a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=37951" target="_blank">#37951</a> fixing an issue with the port when using bonjour for worker auto-registration.</li>
-		<li>Import patch <a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=37969" target="_blank">#37969</a> fixing a bug affecting the order in which query results are registered when two queries started within the same second.</li>
-		<li>Import patch <a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=37976" target="_blank">#37976</a> fixing an issue with worker names in PROOF-Lite.</li>
-		<li>Import patch <a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=37980" target="_blank">#37980</a> fixing an issue with event number ranges in the packetizers.</li>
-		<li>Import patch <a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=38102" target="_blank">#38102</a> fixing an issue with enabling packages with option 'notOnClient' in PROOF-Lite.</li>
-		<li>Import patch <a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=38142" target="_blank">#38142</a> fixing a possible appearance of spurious log messages in PROOF-Lite.</li>
-		<li>Import patch <a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=38143" target="_blank">#38143</a> defining envs ROOTPROOFCLIENT and ROOTPROOFLITE when appropriate, so that they can be used in BUILD.sh and/or SETUP.C .</li>
-		<li>In TProofMgrLite, import patch <a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=38177" target="_blank">#38177</a> fixing an issue with the validity check for existing sessions.</li>
-		<li>In TProofMgrLite, import patch <a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=38180" target="_blank">#38180</a> fixing a few issues in the SQL monitoring interface.</li>
+		<li>Import fix <a href="http://root.cern/viewcvs?view=rev&amp;revision=37664" target="_blank">#37664</a> fixing a crash when running vs servers not having the fix for the missing files list (&lt; 5.28/00)</li>
+		<li>Import fix <a href="http://root.cern/viewcvs?view=rev&amp;revision=37894" target="_blank">#37894</a> adding support for option ':lite:' to TProof::GetDataSets; this allows to fill the map with only the summary information about the datasets (the header of TFileCollections), significantly increasing the speed and the memory footprint when the number of datasets is very large. Should solve Savannah issue #77303</li>
+		<li>Import fix <a href="http://root.cern/viewcvs?view=rev&amp;revision=37897" target="_blank">#37897</a> adding support for '.' in user names in dataset paths (see Savannah issue #77378)</li>
+		<li>Import fix <a href="http://root.cern/viewcvs?view=rev&amp;revision=37934" target="_blank">#37934</a> in TDataSetManagerFile::NotifyUpdate, improving handling of the case when the file with the global list of datasets does not exist. Fixes an error occurring in new installations or with new dataset directories.</li>
+		<li>Import change <a href="http://root.cern/viewcvs?view=rev&amp;revision=37942" target="_blank">#37942</a> in TProof::Load, adding support for multiple-file specification. See also <a href="http://root.cern/viewcvs?view=rev&amp;revision=37976" target="_blank">#37976</a>.</li>
+		<li>Import patch <a href="http://root.cern/viewcvs?view=rev&amp;revision=37951" target="_blank">#37951</a> fixing an issue with the port when using bonjour for worker auto-registration.</li>
+		<li>Import patch <a href="http://root.cern/viewcvs?view=rev&amp;revision=37969" target="_blank">#37969</a> fixing a bug affecting the order in which query results are registered when two queries started within the same second.</li>
+		<li>Import patch <a href="http://root.cern/viewcvs?view=rev&amp;revision=37976" target="_blank">#37976</a> fixing an issue with worker names in PROOF-Lite.</li>
+		<li>Import patch <a href="http://root.cern/viewcvs?view=rev&amp;revision=37980" target="_blank">#37980</a> fixing an issue with event number ranges in the packetizers.</li>
+		<li>Import patch <a href="http://root.cern/viewcvs?view=rev&amp;revision=38102" target="_blank">#38102</a> fixing an issue with enabling packages with option 'notOnClient' in PROOF-Lite.</li>
+		<li>Import patch <a href="http://root.cern/viewcvs?view=rev&amp;revision=38142" target="_blank">#38142</a> fixing a possible appearance of spurious log messages in PROOF-Lite.</li>
+		<li>Import patch <a href="http://root.cern/viewcvs?view=rev&amp;revision=38143" target="_blank">#38143</a> defining envs ROOTPROOFCLIENT and ROOTPROOFLITE when appropriate, so that they can be used in BUILD.sh and/or SETUP.C .</li>
+		<li>In TProofMgrLite, import patch <a href="http://root.cern/viewcvs?view=rev&amp;revision=38177" target="_blank">#38177</a> fixing an issue with the validity check for existing sessions.</li>
+		<li>In TProofMgrLite, import patch <a href="http://root.cern/viewcvs?view=rev&amp;revision=38180" target="_blank">#38180</a> fixing a few issues in the SQL monitoring interface.</li>
 	</ul>
 	</li>
 	<li>Hist
 	<ul>
-		<li>Import fix <a href="http://root.cern.ch/viewvc?view=rev&amp;revision=37701" target="_blank">#37701</a> for the drawing of 2D TEfficiency objects&nbsp;</li>
-		<li>Fix bug <a href="https://savannah.cern.ch/bugs/index.php?77149" target="_blank">#77149</a>&nbsp;in LabelsDeflate for TProfile (imported the fix <a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=37911" target="_blank">#37911</a>)</li>
+		<li>Import fix <a href="http://root.cern/viewvc?view=rev&amp;revision=37701" target="_blank">#37701</a> for the drawing of 2D TEfficiency objects&nbsp;</li>
+		<li>Fix bug <a href="https://savannah.cern.ch/bugs/index.php?77149" target="_blank">#77149</a>&nbsp;in LabelsDeflate for TProfile (imported the fix <a href="http://root.cern/viewcvs?view=rev&amp;revision=37911" target="_blank">#37911</a>)</li>
 		<li>Fix a bug in TProfileXD::GetStats which is affecting the global effective entries (bug <a href="https://savannah.cern.ch/bugs/index.php?77751" target="_blank">#77751</a>)</li>
 		<li>Fix TEfficiency::Draw() and possibility to pick and change axes ranges</li>
 		<li>Fix TGraphAsymmErrors() for the case of weighted histograms (bug #<a href="https://savannah.cern.ch/bugs/index.php?78249" target="_blank">78249</a>)</li>
@@ -445,7 +445,7 @@ sidebar:
 	</li>
 	<li>GUI
 	<ul>
-		<li>Fix problems with context menus as reported <a href="http://root.cern.ch/phpBB3/viewtopic.php?f=3&amp;t=12039" target="_blank">on the forum</a></li>
+		<li>Fix problems with context menus as reported <a href="http://root.cern/phpBB3/viewtopic.php?f=3&amp;t=12039" target="_blank">on the forum</a></li>
 		<li>Only call XFreeColors if we are on a &lt;= 8 plane machine (to match calls to XAllocColor). This fixes the bug <a href="https://savannah.cern.ch/bugs/?77329" target="_blank">#77329</a></li>
 		<li>Allow to override CTRL+S behavior by using the TGMainFrame::BindKey() function. Fixes the bug <a href="https://savannah.cern.ch/bugs/?78057" target="_blank">#78057</a></li>
 	</ul>

--- a/install/all_releases/root-version-v5-30-00-patch-release-notes.md
+++ b/install/all_releases/root-version-v5-30-00-patch-release-notes.md
@@ -14,27 +14,27 @@ sidebar:
 <code>/afs/cern.ch/sw/lcg/app/releases/ROOT/5.30.06/ </code>
 
 <p>The complete source tree for all systems (39 MB) is available here:</p>
-<code> <a href="ftp://root.cern.ch/root/root_v5.30.06.source.tar.gz" target="_blank">ftp://root.cern.ch/root/root_v5.30.06.source.tar.gz</a> </code>
+<code> <a href="ftp://root.cern/root/root_v5.30.06.source.tar.gz" target="_blank">ftp://root.cern/root/root_v5.30.06.source.tar.gz</a> </code>
 
 <p>Alternatively get the source from <a href="/node/92" target="_blank">Git</a> using:</p>
-<code> git clone http://root.cern.ch/git/root.git root-v5-30; cd root-v5-30; git checkout -b v5-30-06 </code>
+<code> git clone http://root.cern/git/root.git root-v5-30; cd root-v5-30; git checkout -b v5-30-06 </code>
 
 <p>After obtaining the source read the file <a href="/node/103" target="_blank">README/INSTALL</a> <span>(broken)</span> (in short just do: cd root; ./configure; make).</p>
 
 <p>To get the source of the head of the v5-30-00-patches branch do:</p>
-<code> git clone -b v5-30-00-patches http://root.cern.ch/git/root.git root-v5-30 </code>
+<code> git clone -b v5-30-00-patches http://root.cern/git/root.git root-v5-30 </code>
 
 <h2>Changes in the head of the v5-30-00-patches branch</h2>
 
 <ul>
 	<li>Cint
 	<ul>
-		<li>Import patch <a href="http://root.cern.ch/viewvc?rev=42805&amp;root=root&amp;view=rev" target="_blank">#42805</a> fixing the problem <a href="https://savannah.cern.ch/bugs/index.php?83909" target="_blank">#83909</a> which leading to failure of the auto-dictionary generator when dealing with class template inside a namespace.</li>
+		<li>Import patch <a href="http://root.cern/viewvc?rev=42805&amp;root=root&amp;view=rev" target="_blank">#42805</a> fixing the problem <a href="https://savannah.cern.ch/bugs/index.php?83909" target="_blank">#83909</a> which leading to failure of the auto-dictionary generator when dealing with class template inside a namespace.</li>
 	</ul>
 	</li>
 	<li>Core
 	<ul>
-		<li>Import patch <a href="http://root.cern.ch/viewvc?rev=42757&amp;root=root&amp;view=rev" target="_blank">#42757</a> fixing memory leak due to multiple allocations of gLibraryVersion.</li>
+		<li>Import patch <a href="http://root.cern/viewvc?rev=42757&amp;root=root&amp;view=rev" target="_blank">#42757</a> fixing memory leak due to multiple allocations of gLibraryVersion.</li>
 		<li>Add missing implementation for TGenericClassInfo::GetDirectoryAutoAdd.</li>
 	</ul>
 	</li>
@@ -52,15 +52,15 @@ sidebar:
 	</li>
 	<li>Proof
 	<ul>
-		<li>Reorder pq2 libraries for Ubuntu 11.10 (<a href="http://root.cern.ch/viewvc?rev=42660&amp;root=root&amp;view=rev" target="_blank">r42660</a>).</li>
-		<li>Import patch <a href="http://root.cern.ch/viewvc?rev=42578&amp;root=root&amp;view=rev" target="_blank">#42578</a> fixing in getProof.C some issues mostly related to PROOF-Lite.</li>
-		<li>Import class to analyse the performance tree (see <a href="http://root.cern.ch/drupal/content/analysing-performance-tree" target="_blank">description</a>) <span>(broken)</span></li>
-		<li>Adapt patch <a href="http://root.cern.ch/viewvc?rev=42671&amp;root=root&amp;view=rev" target="_blank">#42671</a> fixing a problem with TProof::Load reported in the PROOF forum, caused by the fact that the additional files were not copied in the master sandbox but left in the cache.</li>
-		<li>Import patch <a href="http://root.cern.ch/viewvc?rev=41745&amp;root=root&amp;view=rev" target="_blank">#41745</a> fixing TFileCollection::Merge.</li>
-		<li>Import patch <a href="http://root.cern.ch/viewvc?rev=42904&amp;root=root&amp;view=rev" target="_blank">#42904</a> in TProofOutputFile changing the default mode for merging histograms in TFileMerger, to reduce the memory footprint.</li>
-		<li>Import patch <a href="http://root.cern.ch/viewvc?rev=42921&amp;root=root&amp;view=rev" target="_blank">#42921</a> to add also to TXUnixSocket the possibility to disable reconnections via the variable TXSocket.Reconnect (0 disable reconnections; default is 1) .</li>
-		<li>Import patch <a href="http://root.cern.ch/viewvc?rev=43245&amp;root=root&amp;view=rev" target="_blank">#43245</a> fixing an issue with forcing local copies of files before merging (bit not always honored).</li>
-		<li><a>Import patch </a><a href="http://root.cern.ch/viewvc?rev=44048&amp;root=root&amp;view=rev" target="_blank">#44048</a> removing the automatic creation of TDrawFeedback by TProofChain.</li>
+		<li>Reorder pq2 libraries for Ubuntu 11.10 (<a href="http://root.cern/viewvc?rev=42660&amp;root=root&amp;view=rev" target="_blank">r42660</a>).</li>
+		<li>Import patch <a href="http://root.cern/viewvc?rev=42578&amp;root=root&amp;view=rev" target="_blank">#42578</a> fixing in getProof.C some issues mostly related to PROOF-Lite.</li>
+		<li>Import class to analyse the performance tree (see <a href="http://root.cern/drupal/content/analysing-performance-tree" target="_blank">description</a>) <span>(broken)</span></li>
+		<li>Adapt patch <a href="http://root.cern/viewvc?rev=42671&amp;root=root&amp;view=rev" target="_blank">#42671</a> fixing a problem with TProof::Load reported in the PROOF forum, caused by the fact that the additional files were not copied in the master sandbox but left in the cache.</li>
+		<li>Import patch <a href="http://root.cern/viewvc?rev=41745&amp;root=root&amp;view=rev" target="_blank">#41745</a> fixing TFileCollection::Merge.</li>
+		<li>Import patch <a href="http://root.cern/viewvc?rev=42904&amp;root=root&amp;view=rev" target="_blank">#42904</a> in TProofOutputFile changing the default mode for merging histograms in TFileMerger, to reduce the memory footprint.</li>
+		<li>Import patch <a href="http://root.cern/viewvc?rev=42921&amp;root=root&amp;view=rev" target="_blank">#42921</a> to add also to TXUnixSocket the possibility to disable reconnections via the variable TXSocket.Reconnect (0 disable reconnections; default is 1) .</li>
+		<li>Import patch <a href="http://root.cern/viewvc?rev=43245&amp;root=root&amp;view=rev" target="_blank">#43245</a> fixing an issue with forcing local copies of files before merging (bit not always honored).</li>
+		<li><a>Import patch </a><a href="http://root.cern/viewvc?rev=44048&amp;root=root&amp;view=rev" target="_blank">#44048</a> removing the automatic creation of TDrawFeedback by TProofChain.</li>
 	</ul>
 	</li>
 	<li>Graf3D
@@ -85,12 +85,12 @@ sidebar:
 	</li>
 	<li>Proof
 	<ul>
-		<li>Adapt patches <a href="http://root.cern.ch/viewvc?rev=42142&amp;root=root&amp;view=rev" target="_blank">#42142</a> and <a href="http://root.cern.ch/viewvc?rev=42451&amp;root=root&amp;view=rev" target="_blank">#42451</a> to stressProof adding a return code consistent with standard test facilities and the option '-noprogress' to switch off the progress information which may create problems in wrapper applications intercepting the output (e.g. ctest)</li>
+		<li>Adapt patches <a href="http://root.cern/viewvc?rev=42142&amp;root=root&amp;view=rev" target="_blank">#42142</a> and <a href="http://root.cern/viewvc?rev=42451&amp;root=root&amp;view=rev" target="_blank">#42451</a> to stressProof adding a return code consistent with standard test facilities and the option '-noprogress' to switch off the progress information which may create problems in wrapper applications intercepting the output (e.g. ctest)</li>
 	</ul>
 	</li>
 	<li>Geometry
 	<ul>
-		<li>Port patch <a href="http://root.cern.ch/viewvc?view=rev&amp;sortby=rev&amp;revision=40117" target="_blank">#40117</a> that fixes an issue with usage of reflection matrices in assemblies and affected the GEANT4 interface.</li>
+		<li>Port patch <a href="http://root.cern/viewvc?view=rev&amp;sortby=rev&amp;revision=40117" target="_blank">#40117</a> that fixes an issue with usage of reflection matrices in assemblies and affected the GEANT4 interface.</li>
 	</ul>
 	</li>
 </ul>
@@ -100,7 +100,7 @@ sidebar:
 <ul>
 	<li>Proof
 	<ul>
-		<li>Import patches <a href="http://root.cern.ch/viewvc?rev=41958&amp;root=root&amp;view=rev" target="_blank">#41958</a> and <a href="http://root.cern.ch/viewvc?rev=41999&amp;root=root&amp;view=rev" target="_blank">#41999</a> to improve checks, definition and cleaning of the working dir in tutorials/proof/getProof.C</li>
+		<li>Import patches <a href="http://root.cern/viewvc?rev=41958&amp;root=root&amp;view=rev" target="_blank">#41958</a> and <a href="http://root.cern/viewvc?rev=41999&amp;root=root&amp;view=rev" target="_blank">#41999</a> to improve checks, definition and cleaning of the working dir in tutorials/proof/getProof.C</li>
 	</ul>
 	</li>
 	<li>Build System
@@ -132,9 +132,9 @@ sidebar:
 	</li>
 	<li>Proof
 	<ul>
-		<li>Import patches <a href="http://root.cern.ch/viewvc?rev=41785&amp;root=root&amp;view=rev" target="_blank">#41785</a> and <a href="http://root.cern.ch/viewvc?rev=41786&amp;root=root&amp;view=rev" target="_blank">#41786</a> fixing an issue with packetizers preventing proper entry range processing and the file ordering in datasets.</li>
-		<li>Import patch <a href="http://root.cern.ch/viewvc?rev=41788&amp;root=root&amp;view=rev" target="_blank">#41788</a> fixing an issue with AddInputData when objects are TTree or derived.</li>
-		<li>Import patch <a href="http://root.cern.ch/viewvc?rev=41801&amp;root=root&amp;view=rev" target="_blank">#41801</a> fixing an issue in the packetizers potentially crashing PROOF-Lite at exit when using file-resident outputs.</li>
+		<li>Import patches <a href="http://root.cern/viewvc?rev=41785&amp;root=root&amp;view=rev" target="_blank">#41785</a> and <a href="http://root.cern/viewvc?rev=41786&amp;root=root&amp;view=rev" target="_blank">#41786</a> fixing an issue with packetizers preventing proper entry range processing and the file ordering in datasets.</li>
+		<li>Import patch <a href="http://root.cern/viewvc?rev=41788&amp;root=root&amp;view=rev" target="_blank">#41788</a> fixing an issue with AddInputData when objects are TTree or derived.</li>
+		<li>Import patch <a href="http://root.cern/viewvc?rev=41801&amp;root=root&amp;view=rev" target="_blank">#41801</a> fixing an issue in the packetizers potentially crashing PROOF-Lite at exit when using file-resident outputs.</li>
 	</ul>
 	</li>
 </ul>
@@ -165,10 +165,10 @@ sidebar:
 	</li>
 	<li>Proof
 	<ul>
-		<li>Import patches <a href="http://root.cern.ch/viewvc?rev=41313&amp;root=root&amp;view=rev" target="_blank">#41313</a>, <a href="http://root.cern.ch/viewvc?rev=41336&amp;root=root&amp;view=rev" target="_blank">#41336</a>, <a href="http://root.cern.ch/viewvc?rev=41355&amp;root=root&amp;view=rev" target="_blank">#41355</a>, <a href="http://root.cern.ch/viewvc?rev=41378&amp;root=root&amp;view=rev" target="_blank">#41378</a> and <a href="http://root.cern.ch/viewvc?rev=41383&amp;root=root&amp;view=rev" target="_blank">#41383</a> fixing unprivileged multi-user support and access control.</li>
-		<li>Import patches <a href="http://root.cern.ch/viewvc?rev=41393&amp;root=root&amp;view=rev" target="_blank">#41393</a> and <a href="http://root.cern.ch/viewvc?rev=41399&amp;root=root&amp;view=rev" target="_blank">#41399</a> fixing possible issues with PATH and LD_LIBRARY_PATH settings for proofserv.</li>
-		<li>Import patches <a href="http://root.cern.ch/viewvc?rev=40576&amp;root=root&amp;view=rev" target="_blank">#40576</a>, <a href="http://root.cern.ch/viewvc?rev=40699&amp;root=root&amp;view=rev" target="_blank">#40699</a>, <a href="http://root.cern.ch/viewvc?rev=40744&amp;root=root&amp;view=rev" target="_blank">#40744</a> and <a href="http://root.cern.ch/viewvc?rev=40758&amp;root=root&amp;view=rev" target="_blank">#40758</a> with the improvements in PROOF monitoring.</li>
-		<li>Import patch <a href="http://root.cern.ch/viewvc?rev=41493&amp;root=root&amp;view=rev" target="_blank">#41493</a>, <a href="http://root.cern.ch/viewvc?rev=41526&amp;root=root&amp;view=rev" target="_blank">#41526</a> and <a href="http://root.cern.ch/viewvc?rev=41530&amp;root=root&amp;view=rev" target="_blank">#41530</a> fixing return codes on TProof::EnablePackage(...) failures.</li>
+		<li>Import patches <a href="http://root.cern/viewvc?rev=41313&amp;root=root&amp;view=rev" target="_blank">#41313</a>, <a href="http://root.cern/viewvc?rev=41336&amp;root=root&amp;view=rev" target="_blank">#41336</a>, <a href="http://root.cern/viewvc?rev=41355&amp;root=root&amp;view=rev" target="_blank">#41355</a>, <a href="http://root.cern/viewvc?rev=41378&amp;root=root&amp;view=rev" target="_blank">#41378</a> and <a href="http://root.cern/viewvc?rev=41383&amp;root=root&amp;view=rev" target="_blank">#41383</a> fixing unprivileged multi-user support and access control.</li>
+		<li>Import patches <a href="http://root.cern/viewvc?rev=41393&amp;root=root&amp;view=rev" target="_blank">#41393</a> and <a href="http://root.cern/viewvc?rev=41399&amp;root=root&amp;view=rev" target="_blank">#41399</a> fixing possible issues with PATH and LD_LIBRARY_PATH settings for proofserv.</li>
+		<li>Import patches <a href="http://root.cern/viewvc?rev=40576&amp;root=root&amp;view=rev" target="_blank">#40576</a>, <a href="http://root.cern/viewvc?rev=40699&amp;root=root&amp;view=rev" target="_blank">#40699</a>, <a href="http://root.cern/viewvc?rev=40744&amp;root=root&amp;view=rev" target="_blank">#40744</a> and <a href="http://root.cern/viewvc?rev=40758&amp;root=root&amp;view=rev" target="_blank">#40758</a> with the improvements in PROOF monitoring.</li>
+		<li>Import patch <a href="http://root.cern/viewvc?rev=41493&amp;root=root&amp;view=rev" target="_blank">#41493</a>, <a href="http://root.cern/viewvc?rev=41526&amp;root=root&amp;view=rev" target="_blank">#41526</a> and <a href="http://root.cern/viewvc?rev=41530&amp;root=root&amp;view=rev" target="_blank">#41530</a> fixing return codes on TProof::EnablePackage(...) failures.</li>
 	</ul>
 	</li>
 </ul>
@@ -178,17 +178,17 @@ sidebar:
 <ul>
 	<li>Core
 	<ul>
-		<li>Import patch <a href="http://root.cern.ch/viewvc?rev=40820&amp;root=root&amp;view=rev" target="_blank">#40820</a>. Make sure in BuildRealData, to consider all the data member of a transient class (class version 0) as transient. This fixes the issue <a href="https://savannah.cern.ch/bugs/?86352" target="_blank">#86352</a> in Savannah.</li>
+		<li>Import patch <a href="http://root.cern/viewvc?rev=40820&amp;root=root&amp;view=rev" target="_blank">#40820</a>. Make sure in BuildRealData, to consider all the data member of a transient class (class version 0) as transient. This fixes the issue <a href="https://savannah.cern.ch/bugs/?86352" target="_blank">#86352</a> in Savannah.</li>
 		<li>Textinput: fix handling of ESC / Meta (r40778).</li>
-		<li>Import patch <a href="http://root.cern.ch/viewvc?rev=40141&amp;root=root&amp;view=rev" target="_blank">#40141</a> fixing support for '<em>proto</em> ://' in TUrl.</li>
+		<li>Import patch <a href="http://root.cern/viewvc?rev=40141&amp;root=root&amp;view=rev" target="_blank">#40141</a> fixing support for '<em>proto</em> ://' in TUrl.</li>
 	</ul>
 	</li>
 	<li>Proof
 	<ul>
-		<li>Import patch <a href="http://root.cern.ch/viewvc?rev=40659&amp;root=root&amp;view=rev" target="_blank">#40659</a> fixing a possible seg violation when exiting ROOT.</li>
-		<li>Import patch <a href="http://root.cern.ch/viewvc?rev=40660&amp;root=root&amp;view=rev" target="_blank">#40660</a> restoring operability of the dynamic startup (broken by patch 36553).</li>
-		<li>Import patch <a href="http://root.cern.ch/viewvc?rev=40115&amp;root=root&amp;view=rev" target="_blank">#40115</a> with a few fixes in proofbench, including the possibility to run from any directory.</li>
-		<li>Import patches <a href="http://root.cern.ch/viewvc?rev=40912&amp;root=root&amp;view=rev" target="_blank">#40912</a> and <a href="http://root.cern.ch/viewvc?rev=40923&amp;root=root&amp;view=rev" target="_blank">#40923</a> adding the possibility to skip the checks for the data directories during session startup, as they may significantly slowdown the startup process is the medium is busy.</li>
+		<li>Import patch <a href="http://root.cern/viewvc?rev=40659&amp;root=root&amp;view=rev" target="_blank">#40659</a> fixing a possible seg violation when exiting ROOT.</li>
+		<li>Import patch <a href="http://root.cern/viewvc?rev=40660&amp;root=root&amp;view=rev" target="_blank">#40660</a> restoring operability of the dynamic startup (broken by patch 36553).</li>
+		<li>Import patch <a href="http://root.cern/viewvc?rev=40115&amp;root=root&amp;view=rev" target="_blank">#40115</a> with a few fixes in proofbench, including the possibility to run from any directory.</li>
+		<li>Import patches <a href="http://root.cern/viewvc?rev=40912&amp;root=root&amp;view=rev" target="_blank">#40912</a> and <a href="http://root.cern/viewvc?rev=40923&amp;root=root&amp;view=rev" target="_blank">#40923</a> adding the possibility to skip the checks for the data directories during session startup, as they may significantly slowdown the startup process is the medium is busy.</li>
 	</ul>
 	</li>
 	<li>I/O
@@ -210,7 +210,7 @@ sidebar:
 	</li>
 	<li>Hist
 	<ul>
-		<li>Fix a bug in the TEfficiency destructor (see this <a href="http://root.cern.ch/phpBB3//viewtopic.php?f=3&amp;t=13398" target="_blank">post</a> on Root Forum)&nbsp;</li>
+		<li>Fix a bug in the TEfficiency destructor (see this <a href="http://root.cern/phpBB3//viewtopic.php?f=3&amp;t=13398" target="_blank">post</a> on Root Forum)&nbsp;</li>
 	</ul>
 	</li>
 	<li>FitPanel
@@ -238,10 +238,10 @@ sidebar:
 	<li>Core
 	<ul>
 		<li>Textinput: fix handling of keyboard modifiers (r40118).</li>
-		<li>Import patch <a href="http://root.cern.ch/viewvc?rev=40272&amp;root=root&amp;view=rev" target="_blank">#40272</a> adding Hash(), IsSortable() and CompareTo() so that TParameter can be used in hash and/or sorted lists (e.g. gDirectory).</li>
+		<li>Import patch <a href="http://root.cern/viewvc?rev=40272&amp;root=root&amp;view=rev" target="_blank">#40272</a> adding Hash(), IsSortable() and CompareTo() so that TParameter can be used in hash and/or sorted lists (e.g. gDirectory).</li>
 		<li>Properly support tilde (~) in TSystem::ExpandPathName() even when they are not the first character</li>
 		<li>Make sure we write at the end of the file in which we redirect stdout/stderr (avoid overwriting)</li>
-		<li><a href="https://savannah.cern.ch/bugs/?85226" target="_blank">Import patch </a> <a href="http://root.cern.ch/viewvc?rev=40534&amp;root=root&amp;view=rev" target="_blank">#40534</a> to silence spurious warnings when removing objects from TObjectTable.</li>
+		<li><a href="https://savannah.cern.ch/bugs/?85226" target="_blank">Import patch </a> <a href="http://root.cern/viewvc?rev=40534&amp;root=root&amp;view=rev" target="_blank">#40534</a> to silence spurious warnings when removing objects from TObjectTable.</li>
 		<li>Allow home directory to be specified via HOME shell var in case there is no correct passwd file entry, fixes issue <a href="http://savannah.cern.ch/bugs/?83268" target="_blank">83268</a></li>
 	</ul>
 	</li>
@@ -260,30 +260,30 @@ sidebar:
 	</li>
 	<li>TTree
 	<ul>
-		<li>Import fix <a href="http://root.cern.ch/viewvc?rev=40077&amp;root=root&amp;view=rev" target="_blank">#40077</a> to prevent the use of non-existent memory when reading in an object that is part of an STL collection and which used to contains an embedded object (and this data member has been removed)(bug <a href="https://savannah.cern.ch/bugs/?83793" target="_blank">#83793</a>).</li>
+		<li>Import fix <a href="http://root.cern/viewvc?rev=40077&amp;root=root&amp;view=rev" target="_blank">#40077</a> to prevent the use of non-existent memory when reading in an object that is part of an STL collection and which used to contains an embedded object (and this data member has been removed)(bug <a href="https://savannah.cern.ch/bugs/?83793" target="_blank">#83793</a>).</li>
 		<li>Lift ancien restriction (imposed by VC++6) preventing the proper use of unsigned long long by TTreeFormula.</li>
 	</ul>
 	</li>
 	<li>Proof
 	<ul>
-		<li>Import new version 0.9.6 of afdsmgrd (patch <a href="http://root.cern.ch/viewvc?rev=40573&amp;root=root&amp;view=rev" target="_blank">#40573</a>) with improvements/fixes needed by ALICE.</li>
-		<li>Import patch <a href="http://root.cern.ch/viewvc?rev=40017&amp;root=root&amp;view=rev" target="_blank">#40017</a>&nbsp;making the query exit status available for monitoring and in the output list.</li>
-		<li>Import patch <a href="http://root.cern.ch/viewvc?rev=40068&amp;root=root&amp;view=rev" target="_blank">#40068</a>&nbsp;fixing an issue affecting GetSessionLogs in PROOF-Lite when invoked from the dialog box.</li>
-		<li>Import patch <a href="http://root.cern.ch/viewvc?rev=40138&amp;root=root&amp;view=rev" target="_blank">#40138</a>&nbsp;fixing "workers=n" in PROOF-Lite.</li>
-		<li>Import patch <a href="http://root.cern.ch/viewvc?rev=40170&amp;root=root&amp;view=rev" target="_blank">#40170</a>&nbsp;fixing an issue with directory assertion in xproofd.</li>
-		<li>Import patch <a href="http://root.cern.ch/viewvc?rev=40186&amp;root=root&amp;view=rev" target="_blank">#40186</a>&nbsp;fixing an issue preventing immediate cleaning of histograms after merging with TH1::Add (histogram were still destroyed at the end of the query). The patch adds also master memory usage in TStatus.</li>
-		<li>Import patches <a href="http://root.cern.ch/viewvc?rev=40243&amp;root=root&amp;view=rev" target="_blank">#40243</a> and <a href="http://root.cern.ch/viewvc?rev=40247&amp;root=root&amp;view=rev" target="_blank">#40247</a> &nbsp;fixing a possible segv when leaving proofbench.</li>
-		<li>Import patch <a href="http://root.cern.ch/viewvc?rev=40359&amp;root=root&amp;view=rev" target="_blank">#40359</a>&nbsp; fixing an issue showing up in PROOF-Lite when merging via files.</li>
+		<li>Import new version 0.9.6 of afdsmgrd (patch <a href="http://root.cern/viewvc?rev=40573&amp;root=root&amp;view=rev" target="_blank">#40573</a>) with improvements/fixes needed by ALICE.</li>
+		<li>Import patch <a href="http://root.cern/viewvc?rev=40017&amp;root=root&amp;view=rev" target="_blank">#40017</a>&nbsp;making the query exit status available for monitoring and in the output list.</li>
+		<li>Import patch <a href="http://root.cern/viewvc?rev=40068&amp;root=root&amp;view=rev" target="_blank">#40068</a>&nbsp;fixing an issue affecting GetSessionLogs in PROOF-Lite when invoked from the dialog box.</li>
+		<li>Import patch <a href="http://root.cern/viewvc?rev=40138&amp;root=root&amp;view=rev" target="_blank">#40138</a>&nbsp;fixing "workers=n" in PROOF-Lite.</li>
+		<li>Import patch <a href="http://root.cern/viewvc?rev=40170&amp;root=root&amp;view=rev" target="_blank">#40170</a>&nbsp;fixing an issue with directory assertion in xproofd.</li>
+		<li>Import patch <a href="http://root.cern/viewvc?rev=40186&amp;root=root&amp;view=rev" target="_blank">#40186</a>&nbsp;fixing an issue preventing immediate cleaning of histograms after merging with TH1::Add (histogram were still destroyed at the end of the query). The patch adds also master memory usage in TStatus.</li>
+		<li>Import patches <a href="http://root.cern/viewvc?rev=40243&amp;root=root&amp;view=rev" target="_blank">#40243</a> and <a href="http://root.cern/viewvc?rev=40247&amp;root=root&amp;view=rev" target="_blank">#40247</a> &nbsp;fixing a possible segv when leaving proofbench.</li>
+		<li>Import patch <a href="http://root.cern/viewvc?rev=40359&amp;root=root&amp;view=rev" target="_blank">#40359</a>&nbsp; fixing an issue showing up in PROOF-Lite when merging via files.</li>
 	</ul>
 	</li>
 	<li>Rpdutils
 	<ul>
-		<li>Import patch <a href="http://root.cern.ch/viewvc?rev=40120&amp;root=root&amp;view=rev" target="_blank">#40120</a>&nbsp; fixing a compilation issue on OSX Lion.</li>
+		<li>Import patch <a href="http://root.cern/viewvc?rev=40120&amp;root=root&amp;view=rev" target="_blank">#40120</a>&nbsp; fixing a compilation issue on OSX Lion.</li>
 	</ul>
 	</li>
 	<li>Netx/Xrootd
 	<ul>
-		<li>Import patches <a href="http://root.cern.ch/viewvc?rev=40435&amp;root=root&amp;view=rev" target="_blank">#40435</a> and <a href="http://root.cern.ch/viewvc?rev=40436&amp;root=root&amp;view=rev" target="_blank">#40436</a> &nbsp; to fix the issues preventing proper notification of XrdClient authentication errors.</li>
+		<li>Import patches <a href="http://root.cern/viewvc?rev=40435&amp;root=root&amp;view=rev" target="_blank">#40435</a> and <a href="http://root.cern/viewvc?rev=40436&amp;root=root&amp;view=rev" target="_blank">#40436</a> &nbsp; to fix the issues preventing proper notification of XrdClient authentication errors.</li>
 	</ul>
 	</li>
 	<li>RooFit
@@ -331,8 +331,8 @@ sidebar:
 <ul>
 	<li>Build System
 	<ul>
-		<li>Changes to CMake: improve detection of external packages (<a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=39804" target="_blank">r39804</a>).</li>
-		<li>Use Apple clang v3 by default when available (<a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=39805" target="_blank">r39805</a>).</li>
+		<li>Changes to CMake: improve detection of external packages (<a href="http://root.cern/viewcvs?view=rev&amp;revision=39804" target="_blank">r39804</a>).</li>
+		<li>Use Apple clang v3 by default when available (<a href="http://root.cern/viewcvs?view=rev&amp;revision=39805" target="_blank">r39805</a>).</li>
 	</ul>
 	</li>
 	<li>I/O
@@ -346,17 +346,17 @@ sidebar:
 	</li>
 	<li>TTree
 	<ul>
-		<li>Properly recognize a TClonesArray data member even if the requested type was a typedef (to TClonesArray) that is in a namespace (for example edm::Event::ContainerType).(<a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=39786" target="_blank">39786</a>)</li>
+		<li>Properly recognize a TClonesArray data member even if the requested type was a typedef (to TClonesArray) that is in a namespace (for example edm::Event::ContainerType).(<a href="http://root.cern/viewcvs?view=rev&amp;revision=39786" target="_blank">39786</a>)</li>
 	</ul>
 	</li>
 	<li>Core
 	<ul>
-		<li>TextInput: improved treatment of read-ahead buffer (<a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=39790" target="_blank">r39790</a>)</li>
-		<li>TextInput: no unnecessary redraws (<a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=39862" target="_blank">r39862</a>)</li>
-		<li>TextInput: home / end key on debian (<a href="http://savannah.cern.ch/bugs/?83478" target="_blank">bug #83478</a>, <a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=39863" target="_blank">r39863</a>)</li>
-		<li>TextInput: fix bug in clear-to-end-of-line visible on Windows ssh-ing to Linux (<a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=39884" target="_blank">r39884</a>)</li>
-		<li>TextInput: fix possible crash in paren-matching (<a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=39910" target="_blank">r39910</a>)</li>
-		<li>TextInput: fix infinite loop handling SIGABRT (e.g. .qqqqqqqq) (<a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=39941" target="_blank">r39941</a>)</li>
+		<li>TextInput: improved treatment of read-ahead buffer (<a href="http://root.cern/viewcvs?view=rev&amp;revision=39790" target="_blank">r39790</a>)</li>
+		<li>TextInput: no unnecessary redraws (<a href="http://root.cern/viewcvs?view=rev&amp;revision=39862" target="_blank">r39862</a>)</li>
+		<li>TextInput: home / end key on debian (<a href="http://savannah.cern.ch/bugs/?83478" target="_blank">bug #83478</a>, <a href="http://root.cern/viewcvs?view=rev&amp;revision=39863" target="_blank">r39863</a>)</li>
+		<li>TextInput: fix bug in clear-to-end-of-line visible on Windows ssh-ing to Linux (<a href="http://root.cern/viewcvs?view=rev&amp;revision=39884" target="_blank">r39884</a>)</li>
+		<li>TextInput: fix possible crash in paren-matching (<a href="http://root.cern/viewcvs?view=rev&amp;revision=39910" target="_blank">r39910</a>)</li>
+		<li>TextInput: fix infinite loop handling SIGABRT (e.g. .qqqqqqqq) (<a href="http://root.cern/viewcvs?view=rev&amp;revision=39941" target="_blank">r39941</a>)</li>
 	</ul>
 	</li>
 	<li>Xrootd
@@ -366,14 +366,14 @@ sidebar:
 	</li>
 	<li>Proof
 	<ul>
-		<li>Import patch <a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=39835" target="_blank">r39835</a> fixing open issues with honoring the request for processing a fixed number of events and the correct handling of 'ForceLocal' requests when for local files; also fixes an issue with the handling of 'Stop' in PROOF-Lite.</li>
-		<li>Fix coverity warnings in TProofServ and TProofNodes (patch <a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=39878" target="_blank">r39878</a>)</li>
-		<li>Import patch <a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=39967" target="_blank">r39967</a> introducing the protocol "pod://" to automatically address the entry point of the available PoD installation, and protocol "lite://" for PROOF-Lite sessions (in the place of "lite"; behavior of "" unchanged).</li>
+		<li>Import patch <a href="http://root.cern/viewcvs?view=rev&amp;revision=39835" target="_blank">r39835</a> fixing open issues with honoring the request for processing a fixed number of events and the correct handling of 'ForceLocal' requests when for local files; also fixes an issue with the handling of 'Stop' in PROOF-Lite.</li>
+		<li>Fix coverity warnings in TProofServ and TProofNodes (patch <a href="http://root.cern/viewcvs?view=rev&amp;revision=39878" target="_blank">r39878</a>)</li>
+		<li>Import patch <a href="http://root.cern/viewcvs?view=rev&amp;revision=39967" target="_blank">r39967</a> introducing the protocol "pod://" to automatically address the entry point of the available PoD installation, and protocol "lite://" for PROOF-Lite sessions (in the place of "lite"; behavior of "" unchanged).</li>
 	</ul>
 	</li>
 	<li>TMVA
 	<ul>
-		<li>Fix stress test issue with ICC11 / 64bit.(<a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=39890" target="_blank">39890</a>)</li>
+		<li>Fix stress test issue with ICC11 / 64bit.(<a href="http://root.cern/viewcvs?view=rev&amp;revision=39890" target="_blank">39890</a>)</li>
 	</ul>
 	</li>
 </ul>
@@ -383,46 +383,46 @@ sidebar:
 <ul>
 	<li>Build System
 	<ul>
-		<li>Changes to CMake: TextInput, Windows dictionaries (<a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=39554" target="_blank">r39554</a>, <a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=39582" target="_blank">r39582</a>).</li>
+		<li>Changes to CMake: TextInput, Windows dictionaries (<a href="http://root.cern/viewcvs?view=rev&amp;revision=39554" target="_blank">r39554</a>, <a href="http://root.cern/viewcvs?view=rev&amp;revision=39582" target="_blank">r39582</a>).</li>
 	</ul>
 	</li>
 	<li>Core
 	<ul>
 		<li>Fix error when linking statically on OSX.</li>
-		<li>On non-Windows, root.exe is now killed when root is killed (<a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=39540" target="_blank">r39540</a>).</li>
-		<li>TextInput: improved history management (<a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=39537" target="_blank">r39537</a>, <a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=39539" target="_blank">r39539</a>, <a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=39570" target="_blank">r39570</a>, <a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=39711" target="_blank">r39711</a>).</li>
-		<li>TextInput: reset the terminal to a sane state after even more signals (<a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=39538" target="_blank">r39538</a>, <a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=39541" target="_blank">r39541</a>)</li>
-		<li>TextInput: on Windows, get dedicated handle to CONIN$, CONOUT$ to prevent redirection from stealing it (<a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=39543" target="_blank">r39543</a>).</li>
-		<li>TextInput: on Windows, redraw the prompt if ROOT moved the cursor (<a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=39604" target="_blank">r39604</a>).</li>
-		<li>TextInput: proper event loop for full line mode (<a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=39560" target="_blank">r39560</a>).</li>
-		<li>TextInput: continue reading if ESC was entered, fixes ESC-f etc (<a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=39709" target="_blank">r39709</a>).</li>
-		<li>TextInput: handle ROOT running in background (<a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=39591" target="_blank">r39591</a>).</li>
-		<li>TextInput: reset input modifier for each new input, e.g. "Ctrl is pressed"; make it unsigned (<a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=39597" target="_blank">r39597</a>, <a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=39703" target="_blank">r39703</a>).</li>
-		<li>On Windows, don't expand urls like root://user@any.where.com:1234//~user/...(<a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=39624" target="_blank">r39624</a>).</li>
+		<li>On non-Windows, root.exe is now killed when root is killed (<a href="http://root.cern/viewcvs?view=rev&amp;revision=39540" target="_blank">r39540</a>).</li>
+		<li>TextInput: improved history management (<a href="http://root.cern/viewcvs?view=rev&amp;revision=39537" target="_blank">r39537</a>, <a href="http://root.cern/viewcvs?view=rev&amp;revision=39539" target="_blank">r39539</a>, <a href="http://root.cern/viewcvs?view=rev&amp;revision=39570" target="_blank">r39570</a>, <a href="http://root.cern/viewcvs?view=rev&amp;revision=39711" target="_blank">r39711</a>).</li>
+		<li>TextInput: reset the terminal to a sane state after even more signals (<a href="http://root.cern/viewcvs?view=rev&amp;revision=39538" target="_blank">r39538</a>, <a href="http://root.cern/viewcvs?view=rev&amp;revision=39541" target="_blank">r39541</a>)</li>
+		<li>TextInput: on Windows, get dedicated handle to CONIN$, CONOUT$ to prevent redirection from stealing it (<a href="http://root.cern/viewcvs?view=rev&amp;revision=39543" target="_blank">r39543</a>).</li>
+		<li>TextInput: on Windows, redraw the prompt if ROOT moved the cursor (<a href="http://root.cern/viewcvs?view=rev&amp;revision=39604" target="_blank">r39604</a>).</li>
+		<li>TextInput: proper event loop for full line mode (<a href="http://root.cern/viewcvs?view=rev&amp;revision=39560" target="_blank">r39560</a>).</li>
+		<li>TextInput: continue reading if ESC was entered, fixes ESC-f etc (<a href="http://root.cern/viewcvs?view=rev&amp;revision=39709" target="_blank">r39709</a>).</li>
+		<li>TextInput: handle ROOT running in background (<a href="http://root.cern/viewcvs?view=rev&amp;revision=39591" target="_blank">r39591</a>).</li>
+		<li>TextInput: reset input modifier for each new input, e.g. "Ctrl is pressed"; make it unsigned (<a href="http://root.cern/viewcvs?view=rev&amp;revision=39597" target="_blank">r39597</a>, <a href="http://root.cern/viewcvs?view=rev&amp;revision=39703" target="_blank">r39703</a>).</li>
+		<li>On Windows, don't expand urls like root://user@any.where.com:1234//~user/...(<a href="http://root.cern/viewcvs?view=rev&amp;revision=39624" target="_blank">r39624</a>).</li>
 	</ul>
 	</li>
 	<li>I/O
 	<ul>
-		<li>Allow to explicit veto or force the splitting of a class to insure that its custom streamer is always used ((<a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=39694" target="_blank">39694</a>) fixing <a href="https://savannah.cern.ch/bugs/index.php?83119" target="_blank">Savannah #83119</a></li>
+		<li>Allow to explicit veto or force the splitting of a class to insure that its custom streamer is always used ((<a href="http://root.cern/viewcvs?view=rev&amp;revision=39694" target="_blank">39694</a>) fixing <a href="https://savannah.cern.ch/bugs/index.php?83119" target="_blank">Savannah #83119</a></li>
 		<li>Reduce memory footprint of the TFilePrefetch mechanism.</li>
 		<li>Introduce TBuffer::AutoExpand</li>
 		<li>Make the memcpy in TBuffer::Expand optional. Avoid this memcpy from TBasket::Reset.</li>
-		<li>Improve error handling in MakeProject, (<a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=39692" target="_blank">r39692</a>) fixing <a href="https://savannah.cern.ch/bugs/index.php?83188" target="_blank">Savannah #83188</a></li>
+		<li>Improve error handling in MakeProject, (<a href="http://root.cern/viewcvs?view=rev&amp;revision=39692" target="_blank">r39692</a>) fixing <a href="https://savannah.cern.ch/bugs/index.php?83188" target="_blank">Savannah #83188</a></li>
 	</ul>
 	</li>
 	<li>TTree
 	<ul>
 		<li>Reduce the memory used by a TTree by sharing the scratch buffer used to hold the compressed data.</li>
-		<li>Do no assume that there is a least one '.root' in the filename passed to TChain::Add.(<a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=39588" target="_blank">r39588</a>)</li>
-		<li>Improve error recover in TTreeCloner in case of missing TTree or unwriteable file (<a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=39720" target="_blank">39720</a>) fixing <a href="https://savannah.cern.ch/bugs/index.php?83140" target="_blank">Savannah #83140</a></li>
-		<li>Make sure the TTreeCloner properly carry forward the value of the kDoNotUseBufferMap bit in the branch (Addendum to (<a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=38801" target="_blank">38801</a>)</li>
+		<li>Do no assume that there is a least one '.root' in the filename passed to TChain::Add.(<a href="http://root.cern/viewcvs?view=rev&amp;revision=39588" target="_blank">r39588</a>)</li>
+		<li>Improve error recover in TTreeCloner in case of missing TTree or unwriteable file (<a href="http://root.cern/viewcvs?view=rev&amp;revision=39720" target="_blank">39720</a>) fixing <a href="https://savannah.cern.ch/bugs/index.php?83140" target="_blank">Savannah #83140</a></li>
+		<li>Make sure the TTreeCloner properly carry forward the value of the kDoNotUseBufferMap bit in the branch (Addendum to (<a href="http://root.cern/viewcvs?view=rev&amp;revision=38801" target="_blank">38801</a>)</li>
 	</ul>
 	</li>
 	<li>Proof
 	<ul>
-		<li>Import patch <a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=39579" target="_blank">r39579</a> avoid a segmentation fault when reading file where the AutoFlush mechanism has been disabled and the TTreeCache is requested nonetheless.</li>
-		<li>Import patch <a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=39580" target="_blank">r39580</a> fixing an issue with connections via a SSH tunnel.</li>
-		<li>Import patch <a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=39585" target="_blank">r39585</a> fixing an issue preventing the correct handling of a 'Stop' request.</li>
+		<li>Import patch <a href="http://root.cern/viewcvs?view=rev&amp;revision=39579" target="_blank">r39579</a> avoid a segmentation fault when reading file where the AutoFlush mechanism has been disabled and the TTreeCache is requested nonetheless.</li>
+		<li>Import patch <a href="http://root.cern/viewcvs?view=rev&amp;revision=39580" target="_blank">r39580</a> fixing an issue with connections via a SSH tunnel.</li>
+		<li>Import patch <a href="http://root.cern/viewcvs?view=rev&amp;revision=39585" target="_blank">r39585</a> fixing an issue preventing the correct handling of a 'Stop' request.</li>
 	</ul>
 	</li>
 	<li>Graf3d
@@ -433,12 +433,12 @@ sidebar:
 	</li>
 	<li>CINT
 	<ul>
-		<li>Avoid possible buffer underrun for empty (e.g. '@'-cancelled) commands (<a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=39705" target="_blank">r39705</a>).</li>
+		<li>Avoid possible buffer underrun for empty (e.g. '@'-cancelled) commands (<a href="http://root.cern/viewcvs?view=rev&amp;revision=39705" target="_blank">r39705</a>).</li>
 	</ul>
 	</li>
 	<li>THtml
 	<ul>
-		<li>Adapt to new (now standard) location of the headers of TMVA and the RooFit family (<a href="http://root.cern.ch/viewcvs?view=rev&amp;revision=39713" target="_blank">r39713</a>).</li>
+		<li>Adapt to new (now standard) location of the headers of TMVA and the RooFit family (<a href="http://root.cern/viewcvs?view=rev&amp;revision=39713" target="_blank">r39713</a>).</li>
 	</ul>
 	</li>
 </ul>

--- a/install/all_releases/root-version-v5-32-00-patch-release-notes.md
+++ b/install/all_releases/root-version-v5-32-00-patch-release-notes.md
@@ -15,24 +15,24 @@ sidebar:
 
 <p>The complete source tree for all systems (54 MB) is available here:</p>
 
-<p><code><a href="ftp://root.cern.ch/root/root_v5.32.04.source.tar.gz" target="_blank">ftp://root.cern.ch/root/root_v5.32.04.source.tar.gz</a> </code></p>
+<p><code><a href="ftp://root.cern/root/root_v5.32.04.source.tar.gz" target="_blank">ftp://root.cern/root/root_v5.32.04.source.tar.gz</a> </code></p>
 
 <p>Alternatively get the source from <a href="/node/92" target="_blank">Git</a> using:</p>
 
-<p><code>git clone http://root.cern.ch/git/root.git root-v5-32 cd root-v5-32 git checkout -b v5-32-04 v5-32-04 </code></p>
+<p><code>git clone http://root.cern/git/root.git root-v5-32 cd root-v5-32 git checkout -b v5-32-04 v5-32-04 </code></p>
 
 <p>After obtaining the source read the file <a href="/node/103" target="_blank">README/INSTALL</a> (in short just do: cd root; ./configure; make).</p>
 
 <p>To get the source of the head of the v5-32-00-patches branch do:</p>
 
-<p><code>git clone -b v5-32-00-patches http://root.cern.ch/git/root.git root-v5-32 </code></p>
+<p><code>git clone -b v5-32-00-patches http://root.cern/git/root.git root-v5-32 </code></p>
 
 <h2>Changes in head of v5-32-00-patches branch</h2>
 
 <ul>
 	<li>I/O
 	<ul>
-		<li>Corrected the calculation of the number of read calls in TRFIOFile (See the forum <a href="http://root.cern.ch/phpBB3/viewtopic.php?f=3&amp;t=14673&amp;p=64367#p64367" target="_blank">post</a> on the subject. Fixed by revision 45140).</li>
+		<li>Corrected the calculation of the number of read calls in TRFIOFile (See the forum <a href="http://root.cern/phpBB3/viewtopic.php?f=3&amp;t=14673&amp;p=64367#p64367" target="_blank">post</a> on the subject. Fixed by revision 45140).</li>
 		<li>Add protection against corrupted ROOT File (wrong length stored in the file header) (Revision 45170).</li>
 		<li>Fix for recent versions of castor (Revision 48474).</li>
 		<li>&nbsp;</li>
@@ -40,7 +40,7 @@ sidebar:
 	</li>
 	<li>Proof
 	<ul>
-		<li>Import patches <a href="http://root.cern.ch/viewvc?rev=45092&amp;root=root&amp;view=rev" target="_blank">#45092</a> and <a href="http://root.cern.ch/viewvc?rev=45093&amp;root=root&amp;view=rev" target="_blank">#45093</a> adding functions to retrieve environment information from the nodes, typically from the master (datadir or some env settings).
+		<li>Import patches <a href="http://root.cern/viewvc?rev=45092&amp;root=root&amp;view=rev" target="_blank">#45092</a> and <a href="http://root.cern/viewvc?rev=45093&amp;root=root&amp;view=rev" target="_blank">#45093</a> adding functions to retrieve environment information from the nodes, typically from the master (datadir or some env settings).
 		<p><b>Warning:</b> This change in binary incompatible.</p>
 		</li>
 	</ul>
@@ -58,7 +58,7 @@ sidebar:
 	<li>Core
 	<ul>
 		<li>Avoid risk of executing the tear down routines twice at process termination when -q is used and there is no input file descriptor. (revision 44838).</li>
-		<li>Fix linking of qtcint.dll when explicitly linking is required (see <a href="http://root.cern.ch/phpBB3/viewtopic.php?t=14943" target="_blank">the related forum post</a>).</li>
+		<li>Fix linking of qtcint.dll when explicitly linking is required (see <a href="http://root.cern/phpBB3/viewtopic.php?t=14943" target="_blank">the related forum post</a>).</li>
 	</ul>
 	</li>
 	<li>Net
@@ -85,10 +85,10 @@ sidebar:
 	</li>
 	<li><a>Proof </a>
 	<ul>
-		<li><a>Import patch </a><a href="http://root.cern.ch/viewvc?rev=44397&amp;root=root&amp;view=rev" target="_blank">#44397</a> changing the default merging procedure used histograms to cover correctly all the cases.</li>
-		<li><a>Import patch </a><a href="http://root.cern.ch/viewvc?rev=44048&amp;root=root&amp;view=rev" target="_blank">#44048</a> removing the automatic creation of TDrawFeedback by TProofChain.</li>
-		<li><a>Import patch </a><a href="http://root.cern.ch/viewvc?rev=44701&amp;root=root&amp;view=rev" target="_blank">#44701</a> fixing several stability issues in xproofd. Patch is server side only; only the upgraded xproofd (or libXrdProofd) is equired.</li>
-		<li><a>Import patch </a><a href="http://root.cern.ch/viewvc?rev=42703&amp;root=root&amp;view=rev" target="_blank">#42703</a> removing unused variables in xproofd.</li>
+		<li><a>Import patch </a><a href="http://root.cern/viewvc?rev=44397&amp;root=root&amp;view=rev" target="_blank">#44397</a> changing the default merging procedure used histograms to cover correctly all the cases.</li>
+		<li><a>Import patch </a><a href="http://root.cern/viewvc?rev=44048&amp;root=root&amp;view=rev" target="_blank">#44048</a> removing the automatic creation of TDrawFeedback by TProofChain.</li>
+		<li><a>Import patch </a><a href="http://root.cern/viewvc?rev=44701&amp;root=root&amp;view=rev" target="_blank">#44701</a> fixing several stability issues in xproofd. Patch is server side only; only the upgraded xproofd (or libXrdProofd) is equired.</li>
+		<li><a>Import patch </a><a href="http://root.cern/viewvc?rev=42703&amp;root=root&amp;view=rev" target="_blank">#42703</a> removing unused variables in xproofd.</li>
 	</ul>
 	</li>
 	<li>CINT
@@ -98,7 +98,7 @@ sidebar:
 	</li>
 	<li>RooFit
 	<ul>
-		<li>Fix bug in binned generation of extended pdf (patch <a href="http://root.cern.ch/viewvc?rev=44630&amp;root=root&amp;view=rev" target="_blank">#44630</a> )</li>
+		<li>Fix bug in binned generation of extended pdf (patch <a href="http://root.cern/viewvc?rev=44630&amp;root=root&amp;view=rev" target="_blank">#44630</a> )</li>
 	</ul>
 	</li>
 	<li>Hist
@@ -137,15 +137,15 @@ sidebar:
 	</li>
 	<li>TreeViewer
 	<ul>
-		<li>Fix a problem with array names (e.g. fVertex[]) as reported <a href="http://root.cern.ch/phpBB3//viewtopic.php?f=3&amp;t=14507" target="_blank">on the forum</a>.</li>
+		<li>Fix a problem with array names (e.g. fVertex[]) as reported <a href="http://root.cern/phpBB3//viewtopic.php?f=3&amp;t=14507" target="_blank">on the forum</a>.</li>
 	</ul>
 	</li>
 	<li>Proof
 	<ul>
-		<li>Import patch <a href="http://root.cern.ch/viewvc?rev=42921&amp;root=root&amp;view=rev" target="_blank">#42921</a> to add also to TXUnixSocket the possibility to disable reconnections via the variable TXSocket.Reconnect (0 disable reconnections; default is 1) .</li>
-		<li>Import patches <a href="http://root.cern.ch/viewvc?rev=42775&amp;root=root&amp;view=rev" target="_blank">#42775</a>, <a href="http://root.cern.ch/viewvc?rev=42788&amp;root=root&amp;view=rev" target="_blank">#42788</a>, <a href="http://root.cern.ch/viewvc?rev=42882&amp;root=root&amp;view=rev" target="_blank">#42882</a> and <a href="http://root.cern.ch/viewvc?rev=42883&amp;root=root&amp;view=rev" target="_blank">#42883</a> enabling parallel dataset verification.</li>
-		<li>Import patches <a href="http://root.cern.ch/viewvc?rev=43101&amp;root=root&amp;view=rev" target="_blank">#43101</a>, <a href="http://root.cern.ch/viewvc?rev=43884&amp;root=root&amp;view=rev" target="_blank">#43884</a> and <a href="http://root.cern.ch/viewvc?rev=43886&amp;root=root&amp;view=rev" target="_blank">#43886</a> adding in proofbench full support for dataset generation on external storage.</li>
-		<li>Import patch <a href="http://root.cern.ch/viewvc?rev=43567&amp;root=root&amp;view=rev" target="_blank">#43567</a> fixing a few issues with dataset verification of back-ends different from xrootd.</li>
+		<li>Import patch <a href="http://root.cern/viewvc?rev=42921&amp;root=root&amp;view=rev" target="_blank">#42921</a> to add also to TXUnixSocket the possibility to disable reconnections via the variable TXSocket.Reconnect (0 disable reconnections; default is 1) .</li>
+		<li>Import patches <a href="http://root.cern/viewvc?rev=42775&amp;root=root&amp;view=rev" target="_blank">#42775</a>, <a href="http://root.cern/viewvc?rev=42788&amp;root=root&amp;view=rev" target="_blank">#42788</a>, <a href="http://root.cern/viewvc?rev=42882&amp;root=root&amp;view=rev" target="_blank">#42882</a> and <a href="http://root.cern/viewvc?rev=42883&amp;root=root&amp;view=rev" target="_blank">#42883</a> enabling parallel dataset verification.</li>
+		<li>Import patches <a href="http://root.cern/viewvc?rev=43101&amp;root=root&amp;view=rev" target="_blank">#43101</a>, <a href="http://root.cern/viewvc?rev=43884&amp;root=root&amp;view=rev" target="_blank">#43884</a> and <a href="http://root.cern/viewvc?rev=43886&amp;root=root&amp;view=rev" target="_blank">#43886</a> adding in proofbench full support for dataset generation on external storage.</li>
+		<li>Import patch <a href="http://root.cern/viewvc?rev=43567&amp;root=root&amp;view=rev" target="_blank">#43567</a> fixing a few issues with dataset verification of back-ends different from xrootd.</li>
 	</ul>
 	</li>
 </ul>
@@ -166,22 +166,22 @@ sidebar:
 	<li>I/O
 	<ul>
 		<li>Fix the merging (hadd and TFileMerger) of TTree in subdirectories when an incremental merge is requested (or needed). See the post <a bugs="" href="https://savannah.cern.ch/bugs/index.php?92486" savannah.cern.ch="">#92486</a>).</li>
-		<li>In TChainIndex (and hence tree friendship involving chains), properly handle the case where the requested index is too high. (See Forum <a href="http://root.cern.ch/phpBB3/viewtopic.php?p=61833" target="_blank">#61833)</a>.</li>
+		<li>In TChainIndex (and hence tree friendship involving chains), properly handle the case where the requested index is too high. (See Forum <a href="http://root.cern/phpBB3/viewtopic.php?p=61833" target="_blank">#61833)</a>.</li>
 	</ul>
 	</li>
 	<li>Proof
 	<ul>
-		<li>Import patch <a href="http://root.cern.ch/viewvc?rev=43245&amp;root=root&amp;view=rev" target="_blank">#43245</a> fixing an issue with forcing local copies of files before merging (bit not always honored).</li>
-		<li>Import patch <a href="http://root.cern.ch/viewvc?rev=43295&amp;root=root&amp;view=rev" target="_blank">#43295</a> to remove dependencies of netx on xrootd-related internal headers (the patch also removes external support for xrootd versions older than 4 years)</li>
-		<li>Import patch <a href="http://root.cern.ch/viewvc?rev=43107&amp;root=root&amp;view=rev" target="_blank">#43107</a> to add the possibility to force submerging at node level, i.e. one submerger per physical machine; in this way the network traffic can be minimized, for example when merging large output files.</li>
-		<li>Import patch <a href="http://root.cern.ch/viewvc?rev=43426&amp;root=root&amp;view=rev" target="_blank">#43426</a> fixing a problem with TProofOutputFile (more flexibility in the automatic definition of the env LOCALDATASERVER).</li>
-		<li>Import patch <a href="http://root.cern.ch/viewvc?rev=43440&amp;root=root&amp;view=rev" target="_blank">#43440</a> fixing an issue with the username used to access a remote file in the xproofd daemon. Fixes a problem when retrieving files from workers where the username is different, e.g. PoD on gLite.</li>
-		<li>Import patch <a href="http://root.cern.ch/viewvc?rev=43470&amp;root=root&amp;view=rev" target="_blank">#43470</a> fixing an backward compatibility issue affecting TProofBench::MakeDataSet.</li>
+		<li>Import patch <a href="http://root.cern/viewvc?rev=43245&amp;root=root&amp;view=rev" target="_blank">#43245</a> fixing an issue with forcing local copies of files before merging (bit not always honored).</li>
+		<li>Import patch <a href="http://root.cern/viewvc?rev=43295&amp;root=root&amp;view=rev" target="_blank">#43295</a> to remove dependencies of netx on xrootd-related internal headers (the patch also removes external support for xrootd versions older than 4 years)</li>
+		<li>Import patch <a href="http://root.cern/viewvc?rev=43107&amp;root=root&amp;view=rev" target="_blank">#43107</a> to add the possibility to force submerging at node level, i.e. one submerger per physical machine; in this way the network traffic can be minimized, for example when merging large output files.</li>
+		<li>Import patch <a href="http://root.cern/viewvc?rev=43426&amp;root=root&amp;view=rev" target="_blank">#43426</a> fixing a problem with TProofOutputFile (more flexibility in the automatic definition of the env LOCALDATASERVER).</li>
+		<li>Import patch <a href="http://root.cern/viewvc?rev=43440&amp;root=root&amp;view=rev" target="_blank">#43440</a> fixing an issue with the username used to access a remote file in the xproofd daemon. Fixes a problem when retrieving files from workers where the username is different, e.g. PoD on gLite.</li>
+		<li>Import patch <a href="http://root.cern/viewvc?rev=43470&amp;root=root&amp;view=rev" target="_blank">#43470</a> fixing an backward compatibility issue affecting TProofBench::MakeDataSet.</li>
 	</ul>
 	</li>
 	<li>QT
 	<ul>
-		<li>Repair generation of qtcint (see the forum post <a href="http://root.cern.ch/phpBB3/viewtopic.php?t=13636" target="_blank">#13636</a>.</li>
+		<li>Repair generation of qtcint (see the forum post <a href="http://root.cern/phpBB3/viewtopic.php?t=13636" target="_blank">#13636</a>.</li>
 	</ul>
 	</li>
 	<li>Histfactory
@@ -205,25 +205,25 @@ sidebar:
 	</li>
 	<li>Cint
 	<ul>
-		<li>Import patch <a href="http://root.cern.ch/viewvc?rev=42566&amp;root=root&amp;view=rev" target="_blank">#42566</a> fixing an issue preventing the generation on the dictionary for MathCore on some 32bits distributions This fixes <a href="https://savannah.cern.ch/bugs/?90906" target="_blank">#90906</a>.</li>
-		<li>Import patch <a href="http://root.cern.ch/viewvc?rev=42805&amp;root=root&amp;view=rev" target="_blank">#42805</a> fixing the problem <a href="https://savannah.cern.ch/bugs/index.php?83909" target="_blank">#83909</a> which leading to failure of the auto-dictionary generator when dealing with class template inside a namespace.</li>
-		<li>Fix parsing of templated function names in Linkdefs (Savannah <a href="https://savannah.cern.ch/bugs/index.php?90486" target="_blank">#90486</a>, <a href="http://root.cern.ch/viewvc?rev=42849&amp;root=root&amp;view=rev" target="_blank">r42849</a>).</li>
+		<li>Import patch <a href="http://root.cern/viewvc?rev=42566&amp;root=root&amp;view=rev" target="_blank">#42566</a> fixing an issue preventing the generation on the dictionary for MathCore on some 32bits distributions This fixes <a href="https://savannah.cern.ch/bugs/?90906" target="_blank">#90906</a>.</li>
+		<li>Import patch <a href="http://root.cern/viewvc?rev=42805&amp;root=root&amp;view=rev" target="_blank">#42805</a> fixing the problem <a href="https://savannah.cern.ch/bugs/index.php?83909" target="_blank">#83909</a> which leading to failure of the auto-dictionary generator when dealing with class template inside a namespace.</li>
+		<li>Fix parsing of templated function names in Linkdefs (Savannah <a href="https://savannah.cern.ch/bugs/index.php?90486" target="_blank">#90486</a>, <a href="http://root.cern/viewvc?rev=42849&amp;root=root&amp;view=rev" target="_blank">r42849</a>).</li>
 		<li>Fix G__ONELINE at 1024 even if configuring --with-cint-longline (<a href="https://savannah.cern.ch/bugs/index.php?90330" target="_blank">bug #90330</a>, r42584).</li>
 		<li>Warn if selection.xml references a field that does not exist (<a href="https://savannah.cern.ch/bugs/index.php?90061" target="_blank">bug #90061</a>, r42899).</li>
 		<li>Silence warning in Shadow.h on Windows (r42902).</li>
-		<li>Fix the executing of <tt>TPad * pp = (TPad*)gPad</tt>, see the <a href="http://root.cern.ch/phpBB3/viewtopic.php?t=14197" target="_blank">report on the forum.</a></li>
+		<li>Fix the executing of <tt>TPad * pp = (TPad*)gPad</tt>, see the <a href="http://root.cern/phpBB3/viewtopic.php?t=14197" target="_blank">report on the forum.</a></li>
 	</ul>
 	</li>
 	<li>Core
 	<ul>
-		<li>Import patch <a href="http://root.cern.ch/viewvc?rev=42757&amp;root=root&amp;view=rev" target="_blank">#42757</a> fixing memory leak due to multiple allocations of gLibraryVersion.</li>
+		<li>Import patch <a href="http://root.cern/viewvc?rev=42757&amp;root=root&amp;view=rev" target="_blank">#42757</a> fixing memory leak due to multiple allocations of gLibraryVersion.</li>
 		<li>Add missing implementation for TGenericClassInfo::GetDirectoryAutoAdd.</li>
 	</ul>
 	</li>
 	<li>I/O
 	<ul>
 		<li>Initialize the thread local gDirectory to gROOT rather than null (this is in particular useful to support TObject::Clone which needs a non-zero gDirectory)</li>
-		<li>Resolve <a href="https://savannah.cern.ch/bugs/index.php?88174" target="_blank">#88174</a> which lead to failure in hadd and the TFileMerger (See patch <a href="http://root.cern.ch/viewvc?rev=42802&amp;root=root&amp;view=rev" target="_blank">#42802</a>).</li>
+		<li>Resolve <a href="https://savannah.cern.ch/bugs/index.php?88174" target="_blank">#88174</a> which lead to failure in hadd and the TFileMerger (See patch <a href="http://root.cern/viewvc?rev=42802&amp;root=root&amp;view=rev" target="_blank">#42802</a>).</li>
 	</ul>
 	</li>
 	<li>TTree
@@ -287,7 +287,7 @@ sidebar:
 	<ul>
 		<li>Use flag=2 for constant term optimization in the evaluation of the profile likelihood test statistic</li>
 		<li>Fix a bug in running an automatic scan in the HypoTestInverter.</li>
-		<li>Fix a bug in making the Asimov data set in the AsymptoticCalculator when using workspaces generated with the new HistFactory version (see this RootForum&nbsp;<a href="http://root.cern.ch/phpBB3//viewtopic.php?f=15&amp;t=13863" target="_blank">post</a>).</li>
+		<li>Fix a bug in making the Asimov data set in the AsymptoticCalculator when using workspaces generated with the new HistFactory version (see this RootForum&nbsp;<a href="http://root.cern/phpBB3//viewtopic.php?f=15&amp;t=13863" target="_blank">post</a>).</li>
 		<li>Add possibility to make an AsimovDataSet using &nbsp;nominal nuisance parameter values</li>
 		<li>Add ProfileLikelihoodTestStat::SetOneSidedDiscovery() for q0 and added ::SetSigned() option to allow test statistic to probe fluctuations corresponding to p-values &gt;50%.</li>
 		<li>Misc. fixes to SamplingDistPlot and HypoTestPlot</li>
@@ -308,13 +308,13 @@ sidebar:
 	<li>Proof
 	<ul>
 		<li>Import in stressProof the patches introducing new tests, adding a return code consistent with standard test facilities and the option '-noprogress' to switch off the progress information which may create problems in wrapper applications intercepting the output (e.g. ctest). Patches imported: 42000,42142,42302,42303,42376,42386,42387,42393,42400,42416,42434,42451,42462 .</li>
-		<li>Import patch <a href="http://root.cern.ch/viewvc?rev=42578&amp;root=root&amp;view=rev" target="_blank">#42578</a> fixing in getProof.C some issues mostly related to PROOF-Lite.</li>
-		<li>Import class to analyse the performance tree (see <a href="http://root.cern.ch/drupal/content/analysing-performance-tree" target="_blank">description</a> <span style="color:#B22222;">(broken)</span> )</li>
-		<li>Adapt patch <a href="http://root.cern.ch/viewvc?rev=42671&amp;root=root&amp;view=rev" target="_blank">#42671</a> fixing a problem with TProof::Load reported in the PROOF forum, caused by the fact that the additional files were not copied in the master sandbox but left in the cache.</li>
-		<li>Import patch <a href="http://root.cern.ch/viewvc?rev=42798&amp;root=root&amp;view=rev" target="_blank">#42798</a> in TDataSetManagerFile consolidating the way duplicates are removed.</li>
-		<li>Import patch <a href="http://root.cern.ch/viewvc?rev=42904&amp;root=root&amp;view=rev" target="_blank">#42904</a> in TProofOutputFile changing the default mode for merging histograms in TFileMerger, to reduce the memory footprint.</li>
-		<li>Import patch <a href="http://root.cern.ch/viewvc?rev=43074&amp;root=root&amp;view=rev" target="_blank">#43074</a> fixing the way errors are handled when uploading files (e.g. UploadPackage).</li>
-		<li>Import patch <a href="http://root.cern.ch/viewvc?rev=43157&amp;root=root&amp;view=rev" target="_blank">#43157</a> fixing a compilation issue with xrootd 3.0.2 .</li>
+		<li>Import patch <a href="http://root.cern/viewvc?rev=42578&amp;root=root&amp;view=rev" target="_blank">#42578</a> fixing in getProof.C some issues mostly related to PROOF-Lite.</li>
+		<li>Import class to analyse the performance tree (see <a href="http://root.cern/drupal/content/analysing-performance-tree" target="_blank">description</a> <span style="color:#B22222;">(broken)</span> )</li>
+		<li>Adapt patch <a href="http://root.cern/viewvc?rev=42671&amp;root=root&amp;view=rev" target="_blank">#42671</a> fixing a problem with TProof::Load reported in the PROOF forum, caused by the fact that the additional files were not copied in the master sandbox but left in the cache.</li>
+		<li>Import patch <a href="http://root.cern/viewvc?rev=42798&amp;root=root&amp;view=rev" target="_blank">#42798</a> in TDataSetManagerFile consolidating the way duplicates are removed.</li>
+		<li>Import patch <a href="http://root.cern/viewvc?rev=42904&amp;root=root&amp;view=rev" target="_blank">#42904</a> in TProofOutputFile changing the default mode for merging histograms in TFileMerger, to reduce the memory footprint.</li>
+		<li>Import patch <a href="http://root.cern/viewvc?rev=43074&amp;root=root&amp;view=rev" target="_blank">#43074</a> fixing the way errors are handled when uploading files (e.g. UploadPackage).</li>
+		<li>Import patch <a href="http://root.cern/viewvc?rev=43157&amp;root=root&amp;view=rev" target="_blank">#43157</a> fixing a compilation issue with xrootd 3.0.2 .</li>
 	</ul>
 	</li>
 	<li>Core / Textinput
@@ -329,7 +329,7 @@ sidebar:
 	</li>
 	<li>GUI
 	<ul>
-		<li>Import patch <a href="http://root.cern.ch/viewvc?rev=42940&amp;root=root&amp;view=rev" target="_blank">#42940</a> fixing a problem with new style when using SetBackgroundPixmap() with flat buttons.</li>
+		<li>Import patch <a href="http://root.cern/viewvc?rev=42940&amp;root=root&amp;view=rev" target="_blank">#42940</a> fixing a problem with new style when using SetBackgroundPixmap() with flat buttons.</li>
 	</ul>
 	</li>
 	<li>PyROOT
@@ -349,14 +349,14 @@ sidebar:
 	</li>
 	<li>Hist
 	<ul>
-		<li>Import fix<a href="http:// http://root.cern.ch/viewvc?rev=42155&amp;root=root&amp;view=rev" target="_blank"> #42155</a> from the trunk to fix for bug <a href="https://savannah.cern.ch/bugs/index.php?88561" target="_blank">#88561</a></li>
+		<li>Import fix<a href="http:// http://root.cern/viewvc?rev=42155&amp;root=root&amp;view=rev" target="_blank"> #42155</a> from the trunk to fix for bug <a href="https://savannah.cern.ch/bugs/index.php?88561" target="_blank">#88561</a></li>
 		<li>THnSparse: fix calculation of number of entries (r42190)</li>
 		<li>Import r42237 to optimize the merging of histograms in case of equal axes.</li>
 	</ul>
 	</li>
 	<li>Minuit2
 	<ul>
-		<li>Import fix <a href="http:// http://root.cern.ch/viewvc?rev=42147&amp;root=root&amp;view=rev" target="_blank">#42147</a> in Minuit2Minimizer for fixing bug <a href="https://savannah.cern.ch/bugs/?89111" target="_blank">#89111</a> &nbsp;seen only on Windows</li>
+		<li>Import fix <a href="http:// http://root.cern/viewvc?rev=42147&amp;root=root&amp;view=rev" target="_blank">#42147</a> in Minuit2Minimizer for fixing bug <a href="https://savannah.cern.ch/bugs/?89111" target="_blank">#89111</a> &nbsp;seen only on Windows</li>
 	</ul>
 	</li>
 	<li>Roofit
@@ -376,9 +376,9 @@ sidebar:
 	</li>
 	<li>Proof
 	<ul>
-		<li>Adapt patch <a href="http://root.cern.ch/viewvc?rev=42142&amp;root=root&amp;view=rev" target="_blank">#42142</a> fixing the return code of stressProof.</li>
-		<li>Import patch <a href="http://root.cern.ch/viewvc?rev=42238&amp;root=root&amp;view=rev" target="_blank">#42238</a> fixing checks of controlling envs and parameters in TPerfStat.</li>
-		<li>Import patch <a href="http://root.cern.ch/viewvc?rev=42248&amp;root=root&amp;view=rev" target="_blank">#42248</a> fixing name of the internal directory in the draw functions of TProofBench.</li>
+		<li>Adapt patch <a href="http://root.cern/viewvc?rev=42142&amp;root=root&amp;view=rev" target="_blank">#42142</a> fixing the return code of stressProof.</li>
+		<li>Import patch <a href="http://root.cern/viewvc?rev=42238&amp;root=root&amp;view=rev" target="_blank">#42238</a> fixing checks of controlling envs and parameters in TPerfStat.</li>
+		<li>Import patch <a href="http://root.cern/viewvc?rev=42248&amp;root=root&amp;view=rev" target="_blank">#42248</a> fixing name of the internal directory in the draw functions of TProofBench.</li>
 	</ul>
 	</li>
 	<li>Core
@@ -413,14 +413,14 @@ sidebar:
 	</li>
 	<li>Proof
 	<ul>
-		<li>Import patch <a href="http://root.cern.ch/viewvc?rev=41771&amp;root=root&amp;view=rev" target="_blank">#41771</a> fixing an issue locating the xrootd authentication framework plugin in the PROOF client</li>
-		<li>Import patch <a href="http://root.cern.ch/viewvc?rev=41772&amp;root=root&amp;view=rev" target="_blank">#41772</a> fixing an issue with the configuration of xrootd lib paths when xrootd libs are in system lib paths.</li>
-		<li>Import patches <a href="http://root.cern.ch/viewvc?rev=41785&amp;root=root&amp;view=rev" target="_blank">#41785</a> and <a href="http://root.cern.ch/viewvc?rev=41786&amp;root=root&amp;view=rev" target="_blank">#41786</a> fixing an issue with packetizers preventing proper entry range processing and the file ordering in datasets.</li>
-		<li>Import patch <a href="http://root.cern.ch/viewvc?rev=41788&amp;root=root&amp;view=rev" target="_blank">#41788</a> fixing an issue with AddInputData when objects are TTree or derived.</li>
-		<li>Import patch <a href="http://root.cern.ch/viewvc?rev=41801&amp;root=root&amp;view=rev" target="_blank">#41801</a> fixing an issue in the packetizers potentially crashing PROOF-Lite at exit when using file-resident outputs.</li>
-		<li>Import patch <a href="http://root.cern.ch/viewvc?rev=41869&amp;root=root&amp;view=rev" target="_blank">#41869</a> cleaning-up and simplifying the configuration of xrootd-related list of libraries.</li>
-		<li>Import patches <a href="http://root.cern.ch/viewvc?rev=41958&amp;root=root&amp;view=rev" target="_blank">#41958</a> and <a href="http://root.cern.ch/viewvc?rev=41999&amp;root=root&amp;view=rev" target="_blank">#41999</a> to improve checks, definition and cleaning of the working dir in tutorials/proof/getProof.C</li>
-		<li>Import patch <a href="http://root.cern.ch/viewvc?rev=41904&amp;root=root&amp;view=rev" target="_blank">#41904</a> extending TProofMgr::Ping functionality to 'xrootd' too. This is useful to test if an xrootd server is available at a given address.</li>
+		<li>Import patch <a href="http://root.cern/viewvc?rev=41771&amp;root=root&amp;view=rev" target="_blank">#41771</a> fixing an issue locating the xrootd authentication framework plugin in the PROOF client</li>
+		<li>Import patch <a href="http://root.cern/viewvc?rev=41772&amp;root=root&amp;view=rev" target="_blank">#41772</a> fixing an issue with the configuration of xrootd lib paths when xrootd libs are in system lib paths.</li>
+		<li>Import patches <a href="http://root.cern/viewvc?rev=41785&amp;root=root&amp;view=rev" target="_blank">#41785</a> and <a href="http://root.cern/viewvc?rev=41786&amp;root=root&amp;view=rev" target="_blank">#41786</a> fixing an issue with packetizers preventing proper entry range processing and the file ordering in datasets.</li>
+		<li>Import patch <a href="http://root.cern/viewvc?rev=41788&amp;root=root&amp;view=rev" target="_blank">#41788</a> fixing an issue with AddInputData when objects are TTree or derived.</li>
+		<li>Import patch <a href="http://root.cern/viewvc?rev=41801&amp;root=root&amp;view=rev" target="_blank">#41801</a> fixing an issue in the packetizers potentially crashing PROOF-Lite at exit when using file-resident outputs.</li>
+		<li>Import patch <a href="http://root.cern/viewvc?rev=41869&amp;root=root&amp;view=rev" target="_blank">#41869</a> cleaning-up and simplifying the configuration of xrootd-related list of libraries.</li>
+		<li>Import patches <a href="http://root.cern/viewvc?rev=41958&amp;root=root&amp;view=rev" target="_blank">#41958</a> and <a href="http://root.cern/viewvc?rev=41999&amp;root=root&amp;view=rev" target="_blank">#41999</a> to improve checks, definition and cleaning of the working dir in tutorials/proof/getProof.C</li>
+		<li>Import patch <a href="http://root.cern/viewvc?rev=41904&amp;root=root&amp;view=rev" target="_blank">#41904</a> extending TProofMgr::Ping functionality to 'xrootd' too. This is useful to test if an xrootd server is available at a given address.</li>
 	</ul>
 	</li>
 	<li>Hist
@@ -442,7 +442,7 @@ sidebar:
 	</li>
 	<li>RooFit/RooFitCore
 	<ul>
-		<li>Import patch <a href="http://root.cern.ch/viewvc?view=rev&amp;revision=41862" target="_blank">#41862</a>, #41871, #41899, #41976 to improve cache optimizations</li>
+		<li>Import patch <a href="http://root.cern/viewvc?view=rev&amp;revision=41862" target="_blank">#41862</a>, #41871, #41899, #41976 to improve cache optimizations</li>
 		<li>Patch #42089 (add new bin-integrator)</li>
 		<li>Patch #42128 (various optimizations in pdf handling)</li>
 		<li>Patch #42153 (further optimizations, expand bin-integrator to 2/3d, support for mixed binned/unbinned generation)</li>

--- a/install/all_releases/root-version-v5-34-00-patch-release-notes.md
+++ b/install/all_releases/root-version-v5-34-00-patch-release-notes.md
@@ -42,11 +42,11 @@ NOTE: this release exists to backport support for LZ4 compression also to the ol
     * Re-introduced method TPythia6:Pytune()
 *  TTree
     * Fix ([ROOT-7423](https://sft.its.cern.ch/jira/browse/ROOT-7423)) TTreeCache may not stop the learning phase when asynchronous prefetching is enabled.
-    * Fix the issue described in the (following forum post(https://root.cern.ch/phpBB3/viewtopic.php?t=20269)), where a some order of calls to TTree::Scan and TTree::Write resulted in invalid output.
+    * Fix the issue described in the (following forum post(https://root.cern/phpBB3/viewtopic.php?t=20269)), where a some order of calls to TTree::Scan and TTree::Write resulted in invalid output.
     * Repair setting the branch address of a leaflist style branch taking directly the address of the struct.  (Note that leaflist is nonetheless still deprecated and declaring the struct to the interpreter and passing the object directly to create the branch is much better).
 * Graphics
    * `TGraph::GetHistogram()` was resetting the TimeDisplay attribute of axis. The problem was reported [here](https://sft.its.cern.ch/jira/browse/ROOT-7766).
-   * When painting a `TH3` as 3D boxes, `TMarker3DBox` ignored the max and min values specified by `SetMaximum()` and `SetMinimum()`. The problem was reported [here](https://root.cern.ch/phpBB3/viewtopic.php?f=3&t=20906&p=90632#p90632).
+   * When painting a `TH3` as 3D boxes, `TMarker3DBox` ignored the max and min values specified by `SetMaximum()` and `SetMinimum()`. The problem was reported [here](https://root.cern/phpBB3/viewtopic.php?f=3&t=20906&p=90632#p90632).
    *  When using time format in axis, `TGaxis::PaintAxis()` may in some cases call `strftime()` with invalid parameter causing a crash.
   This problem was reported [here](https://sft.its.cern.ch/jira/browse/ROOT-7689).
   * `TASImage` When the first or last point of a wide line is exactly on the window limit the line is drawn vertically or horizontally.
@@ -96,7 +96,7 @@ NOTE: this release exists to backport support for LZ4 compression also to the ol
     *   Fix the ordering of the keys in a TFile being written; in particular fixing the result of GetKey and FindKey which were no longer returning the lastest cycle for a TFile being written since v5.34/11.
 *   Graphics
     *   In the animated gif it is now possible to specify the delay between the last image and the fist image in case of infinite loop ([ROOT-7263](https://sft.its.cern.ch/jira/browse/ROOT-7263)).
-    *   2D stats painting now takes the stats format into account when painting Integral. This problem was mentioned [here](https://root.cern.ch/phpBB3/viewtopic.php?f=3&t=19746).
+    *   2D stats painting now takes the stats format into account when painting Integral. This problem was mentioned [here](https://root.cern/phpBB3/viewtopic.php?f=3&t=19746).
     *   Fix [ROOT-6703](https://sft.its.cern.ch/jira/browse/ROOT-6703).
 *   Proof
     *   In TProofPerfAnalysis, add functionality to save derived objects created / drawn during the calls.
@@ -151,7 +151,7 @@ NOTE: this release exists to backport support for LZ4 compression also to the ol
 
 
 *   Hists
-    *   Fix the problem reported [here](https://root.cern.ch/phpBB3/viewtopic.php?f=3&t=19186).
+    *   Fix the problem reported [here](https://root.cern/phpBB3/viewtopic.php?f=3&t=19186).
 *   Graphics
     *   Fix an issue with transparent pad in TTexDump.
     *   In TMathText \mu is now working for Postscript output.
@@ -276,7 +276,7 @@ NOTE: this release exists to backport support for LZ4 compression also to the ol
     *   In some cases an extra point was drawn when a TGraph2D was drawn with P, P0 or PCOL.
     *   The hollow fill style was not rendered correctly by TTexDump. ([ROOT-6841](https://sft.its.cern.ch/jira/browse/ROOT-6841))
     *   It was possible to interactively zoom outside the histograms' limits. Protections have been added.
-    *   Fix an [issue](http://root.cern.ch/phpBB3/viewtopic.php?f=3&t=18778) with E0 option and log scale.
+    *   Fix an [issue](http://root.cern/phpBB3/viewtopic.php?f=3&t=18778) with E0 option and log scale.
     *   Better line width matching with screen and pdf output ([ROOT-6858](https://sft.its.cern.ch/jira/browse/ROOT-6858))
 *   Http
     *   Imported new version of http server and jsroot (Sergey Linev)
@@ -363,7 +363,7 @@ NOTE: this release exists to backport support for LZ4 compression also to the ol
 *   Core
     *   Fix [ROOT-6445](https://sft.its.cern.ch/jira/browse/ROOT-6445): TThread initialization prevent TApplication::Terminate() without user input.
 *   TTree
-    *   Add support for turn on and customizing the TTreeCache from the environment and .rootrc (see [commit 2201cac9](http://root.cern.ch/gitweb?p=root.git;a=commitdiff;h=2201cac9d4b38c4f3a7f485cd64861ed4c7dabe1))
+    *   Add support for turn on and customizing the TTreeCache from the environment and .rootrc (see [commit 2201cac9](http://root.cern/gitweb?p=root.git;a=commitdiff;h=2201cac9d4b38c4f3a7f485cd64861ed4c7dabe1))
 *   Graphics
     *   Fix ROOT-6470: The marker definition in the TeX output generated by TTeXDump was misplaced.
     *   Implement the option FUNC for 2D histograms.<span style="white-space:pre" class="Apple-tab-span"></span>
@@ -386,7 +386,7 @@ NOTE: this release exists to backport support for LZ4 compression also to the ol
 *   TTree
     *   TTreePerfStats now calculated properly the unzipping time for its given TTree only.
     *   Fix TTreeCache learning when used by TTree::Draw (problem with SetEntryRange) ; this solves [ROOT-6103.](https://sft.its.cern.ch/jira/browse/ROOT-6103)
-    *   Fix TTreeFormula to prevent miscaculation in case [ROOT-5545](http://root.cern.ch/phpBB3/viewtopic.php?t=18049>involving TCutG</a>.</li>
+    *   Fix TTreeFormula to prevent miscaculation in case [ROOT-5545](http://root.cern/phpBB3/viewtopic.php?t=18049>involving TCutG</a>.</li>
 
 *   Proof
     *   Disable by default memory checks during event loop as they can impact significantly performance with fast I/O devices (no impact for CPU intensive tasks). They can be enabled by setting the parameter PROOF_MemLogFreq or the env PROOF_MEMLOGFREQ to the checking period in terms of events.
@@ -439,7 +439,7 @@ NOTE: this release exists to backport support for LZ4 compression also to the ol
     *   Fix the projections of TProfile2D to TProfile, by implementing TProfile2D::ProfileX(Y) and the projections TProfile3D to TProfile2D by implementing TProfile3D::Project3DProfile ([ROOT-6620](https://sft.its.cern.ch/jira/browse/ROOT-6220))
     *   Improve the title of the created histograms in SetShowProjections
     *   Merge from the master a new version of TUnfold (v.17)
-    *   Fix TH1::Fit to draw only the function when fitting an histogram already plotted in a pad. (See [RootTalk-18071](http://root.cern.ch/phpBB3/viewtopic.php?f=3&t=18071))
+    *   Fix TH1::Fit to draw only the function when fitting an histogram already plotted in a pad. (See [RootTalk-18071](http://root.cern/phpBB3/viewtopic.php?f=3&t=18071))
 *   Net
     *   New HTTP Server package
 
@@ -786,7 +786,7 @@ NOTE: this release exists to backport support for LZ4 compression also to the ol
     *   Added user-defined extensions to volumes and nodes. This can be done inheriting from the base class TGeoExtension. To attach a user TObject derived class, one can use the reference counted TGeoRCExtension. The TGeoExtension class allows for either using or not reference counting. A utility TGeoRCPtr was added to allor smart reference counted pointers. To attach a user extension, use TGeoVolume::SetUserExtension() or TGeoNode::SetUserExtension(). To grab a reference counted pointer use GrabUserExtension(), to simply use/release use the method GetExtension().
     *   Added possibility to draw polygons in 2D using TGeoPolygon::Draw() or TGeoXtru::DrawPolygon()
 
-![](http://root.cern.ch/drupal/sites/default/files/images/polygon.preview.gif)
+![](http://root.cern/drupal/sites/default/files/images/polygon.preview.gif)
 
 <a id='07'></a>
 ## Changes in version v5-34-07 (April 26, 2013)
@@ -821,7 +821,7 @@ NOTE: this release exists to backport support for LZ4 compression also to the ol
     *   SetBranchAddress now returns an error code.
     *   In TTree::SetBranchAddress, properly reset the TargetClass when the address is changed (back) to the original type.
     *   Issue an error message if the class type of the argument to TTree::SetBranchAddress can not be determined (missing dictionary but having only a typeid).
-    *   Correct the behavior when attempting to create a branch with split level zero with an object that requires the use a TBranchObject (for example TVector3). See the ROOT Forum [#15975](http://root.cern.ch/phpBB3/viewtopic.php?t=15975)
+    *   Correct the behavior when attempting to create a branch with split level zero with an object that requires the use a TBranchObject (for example TVector3). See the ROOT Forum [#15975](http://root.cern/phpBB3/viewtopic.php?t=15975)
     *   Properly handle the evolution of an STL container containing a class with contains sub-object.
     *   Extend the output of TTree::Print(debugInfo) to include the action sequence information (and add support for the sub option 'func' that also prints the function's (mangled) name.
 *   Math
@@ -829,10 +829,10 @@ NOTE: this release exists to backport support for LZ4 compression also to the ol
 *   Net
     *   The class TS3WebFile was modified to support also reading files hosted by Google using the S3 protocol. Its TFile plugin was also modified to reflect this.
 *   Proof
-    *   Import patch [#46634](http://root.cern.ch/viewvc?rev=46634&root=root&view=rev) removing the dependence on the XRootD header XrdSutAux.hh
-    *   Import patch [#48766](http://root.cern.ch/viewvc?rev=48766&root=root&view=rev) fixing a possible double-delete when a selector is processed by object.
-    *   Import patch [#48939](http://root.cern.ch/viewvc?rev=48939&root=root&view=rev) fixing problem in pq2-verify.
-    *   Import patch [#49113](http://root.cern.ch/viewvc?rev=49113&root=root&view=rev) fixing a possible crash in submerger mode due to missing protection.
+    *   Import patch [#46634](http://root.cern/viewvc?rev=46634&root=root&view=rev) removing the dependence on the XRootD header XrdSutAux.hh
+    *   Import patch [#48766](http://root.cern/viewvc?rev=48766&root=root&view=rev) fixing a possible double-delete when a selector is processed by object.
+    *   Import patch [#48939](http://root.cern/viewvc?rev=48939&root=root&view=rev) fixing problem in pq2-verify.
+    *   Import patch [#49113](http://root.cern/viewvc?rev=49113&root=root&view=rev) fixing a possible crash in submerger mode due to missing protection.
 *   PyROOT
     *   Support for python3.3.
 *   GL
@@ -910,8 +910,8 @@ on top of the merging defaults: kAll | kIncremental (as in the example $ROOTSYS/
     *   Fix a [problem with the option SAME](https://savannah.cern.ch/bugs/?100221).
 *   Proof
     *   Correctly set the PROOF internal protocol value to the level required by the new dataset staging request functionality.
-    *   Import patch [#48355](http://root.cern.ch/viewvc?rev=48355&root=root&view=rev) with important fixes in TDataSetManagerAliEn.
-    *   Import patch [#48439](http://root.cern.ch/viewvc?rev=48439&root=root&view=rev) with fixes/modifications in xpdtest, setxrd.sh and installXrootd.sh.
+    *   Import patch [#48355](http://root.cern/viewvc?rev=48355&root=root&view=rev) with important fixes in TDataSetManagerAliEn.
+    *   Import patch [#48439](http://root.cern/viewvc?rev=48439&root=root&view=rev) with fixes/modifications in xpdtest, setxrd.sh and installXrootd.sh.
 *   Eve
     *   Added a few extra class members to TEveRecTrackT needed by ALICE.
 *   RooFit
@@ -934,42 +934,42 @@ on top of the merging defaults: kAll | kIncremental (as in the example $ROOTSYS/
  <font size="-2">Binary Incompatible</font>
 
 *   Core
-    *   Fixes two thread safety issues affecting accessing TClonesArray objects in more than one thread (see revision [#47726](http://root.cern.ch/viewvc?rev=47726&root=root&view=rev)).
-    *   Import patch [#48132](http://root.cern.ch/viewvc?rev=48132&root=root&view=rev) fixing an issue in TUnixSystem::RedirectOutput; this resolves the Savannah report [#96935](http://savannah.cern.ch/bugs/?96935).
+    *   Fixes two thread safety issues affecting accessing TClonesArray objects in more than one thread (see revision [#47726](http://root.cern/viewvc?rev=47726&root=root&view=rev)).
+    *   Import patch [#48132](http://root.cern/viewvc?rev=48132&root=root&view=rev) fixing an issue in TUnixSystem::RedirectOutput; this resolves the Savannah report [#96935](http://savannah.cern.ch/bugs/?96935).
 *   I/O
     *   Prevent a segmentation fault at the time a TFile is closed and/or deleted if it contains a TTree that is stored in a subdirectory.
     *   Prevent infinite loop when encountering unzipping error. This resolves the Savannah report [#99523](http://savannah.cern.ch/bugs/?99523).
-    *   Import patch [#48115](http://root.cern.ch/viewvc?rev=48115&root=root&view=rev) in TFileMerger basically skipping, for non-mergeable objects, the check on recurrent names. This should fix the Savannah report [#99015](http://savannah.cern.ch/bugs/?99015).
+    *   Import patch [#48115](http://root.cern/viewvc?rev=48115&root=root&view=rev) in TFileMerger basically skipping, for non-mergeable objects, the check on recurrent names. This should fix the Savannah report [#99015](http://savannah.cern.ch/bugs/?99015).
 *   Proof
-    *   Import patch [#46864](http://root.cern.ch/viewvc?rev=46864&root=root&view=rev) fixing a crash in TStatus::Add in the case of missing files. This was a regression introduced by branch patch [#45751](http://root.cern.ch/viewvc?rev=45751&root=root&view=rev) (import of [#45283](http://root.cern.ch/viewvc?rev=45283&root=root&view=rev)).
-    *   Import patch [#46992](http://root.cern.ch/viewvc?rev=46992&root=root&view=rev) addressing a possible crash after finalisation.
-    *   Import patch [#47067](http://root.cern.ch/viewvc?rev=47067&root=root&view=rev) fixing possible (random) failure of test 22.
-    *   Import patch [#47235](http://root.cern.ch/viewvc?rev=47235&root=root&view=rev) fixing a file permission issue in afdsmgrd.
-    *   Import patch [#47238](http://root.cern.ch/viewvc?rev=47238&root=root&view=rev) fixing a few issues preventing proper cleaning of the 'data' directory when running stressProof in Proof-Lite.
-    *   Import patch [#47251](http://root.cern.ch/viewvc?rev=47251&root=root&view=rev) fixing an issue with unexpected settings in TStatus::fBits.
-    *   Import patch [#47270](http://root.cern.ch/viewvc?rev=47270&root=root&view=rev) adding notification of the estimated time left (and, at the end, of the processing time) also when running in batch mode.
-    *   Import patch [#47367](http://root.cern.ch/viewvc?rev=47367&root=root&view=rev) fixing an issue with TDSet::Validate.
-    *   Import patch [#47444](http://root.cern.ch/viewvc?rev=47444&root=root&view=rev) to not print all progress messages during the merging phase in non-tty mode (avoid filling up the logs with useless info).
-    *   Import patch [#47451](http://root.cern.ch/viewvc?rev=47451&root=root&view=rev) to add flexibility in defining directories for PAR packages.
-    *   Import patches [#47528](http://root.cern.ch/viewvc?rev=47528&root=root&view=rev) and [#47573](http://root.cern.ch/viewvc?rev=47573&root=root&view=rev) to support specifying the check version option in TProof::EnablePackage.
-    *   Import patch [#47664](http://root.cern.ch/viewvc?rev=47664&root=root&view=rev) fixing an undefined variable in TSelEventGen (proofbench PAR package).
-    *   Import patch [#47729](http://root.cern.ch/viewvc?rev=47729&root=root&view=rev) fixing a backward incompatibility introduced by patch [#45751](http://root.cern.ch/viewvc?
+    *   Import patch [#46864](http://root.cern/viewvc?rev=46864&root=root&view=rev) fixing a crash in TStatus::Add in the case of missing files. This was a regression introduced by branch patch [#45751](http://root.cern/viewvc?rev=45751&root=root&view=rev) (import of [#45283](http://root.cern/viewvc?rev=45283&root=root&view=rev)).
+    *   Import patch [#46992](http://root.cern/viewvc?rev=46992&root=root&view=rev) addressing a possible crash after finalisation.
+    *   Import patch [#47067](http://root.cern/viewvc?rev=47067&root=root&view=rev) fixing possible (random) failure of test 22.
+    *   Import patch [#47235](http://root.cern/viewvc?rev=47235&root=root&view=rev) fixing a file permission issue in afdsmgrd.
+    *   Import patch [#47238](http://root.cern/viewvc?rev=47238&root=root&view=rev) fixing a few issues preventing proper cleaning of the 'data' directory when running stressProof in Proof-Lite.
+    *   Import patch [#47251](http://root.cern/viewvc?rev=47251&root=root&view=rev) fixing an issue with unexpected settings in TStatus::fBits.
+    *   Import patch [#47270](http://root.cern/viewvc?rev=47270&root=root&view=rev) adding notification of the estimated time left (and, at the end, of the processing time) also when running in batch mode.
+    *   Import patch [#47367](http://root.cern/viewvc?rev=47367&root=root&view=rev) fixing an issue with TDSet::Validate.
+    *   Import patch [#47444](http://root.cern/viewvc?rev=47444&root=root&view=rev) to not print all progress messages during the merging phase in non-tty mode (avoid filling up the logs with useless info).
+    *   Import patch [#47451](http://root.cern/viewvc?rev=47451&root=root&view=rev) to add flexibility in defining directories for PAR packages.
+    *   Import patches [#47528](http://root.cern/viewvc?rev=47528&root=root&view=rev) and [#47573](http://root.cern/viewvc?rev=47573&root=root&view=rev) to support specifying the check version option in TProof::EnablePackage.
+    *   Import patch [#47664](http://root.cern/viewvc?rev=47664&root=root&view=rev) fixing an undefined variable in TSelEventGen (proofbench PAR package).
+    *   Import patch [#47729](http://root.cern/viewvc?rev=47729&root=root&view=rev) fixing a backward incompatibility introduced by patch [#45751](http://root.cern/viewvc?
                 rev=45751&root=root&view=rev).
-    *   Import patch [#47832](http://root.cern.ch/viewvc?rev=47832&root=root&view=rev) to make sure that the fSlaves list contains always ALL workers, even those which did not initially startup; this way GetListOfSlaveInfos can be used to find out which workers had problems starting up.
-    *   Import patch [#47833](http://root.cern.ch/viewvc?rev=47833&root=root&view=rev) to make sure that the XrdProofClient instance is always defined when calling MapClient. This was not done for example when using the weak authentication protocol 'host', or similar protocols not requiring a real authentication token.
-    *   Import patches [#48060](http://root.cern.ch/viewvc?rev=48060&root=root&view=rev) and [#48239](http://root.cern.ch/viewvc?rev=48239&root=root&view=rev) introducing an improved dataset management model where the PROOF (ROOT) dataset manager is a light frontend to the experiment file catalogs; TDataSetManagerFile is still used as local cache of the experiment information or to store the work-in-progress status of the dataset manager daemon. This model is expected to solve the scalability issues observed currently at AAFs. The patches include the new class TDataSetManagerAliEn with the first concrete implementation of experiment catalog interface and a new version of afdsmgrd able to cope with the new dataset model.
-    *   Import patch [#48063](http://root.cern.ch/viewvc?rev=48063&root=root&view=rev) fixing fixing possible deadlock in session startup.
-    *   Import patch [#48068](http://root.cern.ch/viewvc?rev=48068&root=root&view=rev) fixing some issues in TProofBench.
-    *   Import patches [#48086](http://root.cern.ch/viewvc?rev=48086&root=root&view=rev) and [#48099](http://root.cern.ch/viewvc?rev=48099&root=root&view=rev) fixing some building issues.
-    *   Import patch [#48104](http://root.cern.ch/viewvc?rev=48104&root=root&view=rev) fixing fixes failure in TProofBench.
-    *   Import patch [#48122](http://root.cern.ch/viewvc?rev=48122&root=root&view=rev) turning-off role checking for localhost connections (not required and limiting daemon test applications).
-    *   Import patches [#48016](http://root.cern.ch/viewvc?rev=48016&root=root&view=rev) and [#48127](http://root.cern.ch/viewvc?rev=48127&root=root&view=rev) with several fixes in xproofd.
-    *   Import patch [#48130](http://root.cern.ch/viewvc?rev=48130&root=root&view=rev) adding the executable 'ptest' which can be used to test the status of the daemon.
-    *   Import patches [#48130](http://root.cern.ch/viewvc?rev=48130&root=root&view=rev) and [#48141](http://root.cern.ch/viewvc?rev=48141&root=root&view=rev) to support building ROOT using an untagged xrootd (e.g. the trunk).
-    *   Import patch [#48166](http://root.cern.ch/viewvc?rev=48166&root=root&view=rev) reducing verbosity during merge of TProofOutputFile in no debug mode.
-    *   Import patches [#48211](http://root.cern.ch/viewvc?rev=48211&root=root&view=rev) and [#48226](http://root.cern.ch/viewvc?rev=48226&root=root&view=rev) to fix possible deadlocks associated with the handling of asynchronous timers.
+    *   Import patch [#47832](http://root.cern/viewvc?rev=47832&root=root&view=rev) to make sure that the fSlaves list contains always ALL workers, even those which did not initially startup; this way GetListOfSlaveInfos can be used to find out which workers had problems starting up.
+    *   Import patch [#47833](http://root.cern/viewvc?rev=47833&root=root&view=rev) to make sure that the XrdProofClient instance is always defined when calling MapClient. This was not done for example when using the weak authentication protocol 'host', or similar protocols not requiring a real authentication token.
+    *   Import patches [#48060](http://root.cern/viewvc?rev=48060&root=root&view=rev) and [#48239](http://root.cern/viewvc?rev=48239&root=root&view=rev) introducing an improved dataset management model where the PROOF (ROOT) dataset manager is a light frontend to the experiment file catalogs; TDataSetManagerFile is still used as local cache of the experiment information or to store the work-in-progress status of the dataset manager daemon. This model is expected to solve the scalability issues observed currently at AAFs. The patches include the new class TDataSetManagerAliEn with the first concrete implementation of experiment catalog interface and a new version of afdsmgrd able to cope with the new dataset model.
+    *   Import patch [#48063](http://root.cern/viewvc?rev=48063&root=root&view=rev) fixing fixing possible deadlock in session startup.
+    *   Import patch [#48068](http://root.cern/viewvc?rev=48068&root=root&view=rev) fixing some issues in TProofBench.
+    *   Import patches [#48086](http://root.cern/viewvc?rev=48086&root=root&view=rev) and [#48099](http://root.cern/viewvc?rev=48099&root=root&view=rev) fixing some building issues.
+    *   Import patch [#48104](http://root.cern/viewvc?rev=48104&root=root&view=rev) fixing fixes failure in TProofBench.
+    *   Import patch [#48122](http://root.cern/viewvc?rev=48122&root=root&view=rev) turning-off role checking for localhost connections (not required and limiting daemon test applications).
+    *   Import patches [#48016](http://root.cern/viewvc?rev=48016&root=root&view=rev) and [#48127](http://root.cern/viewvc?rev=48127&root=root&view=rev) with several fixes in xproofd.
+    *   Import patch [#48130](http://root.cern/viewvc?rev=48130&root=root&view=rev) adding the executable 'ptest' which can be used to test the status of the daemon.
+    *   Import patches [#48130](http://root.cern/viewvc?rev=48130&root=root&view=rev) and [#48141](http://root.cern/viewvc?rev=48141&root=root&view=rev) to support building ROOT using an untagged xrootd (e.g. the trunk).
+    *   Import patch [#48166](http://root.cern/viewvc?rev=48166&root=root&view=rev) reducing verbosity during merge of TProofOutputFile in no debug mode.
+    *   Import patches [#48211](http://root.cern/viewvc?rev=48211&root=root&view=rev) and [#48226](http://root.cern/viewvc?rev=48226&root=root&view=rev) to fix possible deadlocks associated with the handling of asynchronous timers.
 *   Tree
-    *   Import patch [#47057](http://root.cern.ch/viewvc?rev=47057&root=root&view=rev) in TTree::Merge to make sure that things are really written out to disk before attempting any reading; solves an issue in TFileMerger when the merged file is written to a xrootd backend.
+    *   Import patch [#47057](http://root.cern/viewvc?rev=47057&root=root&view=rev) in TTree::Merge to make sure that things are really written out to disk before attempting any reading; solves an issue in TFileMerger when the merged file is written to a xrootd backend.
     *   TTree::ReadFile and TTree::ReadStream now skip empty lines and commented out line (starting with #) before looking for a description. (This fixes the most recent part of the Savannah report [#28084](http://savannah.cern.ch/bugs/?28084)).
     *   In TTree::ReadFile and TTree::ReadStreama allow colon (:) as the separator for the list of branch and types even in the case of a comma separated file. This resolves the Savannah report [#99528](http://savannah.cern.ch/bugs/?99528).
 *   Graphics
@@ -987,7 +987,7 @@ on top of the merging defaults: kAll | kIncremental (as in the example $ROOTSYS/
 *   PyROOT
     *   Reworked GIL release to be as close to the C++ call as possible
 *   Hist
-    *   Fix a bug in fitting TGraphAsymErrors when including error in x (see Forum [#15564](http://root.cern.ch/phpBB3/viewtopic.php?f=3&t=15564))
+    *   Fix a bug in fitting TGraphAsymErrors when including error in x (see Forum [#15564](http://root.cern/phpBB3/viewtopic.php?f=3&t=15564))
     *   Improve TAxis::SetRange with the possibility to include/exclude also underflow and overflow bins (see issue [#97331](http://savannah.cern.ch/bugs/?97331))
     *   Fix a bug in re-using the stored fit function in the histogram for fitting a second time
 *   Minuit
@@ -996,7 +996,7 @@ on top of the merging defaults: kAll | kIncremental (as in the example $ROOTSYS/
     *   Fix a bug,introduced in 5.34.01, when generating the correct number of events when using the Extended() option ([#98832](https://savannah.cern.ch/bugs/index.php?98832))
     *   Import in RooPoisson the implementation of the analytical integral for the mean
 *   RooStats
-    *   Fix an issue in FactorizePdf (see Forum [#15694](http://root.cern.ch/phpBB3/viewtopic.php?f=15&t=15694))
+    *   Fix an issue in FactorizePdf (see Forum [#15694](http://root.cern/phpBB3/viewtopic.php?f=15&t=15694))
     *   Fix a memory leak in SPlot ([#99400](https://savannah.cern.ch/bugs/?99400))
     *   Add functions in RooStatsUtils to factorize the pdf and to remove constraint terms. Speed-up the SimpleLikelihoodRatio evaluation by avoiding to evaluate the constraints
     *   Fix the AsymptoticCalculator to try to use same binning for Asimov data set as observed data
@@ -1048,7 +1048,7 @@ on top of the merging defaults: kAll | kIncremental (as in the example $ROOTSYS/
 *   FFTW
     *   Fix bug [#97707](https://savannah.cern.ch/bugs/?97707) in TFFTComplexReal::SetPoint(ipoint, c)
 *   MathCore
-    *   Fix a bug in the Fitter class in setting a different error scale for likelihood fits (see post [#15368](http://root.cern.ch/phpBB3/viewtopic.php?f=15&t=15368))
+    *   Fix a bug in the Fitter class in setting a different error scale for likelihood fits (see post [#15368](http://root.cern/phpBB3/viewtopic.php?f=15&t=15368))
 *   Graphics
     *   Implementation of MacOS X back-end finished.
     *   When <tt>GetX(YZ)axis</tt> were called on a <tt>TGraph2D</tt>, the frame limit and plotting options were changed.
@@ -1078,32 +1078,32 @@ on top of the merging defaults: kAll | kIncremental (as in the example $ROOTSYS/
 *   Meta
     *   Making sure that when we lookup for an existing entry we look for an exact match (as oppose to doing a lookup of the unqualified name) to avoid unrelated nested typedef/names to over-ride global scope classes that are marked for autoloading (r42421).
 *   I/O
-    *   Avoid spurious error message when reading an existing file with a class inheriting from std::string ([r45117](http://root.cern.ch/viewvc?rev=45117&root=root&view=rev))
-    *   Corrected the calculation of the number of read calls in TRFIOFile (See the forum [post](http://root.cern.ch/phpBB3/viewtopic.php?f=3&t=14673&p=64367#p64367) on the subject. Fixed by revision [45140](http://root.cern.ch/viewvc?rev=45140&root=root&view=rev)).
-    *   Add protection against corrupted ROOT File (wrong length stored in the file header) (Revision [45170](http://root.cern.ch/viewvc?rev=45170&root=root&view=rev)).
-    *   Fix file->Get("Lumi/physics;2") to properly retrieve the 2nd cycle (revision [45243](http://root.cern.ch/viewvc?rev=45243&root=root&view=rev)).
-    *   Implement TChain::RemoveFriend to avoid leaving the TChain in an unstable state (See the forum [post](http://root.cern.ch/phpBB3/viewtopic.php?t=15206) on the subject.  Fixed by revision [46069](http://root.cern.ch/viewvc?rev=46069&root=root&view=rev)).
+    *   Avoid spurious error message when reading an existing file with a class inheriting from std::string ([r45117](http://root.cern/viewvc?rev=45117&root=root&view=rev))
+    *   Corrected the calculation of the number of read calls in TRFIOFile (See the forum [post](http://root.cern/phpBB3/viewtopic.php?f=3&t=14673&p=64367#p64367) on the subject. Fixed by revision [45140](http://root.cern/viewvc?rev=45140&root=root&view=rev)).
+    *   Add protection against corrupted ROOT File (wrong length stored in the file header) (Revision [45170](http://root.cern/viewvc?rev=45170&root=root&view=rev)).
+    *   Fix file->Get("Lumi/physics;2") to properly retrieve the 2nd cycle (revision [45243](http://root.cern/viewvc?rev=45243&root=root&view=rev)).
+    *   Implement TChain::RemoveFriend to avoid leaving the TChain in an unstable state (See the forum [post](http://root.cern/phpBB3/viewtopic.php?t=15206) on the subject.  Fixed by revision [46069](http://root.cern/viewvc?rev=46069&root=root&view=rev)).
 *   Proof
-    *   Import patches [#45846](http://root.cern.ch/viewvc?rev=45846&root=root&view=rev), [#45847](http://root.cern.ch/viewvc?rev=45847&root=root&view=rev) and [#45849](http://root.cern.ch/viewvc?rev=45849&root=root&view=rev) fixing a few consistency issues (honoring 'workers=N' when passed as option in PROOF-Lite, parallel dataset verification when PROOF is sequential).
-    *   Import patches [#45876](http://root.cern.ch/viewvc?rev=45876&root=root&view=rev), [#45823](http://root.cern.ch/viewvc?rev=45823&root=root&view=rev) and [#45827](http://root.cern.ch/viewvc?rev=45827&root=root&view=rev) fixing, in stressProof, sandbox cleaning and adding some switches to better control log saving an path in case of failures. The patch also adds the correct switches in test/CMakeList.txt for cmake -based test running.
-    *   Import patch [#45759](http://root.cern.ch/viewvc?rev=45759&root=root&view=rev) fixing possible double delete in TProofDraw.
-    *   Import patches [#45283](http://root.cern.ch/viewvc?rev=45283&root=root&view=rev), [#45289](http://root.cern.ch/viewvc?rev=45289&root=root&view=rev), [#45318](http://root.cern.ch/viewvc?rev=45318&root=root&view=rev), [#45348](http://root.cern.ch/viewvc?rev=45348&root=root&view=rev), [#45367](http://root.cern.ch/viewvc?rev=45367&root=root&view=rev), [#45570](http://root.cern.ch/viewvc?rev=45570&root=root&view=rev), [#45610](http://root.cern.ch/viewvc?rev=45610&root=root&view=rev), [#45614](http://root.cern.ch/viewvc?rev=45614&root=root&view=rev), [#45615](http://root.cern.ch/viewvc?rev=45615&root=root&view=rev), [#45632](http://root.cern.ch/viewvc?rev=45632&root=root&view=rev), [#45634](http://root.cern.ch/viewvc?rev=45634&root=root&view=rev), [#45282](http://root.cern.ch/viewvc?rev=45282&root=root&view=rev), [#45696](http://root.cern.ch/viewvc?rev=45696&root=root&view=rev), [#45697](http://root.cern.ch/viewvc?rev=45697&root=root&view=rev), [#45718](http://root.cern.ch/viewvc?rev=45718&root=root&view=rev) and [#45740](http://root.cern.ch/viewvc?rev=45740&root=root&view=rev) automatizing the usage of file-based technology to handle outputs (see [Handling Outputs](/handling-outputs)).
-    *   Import patch [#45664](http://root.cern.ch/viewvc?rev=45664&root=root&view=rev) fixing an issue with afdsmgrd build in the case a '--prefix=' was passed.
-    *   Import patches [#45283](http://root.cern.ch/viewvc?rev=45283&root=root&view=rev) (parts), [#45318](http://root.cern.ch/viewvc?rev=45318&root=root&view=rev), [#45607](http://root.cern.ch/viewvc?rev=45607&root=root&view=rev), [#45610](http://root.cern.ch/viewvc?rev=45610&root=root&view=rev), [#45613](http://root.cern.ch/viewvc?rev=45613&root=root&view=rev), [#45614](http://root.cern.ch/viewvc?rev=45614&root=root&view=rev) (parts), [#45630](http://root.cern.ch/viewvc?rev=45630&root=root&view=rev), [#45632](http://root.cern.ch/viewvc?rev=45632&root=root&view=rev) (parts) and [#45643](http://root.cern.ch/viewvc?rev=45643&root=root&view=rev) fixing several issues:
+    *   Import patches [#45846](http://root.cern/viewvc?rev=45846&root=root&view=rev), [#45847](http://root.cern/viewvc?rev=45847&root=root&view=rev) and [#45849](http://root.cern/viewvc?rev=45849&root=root&view=rev) fixing a few consistency issues (honoring 'workers=N' when passed as option in PROOF-Lite, parallel dataset verification when PROOF is sequential).
+    *   Import patches [#45876](http://root.cern/viewvc?rev=45876&root=root&view=rev), [#45823](http://root.cern/viewvc?rev=45823&root=root&view=rev) and [#45827](http://root.cern/viewvc?rev=45827&root=root&view=rev) fixing, in stressProof, sandbox cleaning and adding some switches to better control log saving an path in case of failures. The patch also adds the correct switches in test/CMakeList.txt for cmake -based test running.
+    *   Import patch [#45759](http://root.cern/viewvc?rev=45759&root=root&view=rev) fixing possible double delete in TProofDraw.
+    *   Import patches [#45283](http://root.cern/viewvc?rev=45283&root=root&view=rev), [#45289](http://root.cern/viewvc?rev=45289&root=root&view=rev), [#45318](http://root.cern/viewvc?rev=45318&root=root&view=rev), [#45348](http://root.cern/viewvc?rev=45348&root=root&view=rev), [#45367](http://root.cern/viewvc?rev=45367&root=root&view=rev), [#45570](http://root.cern/viewvc?rev=45570&root=root&view=rev), [#45610](http://root.cern/viewvc?rev=45610&root=root&view=rev), [#45614](http://root.cern/viewvc?rev=45614&root=root&view=rev), [#45615](http://root.cern/viewvc?rev=45615&root=root&view=rev), [#45632](http://root.cern/viewvc?rev=45632&root=root&view=rev), [#45634](http://root.cern/viewvc?rev=45634&root=root&view=rev), [#45282](http://root.cern/viewvc?rev=45282&root=root&view=rev), [#45696](http://root.cern/viewvc?rev=45696&root=root&view=rev), [#45697](http://root.cern/viewvc?rev=45697&root=root&view=rev), [#45718](http://root.cern/viewvc?rev=45718&root=root&view=rev) and [#45740](http://root.cern/viewvc?rev=45740&root=root&view=rev) automatizing the usage of file-based technology to handle outputs (see [Handling Outputs](/handling-outputs)).
+    *   Import patch [#45664](http://root.cern/viewvc?rev=45664&root=root&view=rev) fixing an issue with afdsmgrd build in the case a '--prefix=' was passed.
+    *   Import patches [#45283](http://root.cern/viewvc?rev=45283&root=root&view=rev) (parts), [#45318](http://root.cern/viewvc?rev=45318&root=root&view=rev), [#45607](http://root.cern/viewvc?rev=45607&root=root&view=rev), [#45610](http://root.cern/viewvc?rev=45610&root=root&view=rev), [#45613](http://root.cern/viewvc?rev=45613&root=root&view=rev), [#45614](http://root.cern/viewvc?rev=45614&root=root&view=rev) (parts), [#45630](http://root.cern/viewvc?rev=45630&root=root&view=rev), [#45632](http://root.cern/viewvc?rev=45632&root=root&view=rev) (parts) and [#45643](http://root.cern/viewvc?rev=45643&root=root&view=rev) fixing several issues:
          - consolidation of username definition in the automatic LOCALDATASERVER setting (by xproofd);
          - fix for TProof::GetUser (Savannah issue #92533)
          - use of LOCALDATASERVER in ProofAux.C, fixing potential failures of stressProof
          - fix for potential segv in the destructors of TPacketizerUnit and TVirtualPacketizer
          - fix issue with merging elements in ProcFileElements which was causing spurious failures in stressProof, test #19
-    *   Import patches [#45568](http://root.cern.ch/viewvc?rev=45568&root=root&view=rev) and [#45597](http://root.cern.ch/viewvc?rev=45597&root=root&view=rev) fixing a few issues in PROOF-Lite.
-    *   Import patches [#45092](http://root.cern.ch/viewvc?rev=45092&root=root&view=rev) and [#45093](http://root.cern.ch/viewvc?rev=45093&root=root&view=rev) adding functions to retrieve environment information from the nodes, typically from the master (datadir or some env settings).
+    *   Import patches [#45568](http://root.cern/viewvc?rev=45568&root=root&view=rev) and [#45597](http://root.cern/viewvc?rev=45597&root=root&view=rev) fixing a few issues in PROOF-Lite.
+    *   Import patches [#45092](http://root.cern/viewvc?rev=45092&root=root&view=rev) and [#45093](http://root.cern/viewvc?rev=45093&root=root&view=rev) adding functions to retrieve environment information from the nodes, typically from the master (datadir or some env settings).
          **Warning:** This change in binary incompatible.
-    *   Import patch [#45181](http://root.cern.ch/viewvc?rev=45181&root=root&view=rev) fixing a crash in xproofd when using security.
+    *   Import patch [#45181](http://root.cern/viewvc?rev=45181&root=root&view=rev) fixing a crash in xproofd when using security.
 *   Graphics
     *   The time axis behavior should now be correct along time zone and summer saving time. A fix has been done with the of Philippe Gras (CEA Saclay. IRFU/SEDI) and Julian Sitarek (IFAE). Time axis transported from a time zone to an other in a ROOT file are correct too. A new example test have been introduced to test the time axis (timeonaxis3.C)
 *   GUI
 
-    *   Prevent the use of a global by TGLabel before it is initialized (revision [#46073](http://root.cern.ch/viewvc?rev=46073&root=root&view=rev)
+    *   Prevent the use of a global by TGLabel before it is initialized (revision [#46073](http://root.cern/viewvc?rev=46073&root=root&view=rev)
 *   EVE
 
     *   Avoid crash in TEveTrack::TEveTrack(TEveMCTrack*) constructor when PDG code is unknown. fCharge is set to 0 in this case.
@@ -1118,7 +1118,7 @@ on top of the merging defaults: kAll | kIncremental (as in the example $ROOTSYS/
     *   Fix setting a second time the nuisance pdf in the ToyMCSampler. This bug affect the HybridCalculator when using different nuisance pdf's for the null and alternate models.
     *   Fix generation of AsymptoticCalculator::GenerateAsimovData  for counting models containing several observables
 *   HistFactory
-    *   Import changes described in revision [45703](http://root.cern.ch/viewvc?view=rev&revision=45703)
+    *   Import changes described in revision [45703](http://root.cern/viewvc?view=rev&revision=45703)
     *   Import changes to have model built without a data tag selected
 *   Hist
     *   Update projection methods to re-set binning on a previously existing histogram ([#94101](https://savannah.cern.ch/bugs/?94101) and [#95808](https://savannah.cern.ch/bugs/?95808))
@@ -1132,7 +1132,7 @@ on top of the merging defaults: kAll | kIncremental (as in the example $ROOTSYS/
 
 *   Core
     *   Avoid risk of executing the tear down routines twice at process termination when -q is used and there is no input file descriptor. (revision 44838).
-    *   Fix linking of qtcint.dll when explicitly linking is required (see [the related forum post](http://root.cern.ch/phpBB3/viewtopic.php?t=14943)).
+    *   Fix linking of qtcint.dll when explicitly linking is required (see [the related forum post](http://root.cern/phpBB3/viewtopic.php?t=14943)).
 *   I/O
     *   Fail gracefully instead of segfaulting on broken files in GetStreamerInfoList (Fixes Savannah [#5439](http://savannah.cern.ch/patch/?5439)).
     *   Avoid seg fault when deleting a reseted TMemFile (revision 44749).
@@ -1143,12 +1143,12 @@ on top of the merging defaults: kAll | kIncremental (as in the example $ROOTSYS/
     *   Fixes issue in TChainIndex that made reading the first entry of the 2nd and subsequent files in the TChain not beeing properly reading when using the index. (Fixes Savannah [#94910](http://savannah.cern.ch/bugs/?94910)).
     *   Avoid an unnecessary flushing of the TTreeCache after the first time it filled (revision 44750)
 *   Proof
-    *   Import patch [#44606](http://root.cern.ch/viewvc?rev=44606&root=root&view=rev) adding support for gcc4.7 in afdsmgrd (version 1.0.3).
-    *   Import patch [#44701](http://root.cern.ch/viewvc?rev=44701&root=root&view=rev) with several important fixes in xproofd. Patch is server side only; only the upgrade of xproofd (or libXrdProofd) are required.
+    *   Import patch [#44606](http://root.cern/viewvc?rev=44606&root=root&view=rev) adding support for gcc4.7 in afdsmgrd (version 1.0.3).
+    *   Import patch [#44701](http://root.cern/viewvc?rev=44701&root=root&view=rev) with several important fixes in xproofd. Patch is server side only; only the upgrade of xproofd (or libXrdProofd) are required.
 *   RooFit
-    *   Fix bug in binned generation of extended pdf (patch [#44630](http://root.cern.ch/viewvc?rev=44630&root=root&view=rev) )
+    *   Fix bug in binned generation of extended pdf (patch [#44630](http://root.cern/viewvc?rev=44630&root=root&view=rev) )
 *   HistFactory
-    *   Fix a problem for pyroot and an issue in creating directory (patch [#44579](http://root.cern.ch/viewvc?view=rev&revision=44579) ).
+    *   Fix a problem for pyroot and an issue in creating directory (patch [#44579](http://root.cern/viewvc?view=rev&revision=44579) ).
 *   Hist
     *   Fix bug in merging histograms and profile when first histogram to merge is empty (bug [#95190](https://savannah.cern.ch/bugs/?95190) and [#94295](https://savannah.cern.ch/bugs/?94295))
     *   Enable TBrowser to access THnSparse with more than 16 axes (r44827).
@@ -1171,11 +1171,11 @@ on top of the merging defaults: kAll | kIncremental (as in the example $ROOTSYS/
 *   Net
     *   Fix in TWebFile reading using https (via TSSLSocket).
 *   IO
-    *   Optimization in TFileMerger for the case where there is only one file to 'merge' (patch [#44533](http://root.cern.ch/viewvc?rev=44533&root=root&view=rev)).
+    *   Optimization in TFileMerger for the case where there is only one file to 'merge' (patch [#44533](http://root.cern/viewvc?rev=44533&root=root&view=rev)).
 *   Proof
-    *   Import patches [#44411](http://root.cern.ch/viewvc?rev=44411&root=root&view=rev) and [#44425](http://root.cern.ch/viewvc?rev=44425&root=root&view=rev) fixing a problem in handling local files in TDataSetManager::ScanFile;
-    *   Import version 1.0.2 of afdsmgrd (patches [#44243](http://root.cern.ch/viewvc?rev=44243&root=root&view=rev), [#44292](http://root.cern.ch/viewvc?rev=44292&root=root&view=rev) and [#44332](http://root.cern.ch/viewvc?rev=44332&root=root&view=rev)) with several important fixes for PEAC and AAFs and the integration in the cmake build
-    *   Import patch [#44397](http://root.cern.ch/viewvc?rev=44397&root=root&view=rev) changing the default merging procedure used histograms to cover correctly all the cases.
+    *   Import patches [#44411](http://root.cern/viewvc?rev=44411&root=root&view=rev) and [#44425](http://root.cern/viewvc?rev=44425&root=root&view=rev) fixing a problem in handling local files in TDataSetManager::ScanFile;
+    *   Import version 1.0.2 of afdsmgrd (patches [#44243](http://root.cern/viewvc?rev=44243&root=root&view=rev), [#44292](http://root.cern/viewvc?rev=44292&root=root&view=rev) and [#44332](http://root.cern/viewvc?rev=44332&root=root&view=rev)) with several important fixes for PEAC and AAFs and the integration in the cmake build
+    *   Import patch [#44397](http://root.cern/viewvc?rev=44397&root=root&view=rev) changing the default merging procedure used histograms to cover correctly all the cases.
     *   Import patches for Coverity-related issues
 *   THtml
     *   Also check for modifications in headers ([bug #94695](https://savannah.cern.ch/bugs/index.php?94695), r44323).

--- a/install/all_releases/root-version-v6-02-00-patch-release-notes.md
+++ b/install/all_releases/root-version-v6-02-00-patch-release-notes.md
@@ -11,7 +11,7 @@ sidebar:
 <div>
 <p>The first release candidate of the new production version ROOT v6-02-00 has been released Sept 25, 2014.</p>
 <p>Get the source from Git using:</p>
-<code>git clone http://root.cern.ch/git/root.git root-v6-02; cd root-v6-02; git checkout -b v6-02-00-patches </code>
+<code>git clone http://root.cern/git/root.git root-v6-02; cd root-v6-02; git checkout -b v6-02-00-patches </code>
 <p>After obtaining the source read the file README/INSTALL (in short just do: cd root; ./configure; make).</p>
 <h2>Note for MaxOsX 10.10 (Yosemite)</h2>
 <p>When installing ROOT from sources the XCode command line tools need to be re-installed with:</p>
@@ -141,7 +141,7 @@ sidebar:
 <ul>
 	<li>Hists
 	<ul>
-		<li>Fix the problem reported <a href="https://root.cern.ch/phpBB3/viewtopic.php?f=3&amp;t=19186" target="_blank">here</a>.</li>
+		<li>Fix the problem reported <a href="https://root.cern/phpBB3/viewtopic.php?f=3&amp;t=19186" target="_blank">here</a>.</li>
 	</ul>
 	</li>
 	<li>Graphics
@@ -299,7 +299,7 @@ sidebar:
 		<li>In some some cases an extra point was drawn when a TGraph2D was drawn with P, P0 or PCOL options.</li>
 		<li>The hollow fill style was not rendered correctly by TTexDump. (<a href="https://sft.its.cern.ch/jira/browse/ROOT-6841" target="_blank">ROOT-6841</a>)</li>
 		<li>It was possible to interactively zoom outside the histograms' limits. Protections have been added.</li>
-		<li>Fix an <a href="https://root.cern.ch/phpBB3/viewtopic.php?f=3&amp;t=18778" target="_blank">issue</a> with E0 option and log scale.</li>
+		<li>Fix an <a href="https://root.cern/phpBB3/viewtopic.php?f=3&amp;t=18778" target="_blank">issue</a> with E0 option and log scale.</li>
 		<li>Better line width matching with screen and pdf output (<a href="https://sft.its.cern.ch/jira/browse/ROOT-6858" target="_blank">ROOT-6858</a>)</li>
 		<li>With the Cocoa backend on Mac, the PDF and PS output produced miss-aligned exponents because the GetTextExtend method behaved differently in batch mode and "screen" mode. This is now fixed.</li>
 		<li>In TTextDump the text color was ignored. It was always black.</li>

--- a/install/build_from_source.md
+++ b/install/build_from_source.md
@@ -120,7 +120,7 @@ For example, from the command line, the standard can be selected by passing one 
 ### ROOT STL backports
 
 ROOT backports certain useful C++ standard library features to make them available in C++11, for example `std::make_unique` and `std::string_view`.
-The backports can be found [here in the reference guide](https://root.cern.ch/doc/master/dir_7780993579c9aa6baf9598fd7cc29d54.html).
+The backports can be found [here in the reference guide](https://root.cern/doc/master/dir_7780993579c9aa6baf9598fd7cc29d54.html).
 The backports are disabled, falling back to the actual C++ standard library implementation if it provides it, depending for instance on the C++ standard ROOT is compiled with and the compiler version.
 
 ## Enabling experimental features, aka ROOT7

--- a/manual/data_frame/index.md
+++ b/manual/data_frame/index.md
@@ -30,7 +30,7 @@ Every `RDataFrame` program follows this workflow:
 
    - [creating custom columns](https://root.cern/doc/master/classROOT_1_1RDataFrame.html#transformations){:target="_blank"}. Custom columns can, for example, contain the results of a computation that must be performed for every row of the data set.
 
-3. [Produce results](https://root.cern/doc/master/classROOT_1_1RDataFrame.html#actions){:target="_blank"}. _Actions_ are used to aggregate data into results. Most actions are _lazy_, i.e. they are not executed on the spot, but registered with `RDataFrame` and executed only when a result is accessed for the first time. The most typical result produced by ROOT analyses is a histogram, but `RDataFrame` supports any kind of data aggregation operation, including [writing out new ROOT files](https://root.cern.ch/doc/master/classROOT_1_1RDF_1_1RInterface.html#a233b7723e498967f4340705d2c4db7f8).
+3. [Produce results](https://root.cern/doc/master/classROOT_1_1RDataFrame.html#actions){:target="_blank"}. _Actions_ are used to aggregate data into results. Most actions are _lazy_, i.e. they are not executed on the spot, but registered with `RDataFrame` and executed only when a result is accessed for the first time. The most typical result produced by ROOT analyses is a histogram, but `RDataFrame` supports any kind of data aggregation operation, including [writing out new ROOT files](https://root.cern/doc/master/classROOT_1_1RDF_1_1RInterface.html#a233b7723e498967f4340705d2c4db7f8).
 
 ## How does it look in code?
 This is a simple cut-and-fill with `RDataFrame`:

--- a/manual/first_steps_with_root/index.md
+++ b/manual/first_steps_with_root/index.md
@@ -349,7 +349,7 @@ The exact kind of quoting depends on the used shell. This example works for bash
 
 ### Compiling ROOT macros
 
-You can use ACLiC (*Compiling Your Code*) to compile your code and build a dictionary and a shared library from your ROOT macro. ACliC is implemented in [TSystem::CompileMacro()](https://root.cern.ch/doc/master/classTSystem.html).
+You can use ACLiC (*Compiling Your Code*) to compile your code and build a dictionary and a shared library from your ROOT macro. ACliC is implemented in [TSystem::CompileMacro()](https://root.cern/doc/master/classTSystem.html).
 
 When using ACliC, ROOT checks what library really needs to be build and calls your system's C++ compiler, linker and dictionary generator. Then ROOT loads a native shared library.
 

--- a/manual/fitting/index.md
+++ b/manual/fitting/index.md
@@ -89,7 +89,7 @@ The `Fit()` method is implemented for:
 
 ### Using TH1::Fit()
 
-- Use the [TH1::Fit()](https://root.cern.ch/doc/master/classTH1.html#a63eb028df86bc86c8e20c989eb23fb2a){:target="_blank"} method to fit a histogram programmatically.<br>By default, the fitted function object is added to the histogram and is drawn in the current pad.
+- Use the [TH1::Fit()](https://root.cern/doc/master/classTH1.html#a63eb028df86bc86c8e20c989eb23fb2a){:target="_blank"} method to fit a histogram programmatically.<br>By default, the fitted function object is added to the histogram and is drawn in the current pad.
 
 The signature is:
 
@@ -144,7 +144,7 @@ In the following section is described how to use the {% include ref class="TF1" 
 
 ### Fitting 1-D histograms with pre-defined functions
 
-- Use the [TH1::Fit()](https://root.cern.ch/doc/master/classTH1.html#a63eb028df86bc86c8e20c989eb23fb2a){:target="_blank"} method to fit a 1-D histogram with a pre-defined function. The name of the pre-definded function is the first parameter. For pre-defined functions, you do not need to set initial values for the parameters.
+- Use the [TH1::Fit()](https://root.cern/doc/master/classTH1.html#a63eb028df86bc86c8e20c989eb23fb2a){:target="_blank"} method to fit a 1-D histogram with a pre-defined function. The name of the pre-definded function is the first parameter. For pre-defined functions, you do not need to set initial values for the parameters.
 
 _**Example**_
 
@@ -171,7 +171,7 @@ The following pre-defined functions are available:
 
 ### Fitting 1-D histograms with user-defined functions
 
-First you create a {% include ref class="TF1" %} object, then use the name of the `TF1` fitting function in the [Fit()](https://root.cern.ch/doc/master/classTH1.html#a63eb028df86bc86c8e20c989eb23fb2a){:target="_blank"} method.
+First you create a {% include ref class="TF1" %} object, then use the name of the `TF1` fitting function in the [Fit()](https://root.cern/doc/master/classTH1.html#a63eb028df86bc86c8e20c989eb23fb2a){:target="_blank"} method.
 
 You can create the `TF1` fitting function as follows:
 
@@ -343,7 +343,7 @@ There is function with 6 parameters. Then there is a setup possible like the fol
 <p><a name="fitting-subranges"></a></p>
 **Fitting subranges**
 
-By default, [TH1::Fit()](https://root.cern.ch/doc/master/classTH1.html#a63eb028df86bc86c8e20c989eb23fb2a){:target="_blank"} fits the function on the defined histogram range. You can specify the `R` option in the second
+By default, [TH1::Fit()](https://root.cern/doc/master/classTH1.html#a63eb028df86bc86c8e20c989eb23fb2a){:target="_blank"} fits the function on the defined histogram range. You can specify the `R` option in the second
 parameter of `TH1::Fit()` to restrict the fit to the range specified in the {% include ref class="TF1" %} constructor.
 
 _**Example**_
@@ -427,7 +427,7 @@ You can obtain the following results of a fit:
 **Associated function**
 
 One or more objects (typically a `TF1\*`) can be added to the list of functions (`fFunctions`) associated to each histogram.
-[TH1::Fit()](https://root.cern.ch/doc/master/classTH1.html#a63eb028df86bc86c8e20c989eb23fb2a){:target="_blank"} adds the fitted function to this list.
+[TH1::Fit()](https://root.cern/doc/master/classTH1.html#a63eb028df86bc86c8e20c989eb23fb2a){:target="_blank"} adds the fitted function to this list.
 
 Given a histogram `h`, you can retrieve the associated function with:
 

--- a/manual/python/index.md
+++ b/manual/python/index.md
@@ -269,7 +269,7 @@ if __name__ == '__main__':
 in [ROOT-10789](https://sft.its.cern.ch/jira/browse/ROOT-10789) and
 [ROOT-10582](https://sft.its.cern.ch/jira/browse/ROOT-10582).
 This affects the creation of GUIs from Python, e.g. in the
-[Python GUI tutorial](https://root.cern.ch/doc/master/gui__ex_8py.html), where the inheritance
+[Python GUI tutorial](https://root.cern/doc/master/gui__ex_8py.html), where the inheritance
 from `TGMainFrame` is not working at the moment. Future releases of ROOT will fix these
 issues and provide a way to program GUIs from Python, including a replacement for TPyDispatcher,
 which is no longer provided.

--- a/manual/storing_root_objects/index.md
+++ b/manual/storing_root_objects/index.md
@@ -503,15 +503,15 @@ Simple session:
 {% highlight C++ %}
 root[] TFile *f1 = TFile::Open("local/file.root","update")
 root[] TFile *f2 = TFile::Open("root://my.server.org/data/file.root","new")
-root[] TFile *f3 = TFile::Open("https://root.cern.ch/files/hsimple.root")
+root[] TFile *f3 = TFile::Open("https://root.cern/files/hsimple.root")
 {% endhighlight %}
 
 `ls ()` lists what is in the ROOT file.
 
 {% highlight C++ %}
 root[] f3.ls()
-TDavixFile**    https://root.cern.ch/files/hsimple.root
- TDavixFile*    https://root.cern.ch/files/hsimple.root
+TDavixFile**    https://root.cern/files/hsimple.root
+ TDavixFile*    https://root.cern/files/hsimple.root
   KEY: TH1F     hpx;1 This is the px distribution
   KEY: TH2F     hpxpy;1 py vs px
   KEY: TProfile hprof;1 Profile of pz versus px

--- a/news/publications.md
+++ b/news/publications.md
@@ -9,7 +9,7 @@ sidebar:
 
 *   Rene Brun and Fons Rademakers,
      _ROOT - An Object Oriented Data Analysis Framework_,
-     Proceedings AIHENP'96 Workshop, Lausanne, Sep. 1996, Nucl. Inst. & Meth. in Phys. Res. A 389 (1997) 81-86\. See also https://root.cern.ch/
+     Proceedings AIHENP'96 Workshop, Lausanne, Sep. 1996, Nucl. Inst. & Meth. in Phys. Res. A 389 (1997) 81-86\. See also https://root.cern/
 
 
 **The most recent overview paper on ROOT**
@@ -21,22 +21,22 @@ sidebar:
 **A (mostly historically interesting) list of ROOT talks and publications**
 
 *   Paper presented at the AIHENP conference in Laussanne 1996.
-     [ROOT - An Object Oriented Data Analysis Framework](https://root.cern.ch/download/laussanne.ps.gz)
+     [ROOT - An Object Oriented Data Analysis Framework](https://root.cern/download/laussanne.ps.gz)
 *   Slides of the presentation at CHEP'97 conference in Berlin.
-     [ROOT - An Interactive Object Oriented Framework and its application to NA49 data analysis](https://root.cern.ch/download//chep97_slides.tar.gz)
+     [ROOT - An Interactive Object Oriented Framework and its application to NA49 data analysis](https://root.cern/download//chep97_slides.tar.gz)
 *   Paper presented at the CHEP'97 conference in Berlin.
-     [ROOT - An Interactive Object Oriented Framework and its application to NA49 data analysis](https://root.cern.ch/download//chep97.ps.gz)
+     [ROOT - An Interactive Object Oriented Framework and its application to NA49 data analysis](https://root.cern/download//chep97.ps.gz)
 *   Paper published in "Interface Magazine" (Japanese Engineering Magazine).
-     [The Power of Object Oriented Frameworks](https://root.cern.ch/download//frameworks.ps.gz)
+     [The Power of Object Oriented Frameworks](https://root.cern/download//frameworks.ps.gz)
 *   Slides used in various presentations of the ROOT system.
-     This is a [compressed tar file](https://root.cern.ch/download/seminar.tar.gz) including a README file and about 40 Postscript files.
+     This is a [compressed tar file](https://root.cern/download/seminar.tar.gz) including a README file and about 40 Postscript files.
 *   First three parts of a ROOT course.
-     [Part1](https://root.cern.ch/download//course1.ps.gz), [part2](https://root.cern.ch/download/course2.ps.gz) and [part3](https://root.cern.ch/download/course3.ps.gz) (the course is not finished yet and part 3 ends quite abruptly).
+     [Part1](https://root.cern/download//course1.ps.gz), [part2](https://root.cern/download/course2.ps.gz) and [part3](https://root.cern/download/course3.ps.gz) (the course is not finished yet and part 3 ends quite abruptly).
 *   First comparison between ROOT, Objectivity/DB and LHC++ histOOgrams.
-     [Paper](https://root.cern.ch/download/oobench.ps.gz) and [full source](https://root.cern.ch/download/oobenchsrc.tar.gz) of used test programs.
+     [Paper](https://root.cern/download/oobench.ps.gz) and [full source](https://root.cern/download/oobenchsrc.tar.gz) of used test programs.
 *   Papers presented at HEPVis'98 at SLAC from Jan 28-30, 1998.
 *   Paper published in the Linux Journal, Issue 51, July 1998.
-     [ROOT: An Object-Oriented Data Analysis Framework.](https://root.cern.ch/download/lj.ps.gz)
+     [ROOT: An Object-Oriented Data Analysis Framework.](https://root.cern/download/lj.ps.gz)
 *   Computer Physics Communications; Anniversary Issue; Volume 180, Issue 12, December 2009, Pages 2499-2512.
      [ROOT — A C++ framework for petabyte data storage, statistical analysis and visualization.](https://www.sciencedirect.com/science/article/pii/S0010465509002550?via%3Dihub)
 

--- a/news/workshops.md
+++ b/news/workshops.md
@@ -10,12 +10,12 @@ sidebar:
 *   [ROOT 2018](https://cern.ch/root2018){:target="_blank"}
 *   [ROOT 2015]({{'/news/workshop_2015' | relative_url}}){:target="_blank"}
 *   [ROOT 2013]({{'/news/workshop_2013' | relative_url}}) ([slides](https://indico.cern.ch/conferenceDisplay.py?confId=217511){:target="_blank"})
-*   [ROOT 2007](https://root.cern.ch/root/R2007/Welcome.html){:target="_blank"} ([slides](https://indico.cern.ch/conferenceOtherViews.py?view=standard&confId=13356){:target="_blank"})
-*   [ROOT 2005](https://root.cern.ch/root/R2005/Welcome.html){:target="_blank"} ([slides](https://indico.cern.ch/conferenceDisplay.py?confId=a055638){:target="_blank"})
+*   [ROOT 2007](https://root.cern/root/R2007/Welcome.html){:target="_blank"} ([slides](https://indico.cern.ch/conferenceOtherViews.py?view=standard&confId=13356){:target="_blank"})
+*   [ROOT 2005](https://root.cern/root/R2005/Welcome.html){:target="_blank"} ([slides](https://indico.cern.ch/conferenceDisplay.py?confId=a055638){:target="_blank"})
 *   [ROOT 2004](https://inspirehep.net/conferences/975993){:target="_blank"}
-*   [ROOT 2002](https://root.cern.ch/root/R2002/Welcome.html){:target="_blank"} ([slides](https://root.cern.ch/root/R2002/Program.html){:target="_blank"})
+*   [ROOT 2002](https://root.cern/root/R2002/Welcome.html){:target="_blank"} ([slides](https://root.cern/root/R2002/Program.html){:target="_blank"})
 *   [ROOT 2001](https://www-root.fnal.gov/root2001/){:target="_blank"} ([slides](https://www-root.fnal.gov/root2001/R2001Program.html){:target="_blank"})
-*   [ROOT 2000](https://root.cern.ch/root/R2000/Welcome.html){:target="_blank"} ([slides](https://root.cern.ch/root/R2000/Program.html){:target="_blank"})
+*   [ROOT 2000](https://root.cern/root/R2000/Welcome.html){:target="_blank"} ([slides](https://root.cern/root/R2000/Program.html){:target="_blank"})
 *   ROOT 1999
 
 

--- a/primer/index.md
+++ b/primer/index.md
@@ -2781,7 +2781,7 @@ transparently used in Python!# Concluding Remarks
 This is the end of our guided tour for beginners through ROOT. There is
 still a lot coming to mind to be said, but by now you are experienced
 enough to use the ROOT documentation, most importantly the **[ROOT home
-page](https://root.cern.ch){:target="_blank"}** and the **[ROOT reference
+page](https://root.cern){:target="_blank"}** and the **[ROOT reference
 guide](https://root.cern/doc/master/){:target="_blank"}** with the
 documentation of all ROOT classes.
 

--- a/topical/index.md
+++ b/topical/index.md
@@ -15,29 +15,29 @@ This page lists all the manuals related to packages used by or close to the ROOT
 The RooFit library provides a toolkit for modeling the expected distribution of events in
 a physics analysis.
 
-  - [RooFit Manual (PDF A4 format)](https://root.cern.ch/download/doc/RooFit_Users_Manual_2.91-33.pdf){:target="_blank"}
-  - [RooFit Quick Start Guide (PDF A4 format)](https://root.cern.ch/download/doc/roofit_quickstart_3.00.pdf){:target="_blank"}
+  - [RooFit Manual (PDF A4 format)](https://root.cern/download/doc/RooFit_Users_Manual_2.91-33.pdf){:target="_blank"}
+  - [RooFit Quick Start Guide (PDF A4 format)](https://root.cern/download/doc/roofit_quickstart_3.00.pdf){:target="_blank"}
 
 ## HTTP Server
 
 The idea of THttpServer is to provide remote http access to running ROOT application and
 enable HTML/JavaScript user interface. Download it
-[here](https://root.cern.ch/root/htmldoc/guides/HttpServer/HttpServer.html){:target="_blank"}.
+[here](https://root.cern/root/htmldoc/guides/HttpServer/HttpServer.html){:target="_blank"}.
 
 
 ### HttpServer manual: 6 Release Cycle
 
-  - [HttpServer manual (PDF A4 format)](https://root.cern.ch/root/htmldoc/guides/HttpServer/HttpServer.pdf){:target="_blank"}
-  - [HttpServer manual (PDF Letter format)](https://root.cern.ch/root/htmldoc/guides/HttpServer/HttpServerLetter.pdf){:target="_blank"}
-  - [HttpServer manual (HTML version)](https://root.cern.ch/root/htmldoc/guides/HttpServer/HttpServer.html){:target="_blank"}
-  - [HttpServer manual (epub version for iPad and iPhone)](https://root.cern.ch/root/htmldoc/guides/HttpServer/HttpServer.epub){:target="_blank"}
+  - [HttpServer manual (PDF A4 format)](https://root.cern/root/htmldoc/guides/HttpServer/HttpServer.pdf){:target="_blank"}
+  - [HttpServer manual (PDF Letter format)](https://root.cern/root/htmldoc/guides/HttpServer/HttpServerLetter.pdf){:target="_blank"}
+  - [HttpServer manual (HTML version)](https://root.cern/root/htmldoc/guides/HttpServer/HttpServer.html){:target="_blank"}
+  - [HttpServer manual (epub version for iPad and iPhone)](https://root.cern/root/htmldoc/guides/HttpServer/HttpServer.epub){:target="_blank"}
 
 ### HttpServer manual (5.34)
 
-  - [HttpServer manual (PDF A4 format)](https://root.cern.ch/root/html534/guides/HttpServer/HttpServer.pdf){:target="_blank"}
-  - [HttpServer manual (PDF Letter format)](https://root.cern.ch/root/html534/guides/HttpServer/HttpServerLetter.pdf){:target="_blank"}
-  - [HttpServer manual (HTML version)](https://root.cern.ch/root/html534/guides/HttpServer/HttpServer.html){:target="_blank"}
-  - [HttpServer manual (epub version for iPad and iPhone)](https://root.cern.ch/root/html534/guides/HttpServer/HttpServer.epub){:target="_blank"}
+  - [HttpServer manual (PDF A4 format)](https://root.cern/root/html534/guides/HttpServer/HttpServer.pdf){:target="_blank"}
+  - [HttpServer manual (PDF Letter format)](https://root.cern/root/html534/guides/HttpServer/HttpServerLetter.pdf){:target="_blank"}
+  - [HttpServer manual (HTML version)](https://root.cern/root/html534/guides/HttpServer/HttpServer.html){:target="_blank"}
+  - [HttpServer manual (epub version for iPad and iPhone)](https://root.cern/root/html534/guides/HttpServer/HttpServer.epub){:target="_blank"}
 
 
 ## JSROOT
@@ -45,7 +45,7 @@ enable HTML/JavaScript user interface. Download it
 The JSROOT project intends to implement ROOT graphics for web browsers. Reading of binary
 ROOT files is supported.
 
-  - [6 series (html)](https://root.cern.ch/root/htmldoc/guides/HttpServer/HttpServer.html){:target="_blank"}
+  - [6 series (html)](https://root.cern/root/htmldoc/guides/HttpServer/HttpServer.html){:target="_blank"}
   - [Documentation on the GitHub repository](https://github.com/root-project/jsroot/blob/master/docs/JSROOT.md){:target="_blank"}
 
 ## CERNLib
@@ -53,7 +53,7 @@ ROOT files is supported.
 The CERN Program Library was a large collection of general-purpose programs written in
 FORTRAN. It is deprecated for many years but many algorithms it implemented at that time
 were back-ported to ROOT. That's why
-[a link to the pdf version of the CERNLib manual](https://root.cern.ch/sites/d35c7d8c.web.cern.ch/files/cernlib.pdf){:target="_blank"}
+[a link to the pdf version of the CERNLib manual](https://root.cern/sites/d35c7d8c.web.cern.ch/files/cernlib.pdf){:target="_blank"}
 is kept here.
 
 ## Minuit
@@ -61,53 +61,53 @@ is kept here.
 Minuit was a FORTRAN package conceived as a tool to find the minimum value of a multi-parameter
 function and analyze the shape of the function around the minimum. It was translated in
 C++ in the {% include ref class="TMinuit"%} class.
-[A link to the pdf version of the Minuit manual](https://root.cern.ch/sites/d35c7d8c.web.cern.ch/files/minuit.pdf){:target="_blank"}
+[A link to the pdf version of the Minuit manual](https://root.cern/sites/d35c7d8c.web.cern.ch/files/minuit.pdf){:target="_blank"}
 is kept here.
 
 ## Minuit 2
 
 Minuit2 is a tool to find the minimum value of a multi-parameter function. Download the
-manual [here](https://root.cern.ch/root/htmldoc/guides/minuit2/Minuit2.html){:target="_blank"}.
+manual [here](https://root.cern/root/htmldoc/guides/minuit2/Minuit2.html){:target="_blank"}.
 
 ### Minuit2 manual: 6 Release Series
 
-  - [Minuit2 manual (PDF A4 format)](https://root.cern.ch/root/htmldoc/guides/minuit2/Minuit2.pdf){:target="_blank"}
-  - [Minuit2 manual (PDF Letter format)](https://root.cern.ch/root/htmldoc/guides/minuit2/Minuit2Letter.pdf){:target="_blank"}
-  - [Minuit2 manual (HTML version)](https://root.cern.ch/root/htmldoc/guides/minuit2/Minuit2.html){:target="_blank"}
-  - [Minuit2 manual (epub version for iPad and iPhone)](https://root.cern.ch/root/htmldoc/guides/minuit2/Minuit2.epub){:target="_blank"}
+  - [Minuit2 manual (PDF A4 format)](https://root.cern/root/htmldoc/guides/minuit2/Minuit2.pdf){:target="_blank"}
+  - [Minuit2 manual (PDF Letter format)](https://root.cern/root/htmldoc/guides/minuit2/Minuit2Letter.pdf){:target="_blank"}
+  - [Minuit2 manual (HTML version)](https://root.cern/root/htmldoc/guides/minuit2/Minuit2.html){:target="_blank"}
+  - [Minuit2 manual (epub version for iPad and iPhone)](https://root.cern/root/htmldoc/guides/minuit2/Minuit2.epub){:target="_blank"}
 
 ### Minuit2 manual (5.34)
 
-  - [Minuit2 manual (PDF A4 format)](https://root.cern.ch/root/html534/guides/minuit2/Minuit2.pdf){:target="_blank"}
-  - [Minuit2 manual (PDF Letter format)](https://root.cern.ch/root/html534/guides/minuit2/Minuit2Letter.pdf){:target="_blank"}
-  - [Minuit2 manual (HTML version)](https://root.cern.ch/root/html534/guides/minuit2/Minuit2.html){:target="_blank"}
-  - [Minuit2 manual (epub version for iPad and iPhone)](https://root.cern.ch/root/html534/guides/minuit2/Minuit2.epub){:target="_blank"}
+  - [Minuit2 manual (PDF A4 format)](https://root.cern/root/html534/guides/minuit2/Minuit2.pdf){:target="_blank"}
+  - [Minuit2 manual (PDF Letter format)](https://root.cern/root/html534/guides/minuit2/Minuit2Letter.pdf){:target="_blank"}
+  - [Minuit2 manual (HTML version)](https://root.cern/root/html534/guides/minuit2/Minuit2.html){:target="_blank"}
+  - [Minuit2 manual (epub version for iPad and iPhone)](https://root.cern/root/html534/guides/minuit2/Minuit2.epub){:target="_blank"}
 
 ## TSpectrum
 
 {% include ref class="TSpectrum" %} is a class providing processing and visualization functions:
-consult its manual [here](https://root.cern.ch/root/htmldoc/guides/spectrum/Spectrum.html){:target="_blank"}.
+consult its manual [here](https://root.cern/root/htmldoc/guides/spectrum/Spectrum.html){:target="_blank"}.
 
 ### TSpectrum manual: 6 Release Cycle
 
-  - [TSpectrum manual (PDF A4 format)](https://root.cern.ch/root/htmldoc/guides/spectrum/Spectrum.pdf){:target="_blank"}
-  - [TSpectrum manual (PDF Letter format)](https://root.cern.ch/root/htmldoc/guides/spectrum/SpectrumLetter.pdf){:target="_blank"}
-  - [TSpectrum manual (HTML version)](https://root.cern.ch/root/htmldoc/guides/spectrum/Spectrum.html){:target="_blank"}
-  - [TSpectrum manual (epub version for iPad and iPhone)](https://root.cern.ch/root/htmldoc/guides/spectrum/Spectrum.epub){:target="_blank"}
+  - [TSpectrum manual (PDF A4 format)](https://root.cern/root/htmldoc/guides/spectrum/Spectrum.pdf){:target="_blank"}
+  - [TSpectrum manual (PDF Letter format)](https://root.cern/root/htmldoc/guides/spectrum/SpectrumLetter.pdf){:target="_blank"}
+  - [TSpectrum manual (HTML version)](https://root.cern/root/htmldoc/guides/spectrum/Spectrum.html){:target="_blank"}
+  - [TSpectrum manual (epub version for iPad and iPhone)](https://root.cern/root/htmldoc/guides/spectrum/Spectrum.epub){:target="_blank"}
 
 ### TSpectrum manual (5.34)
 
-  - [TSpectrum manual (PDF A4 format)](https://root.cern.ch/root/html534/guides/spectrum/Spectrum.pdf){:target="_blank"}
-  - [TSpectrum manual (PDF Letter format)](https://root.cern.ch/root/html534/guides/spectrum/SpectrumLetter.pdf){:target="_blank"}
-  - [TSpectrum manual (HTML version)](https://root.cern.ch/root/html534/guides/spectrum/Spectrum.html){:target="_blank"}
-  - [TSpectrum manual (epub version for iPad and iPhone)](https://root.cern.ch/root/html534/guides/spectrum/Spectrum.epub){:target="_blank"}
+  - [TSpectrum manual (PDF A4 format)](https://root.cern/root/html534/guides/spectrum/Spectrum.pdf){:target="_blank"}
+  - [TSpectrum manual (PDF Letter format)](https://root.cern/root/html534/guides/spectrum/SpectrumLetter.pdf){:target="_blank"}
+  - [TSpectrum manual (HTML version)](https://root.cern/root/html534/guides/spectrum/Spectrum.html){:target="_blank"}
+  - [TSpectrum manual (epub version for iPad and iPhone)](https://root.cern/root/html534/guides/spectrum/Spectrum.epub){:target="_blank"}
 
 
 ## TMVA
 
 TMVA is a toolkit for Multivariate Data Analysis.
 
-  - [6 Series (pdf)](https://root.cern.ch/download/doc/tmva/TMVAUsersGuide.pdf){:target="_blank"}.
+  - [6 Series (pdf)](https://root.cern/download/doc/tmva/TMVAUsersGuide.pdf){:target="_blank"}.
   - [Documentation on the GitHub repository](https://github.com/root-project/root/blob/master/documentation/tmva/UsersGuide/TMVAUsersGuide.pdf){:target="_blank"} (Updated version for ROOT 6).
 
 ## VMC


### PR DESCRIPTION
Addresses the third bullet point in #103 .