### PR TITLE
Replace openssl-dev fully with libssl-dev in section on dependencies on Ubuntu and Debian

### DIFF
--- a/install/dependencies.md
+++ b/install/dependencies.md
@@ -85,16 +85,14 @@ Use `sudo apt-get install <package>` or use the graphical "Synaptic Package Mana
 *   **libpng:** png library
 *   **libjpeg:** jpeg library
 *   **python:** (ROOT6 requires version >= 2.7)
-*   **openssl-dev** or **libssl-dev:** for /usr/include/openssl/pem.h and /usr/lib/libssl.so and /usr/lib/libcrypto.so
+*   **libssl-dev:** for `/usr/include/openssl/pem.h`, `/usr/lib/libssl.so` and `/usr/lib/libcrypto.so` (on older systems the package might be called `openssl-dev`)
 
 As a one-liner:
 
 ```bash
 sudo apt-get install dpkg-dev cmake g++ gcc binutils libx11-dev libxpm-dev \
-libxft-dev libxext-dev python openssl-dev
+libxft-dev libxext-dev python libssl-dev
 ```
-
-On Debian, substitute `openssl-dev` with `libssl-dev`.
 
 ### Most common optional packages
 


### PR DESCRIPTION
I just tried to build ROOT master today and installed the required dependencies as written here into my Ubuntu 20.10 WSL: https://root.cern/install/dependencies/#ubuntu-and-other-debian-based-distributions. It states there:

> `sudo apt-get install dpkg-dev cmake g++ gcc binutils libx11-dev libxpm-dev \`
> `libxft-dev libxext-dev python openssl-dev`
> On Debian, substitute openssl-dev with libssl-dev.

I also needed `libssl-dev` on my Ubuntu. So I propose to update the documentation.

Furthermore, I seems `libssl-dev` is available since Ubuntu 16.04: https://packages.ubuntu.com/xenial/libssl-dev. On the contrary, there is no direct search hit for `openssl-dev`: https://packages.ubuntu.com/search?keywords=openssl-dev&searchon=names

Could any other Ubuntu expert verify that `libssl-dev` is the correct package?