### PR TITLE
Change lcginfo link from HTTPS to HTTP

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -33,9 +33,10 @@ jobs:
           # - lcgapp-services.cern.ch: Breaks due to SSO
           # - indico.desy.de: Returns frequently error code 403
           # - nbviewer: When notebook generation fails, nbviewer returns 404 errors, and errors might even be cached in CDNs for a while
+          # - lcginfo.cern.ch: does not support HTTPS, see https://sft.its.cern.ch/jira/browse/SPI-1672
           # Reasons for file-ignore
           # - Broken links in historic ROOT v5 release notes
-          arguments:  --empty-alt-ignore --file-ignore "/.*root-version-v5.*/" --allow-hash-href --url-ignore "/(https://ph-root-2.cern.ch/.*|https://rootbnch-grafana-test.cern.ch|https://lcgapp-services.cern.ch/root-jenkins|https://indico.desy.de.*|https://nbviewer.jupyter.org)/" --only-4xx --http-status-ignore "429" --enforce-https --check-favicon --url_swap '^/doc/:https\://root.cern/doc/,^/d/:https\://root.cern/d/,^/files/:https\://root.cern/files/,^/download/:https\://root.cern/download/,^/js/:https\://root.cern/js/,^/TaligentDocs/:https\://root.cern/TaligentDocs/,^/root/:https\://root.cern/root/'
+          arguments:  --empty-alt-ignore --file-ignore "/.*root-version-v5.*/" --allow-hash-href --url-ignore "/(https://ph-root-2.cern.ch/.*|https://rootbnch-grafana-test.cern.ch|https://lcgapp-services.cern.ch/root-jenkins|https://indico.desy.de.*|https://nbviewer.jupyter.org|http://lcginfo.cern.ch)/" --only-4xx --http-status-ignore "429" --enforce-https --check-favicon --url_swap '^/doc/:https\://root.cern/doc/,^/d/:https\://root.cern/d/,^/files/:https\://root.cern/files/,^/download/:https\://root.cern/download/,^/js/:https\://root.cern/js/,^/TaligentDocs/:https\://root.cern/TaligentDocs/,^/root/:https\://root.cern/root/'
 
       - name: Only allow links to root.cern, never root.cern.ch
         run: |

--- a/install/index.md
+++ b/install/index.md
@@ -128,7 +128,7 @@ $ sudo port install root6
 ## Pre-built ROOT without dependencies
 
 If your platform mounts [CVMFS](https://cernvm.cern.ch/portal/filesystem){:target="\_blank"} (as, for example, CERN LXPLUS does),
-ROOT is directly available as an [LCG release](https://lcginfo.cern.ch/){:target="\_blank"}.
+ROOT is directly available as an [LCG release](http://lcginfo.cern.ch/){:target="\_blank"}.
 
 ROOT installations with minimal external dependencies are available for Fedora, Ubuntu, CentOS 7 and MacOS at:
 


### PR DESCRIPTION
lcginfo.cern.ch does not support HTTPS, see
https://sft.its.cern.ch/jira/browse/SPI-1672