### PR TITLE
New logo page

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -162,8 +162,7 @@ for_developers:
      url: https://rootbnch-grafana-test.cern.ch
      target: _blank
    - title: ROOT Logos
-     url: https://root.cern/img/logos/ROOT_Logo/
-     target: _blank
+     url: for_developers/logos
 
 releases:
    - title: Useful links

--- a/for_developers/logos/index.md
+++ b/for_developers/logos/index.md
@@ -1,0 +1,44 @@
+---
+title: ROOT Logos
+layout: single
+toc: true
+toc_sticky: true
+sidebar:
+  nav: "for_developers"
+---
+
+The current ROOT logos and icons were developed by Noël Ströhmer in 2014.
+The aim was to have a serie of simple and clean logos easy to use in web-sites,
+web-sites banners, presentations, and even fav-icon. All the various logos
+and banners in various sizes and formats can be found [here](https://root.cern/img/logos/ROOT_Logo/).
+
+## Basic logo and favicon
+
+  - favicon: ![](https://root.cern/img/logos/ROOT_Logo/favicon.ico)
+  - 16 pixels: ![](https://root.cern/img/logos/ROOT_Logo/logos/osx/osx-icon-16.png)
+  - 32 pixels: ![](https://root.cern/img/logos/ROOT_Logo/logos/osx/osx-icon-32.png)
+  - 64 pixels: ![](https://root.cern/img/logos/ROOT_Logo/logos/osx/osx-icon-64.png)
+  - 128 pixels: ![](https://root.cern/img/logos/ROOT_Logo/logos/osx/osx-icon-128.png)
+  - 256 pixels: ![](https://root.cern/img/logos/ROOT_Logo/logos/osx/osx-icon-256.png)
+
+Two more sizes are available [here](https://root.cern/img/logos/ROOT_Logo/logos/osx/).
+
+## Splash screen
+
+![](https://root.cern/img/logos/ROOT_Logo/final-splash.png)
+
+## File icon
+
+  - 16 pixels: ![](https://root.cern/img/logos/ROOT_Logo/logos/filetype-anyos/filetype-root-16.png)
+  - 48 pixels: ![](https://root.cern/img/logos/ROOT_Logo/logos/filetype-anyos/filetype-root-48.png)
+  - 128 pixels: ![](https://root.cern/img/logos/ROOT_Logo/logos/filetype-anyos/filetype-root-128.png)
+  - 256 pixels: ![](https://root.cern/img/logos/ROOT_Logo/logos/filetype-anyos/filetype-root-256.png)
+
+## Miscellaneous
+
+  - generic logo black (512 pixels): ![](https://root.cern/img/logos/ROOT_Logo/misc/generic-logo-black-512.png)
+  - generic logo black plus text (512 pixels): ![](https://root.cern/img/logos/ROOT_Logo/misc/generic-logo-black-plustext-512.png)
+  - generic logo color shadowed (512 pixels): ![](https://root.cern/img/logos/ROOT_Logo/misc/generic-logo-color-shadowed-512.png)
+  - full logo: ![](https://root.cern/img/logos/ROOT_Logo/misc/logo_full-350.png)
+
+More miscellaneous logos are available [here](https://root.cern/img/logos/ROOT_Logo/misc/).


### PR DESCRIPTION
The old logo page was just a link to the files on the ROOT server.
This page is a bit more attractive to read and mention the author of the logos.