### PR TITLE
Add the namespace parameter to the ref macro

### DIFF
--- a/_includes/ref
+++ b/_includes/ref
@@ -1,1 +1,2 @@
-<a href="https://root.cern/doc/master/class{% if include.link %}{{include.link}}{% else %}{{include.class}}{% endif %}.html" target="_blank">{{include.class}}</a>
+{% assign c = {{include.class}}  %}{% assign n = {{include.namespace}}  %}{% capture ns %}{{ n | size }}{% endcapture %}
+{% if ns == "0" %}<a href="https://root.cern/doc/master/class{{c}}.html" target="_blank">{{c}}</a>{% else %}<a href="https://root.cern/doc/master/class{{n}}_1_1{{c}}.html" target="_blank">{{c}}</a>{% endif %}

--- a/manual/thread_safety/index.md
+++ b/manual/thread_safety/index.md
@@ -3,8 +3,6 @@ title: Thread safety
 layout: single
 sidebar:
   nav: "manual"
-toc: true
-toc_sticky: true
 ---
 
 ROOT classes support one of the following thread safety levels:
@@ -21,7 +19,7 @@ You can freely use instances of _different_ conditionally safe types concurrentl
 In multi-threaded applications, you should call `ROOT::EnableThreadSafety()`.
 Otherwise you need to consider ROOT objects as being thread unsafe.
 
-With `ROOT::EnableThreadSafety()`, types whose names starts with `R` (e.g. [RDataFrame](https://root.cern/doc/master/classROOT_1_1RDataFrame.html)) generally are conditionally thread safe.
+With `ROOT::EnableThreadSafety()`, types whose names starts with `R` (e.g. {% include ref class="RDataFrame" namespace="ROOT" %}) generally are conditionally thread safe.
 Most of the core, math and I/O related classes are conditionally thread safe ({% include ref class="TTree" %}, {% include ref class="TDirectory" %}, {% include ref class="TFile" %}, `TH*`, {% include ref class="TMinuit" %}).
 Most of the general infrastructure classes (e.g. {% include ref class="TROOT" %}, {% include ref class="TClass" %}) are thread safe.
 For more detail see the individual class documentation.


### PR DESCRIPTION
Add the namespace parameter to the ref macro
Remove the empty TOC in the thread safety page