### PR TITLE
missing dash

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -86,7 +86,7 @@ manual:
         url: reference/
       - title: "Topical Manuals"
         url: topical/
-        title: "How-tos"
+      - title: "How-tos"
         url: https://root-forum.cern.ch/c/howto/
       - title: "Forum & Help"
         url: https://root-forum.cern.ch/


### PR DESCRIPTION
This missing dash made the item "topical manual" disappeared (thanks Johannes to have see it)