### PR TITLE
Added directions for updating/using the `latest-stable` branch

### DIFF
--- a/for_developers/release_checklist/index.md
+++ b/for_developers/release_checklist/index.md
@@ -85,6 +85,11 @@ This assumes you try to create `v6-22-00-patches`, adjust accordingly.
       - `make` must succeed
   1. Push to GitHub
       - `git push origin v6-22-02`
+  1. Update the stable branch. Users that have cloned this branch will receive updates as a fast-forward via `git pull`
+      - `LATEST_STABLE=v6-xx-yy    # e.g. v6-22-02`
+      - If the stable branch does not exist yet, the `-p refs/heads/latest-stable` part must be removed from the command below.
+      - `$ git update-ref refs/heads/latest-stable $(git commit-tree $LATEST_STABLE^{tree} -p refs/heads/latest-stable -m "Updated 'latest-stable' branch to $LATEST_STABLE")`
+      - `$ git push origin latest-stable`
   1. Produce binary tar-files (optional for development releases and release candidates)
       - Start the procedure [root-release-6.22](https://lcgapp-services.cern.ch/root-jenkins/job/root-release-6.22/){:target="_blank"} (or whichever branch) in Jenkins
   1. Install binaries to CVMFS (optional for development releases and release candidates)

--- a/install/build_from_source.md
+++ b/install/build_from_source.md
@@ -30,6 +30,16 @@ The following are the basic instructions for UNIX-like systems. We will use the 
 # substitute `v6-22-00-patches` with the patches branch of the latest release
 $ git clone --branch v6-22-00-patches https://github.com/root-project/root.git root_src
 ```
+
+If you are interested in the latest stable (as opposed to a specific) version, you can get a copy as follows:
+```bash
+$ git clone --branch latest-stable https://github.com/root-project/root.git root_src
+```
+This branch is expected to be updated regularly on each release. Therefore, users who cloned this branch can upgrade to the latest release in a straightforward way:
+```bash
+$ git pull
+```
+
 In the following we will refer to the directory where ROOT sources are (e.g. `root_src` above) as `<sourcedir>`.
 1. Create a directory for the build and a directory for the installation. It is not supported to build ROOT in the source directory. Then change (`cd`) to the build directory:
 ```bash

--- a/install/index.md
+++ b/install/index.md
@@ -200,7 +200,11 @@ it is possible to compile ROOT from source. See [Building ROOT from source]({{'/
 As a quick summary, after installing all [required dependencies]({{'/install/dependencies' | relative_url}}), ROOT can be compiled with these commands on most UNIX-like systems:
 
 ```bash
-# substitute `v6-22-00-patches` with the patches branch of the latest release
+# Substitute `v6-22-00-patches` with the patches branch of the latest release.
+# The latest stable version can be retrieved by cloning the `latest-stable` branch;
+# this branch gets updated automatically on each release. Your may update your
+# local copy by issuing a `git pull` command.
+
 $ git clone --branch v6-22-00-patches https://github.com/root-project/root.git root_src
 $ mkdir root_build root_install && cd root_build
 $ cmake -DCMAKE_INSTALL_PREFIX=../root_install ../root_src # && check cmake configuration output for warnings or errors


### PR DESCRIPTION
The `latest-stable` branch is a convenient way for users that build from source to get
the latest revision that is considered stable by the ROOT team.

The name of this branch does not change, meaning that a `git clone -b latest-stable`
will fetch the the most recent revision without manually specifying a tag name.
Also, this branch is meant to be updated regularly as part of the release
procedure. As such, users can upgrade to the latest published version by
issuing a simple `git pull`.

TL;DR
We attain this by manually committing (via `git commit-tree`) the tree of the
latest stable version to the `latest-stable` branch. Basically, we create a linear
history in which each commit points to the tree of the latest tagged release.

On the client-side, for a `git pull` this is always seen as a fast-forward, and
hence the update is trivial, not requiring a merge.