### PR TITLE
Fix Jenkins instance link

### DIFF
--- a/for_developers/continuous_integration-testing/jenkins_how_to.md
+++ b/for_developers/continuous_integration-testing/jenkins_how_to.md
@@ -7,8 +7,7 @@ sidebar:
   nav: "for_developers"
 ---
 
-The ROOT project uses a [Jenkins instance](https://epsft-jenkins.cern.ch/view/ROOT/){:target="_blank"} to
-schedule a number of software development procedures (nightly builds, production of releases,
+The ROOT project uses a [Jenkins instance](https://lcgapp-services.cern.ch/root-jenkins/view/ROOT/){:target="_blank"} to schedule a number of software development procedures (nightly builds, production of releases,
 documentation generation, etc.). Practical information about the service can be found here.
 The purpose of this page is to document the different existing procedures for the ROOT
 project and basic interaction with them to obtain most of the information.


### PR DESCRIPTION
Current link to our jenkins instance seems broken. This should fix it.