### PR TITLE
Put back the list of all reference guides

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -83,6 +83,8 @@ manual:
         target: _blank
       - title: "Primer"
         url: primer/
+      - title: "All Reference Guides"
+        url: reference/
       - title: "Topical Manuals"
         url: topical/
       - title: "Forum & Help"

--- a/reference/index.md
+++ b/reference/index.md
@@ -1,0 +1,36 @@
+---
+title: All Reference Guides
+layout: single
+sidebar:
+  nav: "manual"
+---
+
+The Reference Guide is available for all major ROOT releases.
+This page gives the list of all the past versions.
+
+
+| ROOT Version           | HTML link                                                                  | Download link                                                           | Link to the Tag file (*)                                            |
+|------------------------|----------------------------------------------------------------------------|------------------------------------------------------------------------ |---------------------------------------------------------------------|
+| HEAD of the git master | [browse](https://root.cern/doc/master/){:target="_blank"}                  |                                                                         | [tag file](https://root.cern/doc/master/ROOT.tag){:target="_blank"} |
+| 6.22                   | [browse](https://root.cern/doc/v622/){:target="_blank"}                    | [download](https://root.cern/download/html622.tar.gz){:target="_blank"} | [tag file](https://root.cern/doc/v622/ROOT.tag){:target="_blank"}   |
+| 6.20                   | [browse](https://root.cern/doc/v620/){:target="_blank"}                    | [download](https://root.cern/download/html620.tar.gz){:target="_blank"} | [tag file](https://root.cern/doc/v620/ROOT.tag){:target="_blank"}   |
+| 6.18                   | [browse](https://root.cern/doc/v618/){:target="_blank"}                    | [download](https://root.cern/download/html618.tar.gz){:target="_blank"} | [tag file](https://root.cern/doc/v618/ROOT.tag){:target="_blank"}   |
+| 6.16                   | [browse](https://root.cern/doc/v616/){:target="_blank"}                    | [download](https://root.cern/download/html616.tar.gz){:target="_blank"} | [tag file](https://root.cern/doc/v616/ROOT.tag){:target="_blank"}   |
+| 6.14                   | [browse](https://root.cern/doc/v614/){:target="_blank"}                    | [download](https://root.cern/download/html614.tar.gz){:target="_blank"} | [tag file](https://root.cern/doc/v614/ROOT.tag){:target="_blank"}   |
+| 6.12                   | [browse](https://root.cern/doc/v612/){:target="_blank"}                    | [download](https://root.cern/download/html612.tar.gz){:target="_blank"} | [tag file](https://root.cern/doc/v612/ROOT.tag){:target="_blank"}   |
+| 6.10                   | [browse](https://root.cern/doc/v610/){:target="_blank"}                    | [download](https://root.cern/download/html610.tar.gz){:target="_blank"} | [tag file](https://root.cern/doc/v610/ROOT.tag){:target="_blank"}   |
+| 6.08                   | [browse](https://root.cern/doc/v608/){:target="_blank"}                    | [download](https://root.cern/download/html608.tar.gz){:target="_blank"} | [tag file](https://root.cern/doc/v608/ROOT.tag){:target="_blank"}   |
+| 6.06                   | [browse](https://root.cern/root/html606/){:target="_blank"}                | [download](https://root.cern/download/html606.tar.gz){:target="_blank"} | [tag file](https://root.cern/doc/v606/ROOT.tag){:target="_blank"}   |
+| 6.04                   | [browse](https://root.cern/root/html604/ClassIndex.html){:target="_blank"} | [download](https://root.cern/download/html604.tar.gz){:target="_blank"} |
+| 6.02                   | [browse](https://root.cern/root/html602/ClassIndex.html){:target="_blank"} | [download](https://root.cern/download/html602.tar.gz){:target="_blank"} |
+| 5.34                   | [browse](https://root.cern/root/html534/ClassIndex.html){:target="_blank"} | [download](https://root.cern/download/html534.tar.gz){:target="_blank"} |
+| 5.32                   | [browse](https://root.cern/root/html532/ClassIndex.html){:target="_blank"} | [download](https://root.cern/download/html532.tar.gz){:target="_blank"} |
+| 5.30                   | [browse](https://root.cern/root/html530/ClassIndex.html){:target="_blank"} | [download](https://root.cern/download/html530.tar.gz){:target="_blank"} |
+| 5.28                   | [browse](https://root.cern/root/html528/ClassIndex.html){:target="_blank"} | [download](https://root.cern/download/html528.tar.gz){:target="_blank"} |
+| 5.26                   | [browse](https://root.cern/root/html526/ClassIndex.html){:target="_blank"} | [download](https://root.cern/download/html526.tar.gz){:target="_blank"} |
+| 5.24                   | [browse](https://root.cern/root/html524/ClassIndex.html){:target="_blank"} | [download](https://root.cern/download/html524.tar.gz){:target="_blank"} |
+
+
+If your project documentation is done via Doxygen and it depends on ROOT, you may want to
+link your project documentation to the ROOT reference guide. This can be done using ROOT
+tag file produced by [Doxygen](https://www.doxygen.nl){:target="_blank"}.


### PR DESCRIPTION
Put back the list of all reference guides under "further information" in the Manual section.

having this list is important to:

 1. give access to old reference guides (5.xx)
 2. give access to doxygen tag files.