### PR TITLE
merge releases and blog side bar

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -159,12 +159,6 @@ for_developers:
      url: https://root.cern/img/logos/ROOT_Logo/
      target: _blank
 
-releases:
-   - title: Useful links
-     children:
-      - title: All releases
-        url: install/all_releases
-
 install:
    - title: Useful links
      children:
@@ -175,13 +169,17 @@ install:
       - title: Building from source
         url: install/build_from_source
 
-blog:
-   - title: Blog Posts
-     url: blog
-   - title: Workshops
-     url: blog/workshops
-   - title: Publications
-     url: blog/publications
+releases:
+   - title: Useful links
+     children:
+      - title: Blog Posts
+        url: blog
+      - title: All releases
+        url: install/all_releases
+      - title: Workshops
+        url: blog/workshops
+      - title: Publications
+        url: blog/publications
 
 contribute:
    - title: How To Contribute

--- a/blog/index.html
+++ b/blog/index.html
@@ -2,6 +2,6 @@
 layout: posts
 title: Blog Posts
 sidebar:
-  nav: "blog"
+  nav: "releases"
 ---
 

--- a/blog/publications.md
+++ b/blog/publications.md
@@ -2,7 +2,7 @@
 title: Publications
 layout: single
 sidebar:
-  nav: "blog"
+  nav: "releases"
 ---
 
 **In case you want to cite ROOT in your own publications, this is the preferred reference**

--- a/blog/workshop_2013.md
+++ b/blog/workshop_2013.md
@@ -2,7 +2,7 @@
 title: ROOT Users Workshop 2013, 11 - 14 March, Saas-Fee
 layout: single
 sidebar:
-  nav: "blog"
+  nav: "releases"
 ---
 
 <div class="content">

--- a/blog/workshop_2015.md
+++ b/blog/workshop_2015.md
@@ -2,7 +2,7 @@
 title: ROOT Users' Workshop 2015
 layout: single
 sidebar:
-  nav: "blog"
+  nav: "releases"
 ---
 
 <h3>ROOT Anniversary Workshop</h3>

--- a/blog/workshops.md
+++ b/blog/workshops.md
@@ -2,7 +2,7 @@
 title: Workshops
 layout: single
 sidebar:
-  nav: "blog"
+  nav: "releases"
 ---
 
 ### Here the list with ROOT workshops:


### PR DESCRIPTION
The releases side bar had only one entry. 
This PR merge it with the blog side which can be also consider as "Useful links" when people
are looking for new about ROOT. This is an attempt to answer this issue: https://github.com/root-project/web/issues/34