### PR TITLE
[Tutorials] Change looks of tutorial links.

### DIFF
--- a/_includes/tutorials
+++ b/_includes/tutorials
@@ -1,11 +1,9 @@
 {% assign name = {{include.name}}  %}
 {% assign url  = {{include.url}}  %}
 
-<center>
-<a href="https://root.cern/doc/master/group__tutorial__{{url}}.html" target="_blank">
-<img width="128" src="{{'/assets/images/tutorials.png' | relative_url}}">
-<font color="#346295" style="font-weight:bold" size="3">
-<br>{{name}} tutorials
+<font style="font-weight:bold" size="4">
+  <a href="https://root.cern/doc/master/group__tutorial__{{url}}.html" target="_blank">
+    <img style="width:auto; height:2em;" src="{{'/assets/images/tutorials.png' | relative_url}}">
+    <font color="#346295"> &rarr; {{name}} tutorials </font>
+  </a>
 </font>
-</a>
-</center>


### PR DESCRIPTION
Both Lorenzo and me overlooked the links to the tutorials, because they
are too big. This makes them look less like an icon, and more like a
link.

Old | New
----|-----
![image](https://user-images.githubusercontent.com/16205615/88415800-61c62c80-cddf-11ea-92b4-f5a456753155.png) | ![image](https://user-images.githubusercontent.com/16205615/88415769-5410a700-cddf-11ea-80ee-0a7574a29f42.png)
