### PR TITLE
Edit the fitting, histograms and graphs manual pages.

### DIFF
--- a/manual/fitting/index.md
+++ b/manual/fitting/index.md
@@ -10,7 +10,7 @@ toc_sticky: true
 Fitting is the method for modeling the expected distribution of events in a physics data analysis. ROOT offers various options to perform the fitting of the data:
 - [Fit Panel](#using-the-fit-panel): After a histogram is drawn, the Fit Panel GUI is best used for prototyping the fit.
 - [Fit() method](#using-the-fit-method): You can fit histograms and graphs programmatically with the `Fit()` method.
-- Minimization packages: ROOT provides several minimization packages like [Minuit2]({{ "/manual/math/#minuit2-library" | relative_url }}) and [FUMILI]({{ "/manual/math/#fumili-minimization-package" | relative_url}}).
+- Minimization packages: ROOT provides [several minimization packages]({{ "/manual/math/#minimization-libraries-and-classes" | relative_url }}).
 - [RooFit]({{ "/manual/roofit" | relative_url }}): The RooFit library is a toolkit for modeling the expected distribution of events in a physics analysis.
 
 {% include tutorials name="Fit" url="fit" %}
@@ -523,8 +523,8 @@ The defined classes can be classified in the following groups:
     - [ROOT::Fit::FitConfig](https://root.cern/doc/master/classROOT_1_1Fit_1_1FitConfig.html){:target="_blank"} for configuring the fit.
     - [ROOT::Fit::ParameterSettings](https://root.cern/doc/master/classROOT_1_1Fit_1_1ParameterSettings.html){:target="_blank"} to define the properties of the fit parameters (initial values, bounds, etc.).
     - [ROOT::Fit::FitResult](https://root.cern/doc/master/classROOT_1_1Fit_1_1FitResult.html){:target="_blank"} for storing the result of the fit.
-    
-In addition, the fitter classes use the generic interfaces for parametric function evaluations, [ROOT::Math::IParametricFunctionMultiDim](https://root.cern/doc/master/namespaceROOT_1_1Math.html#a285ff3c0500f74e5a5c0d8999d65525a){:target="_blank"} to define the fitting model function, and [ROOT::Math::Minimizer](https://root.cern/doc/master/classROOT_1_1Math_1_1Minimizer.html){:target="_blank"}  interface to perform the minimization of the target function. 
+
+In addition, the fitter classes use the generic interfaces for parametric function evaluations, [ROOT::Math::IParametricFunctionMultiDim](https://root.cern/doc/master/namespaceROOT_1_1Math.html#a285ff3c0500f74e5a5c0d8999d65525a){:target="_blank"} to define the fitting model function, and [ROOT::Math::Minimizer](https://root.cern/doc/master/classROOT_1_1Math_1_1Minimizer.html){:target="_blank"}  interface to perform the minimization of the target function.
 
 ### Creating the input fit data
 
@@ -561,7 +561,7 @@ This example shows how to specify the input option to use the integral of the fu
    opt.fIntegral = true;
    ROOT::Fit::DataRange range(xmin,xmax);
    ROOT::Fit::BinData data(opt,range);
-   
+
 // Fill the bin data using the histogram.
 // You can do this by using the following helper function from the histogram library.
    TH1 * h1 = (TH1*) gDirectory->Get("myHistogram");
@@ -636,7 +636,7 @@ _**Example**_
    fitter.SetFunction( fitFunction, false);
 {% endhighlight %}
 
-When creating a wrapper, the parameter values stored in {% include ref class="TF1" %} are copied to the [ROOT::Math::WrappedMultiTF1](https://root.cern/doc/master/namespaceROOT_1_1Math.html#a5c8071dfd2d9d6661de283f5e363566b){:target="_blank"} object. The function object representing the model function is given to the [ROOT::Fit::Fitter](https://root.cern/doc/master/classROOT_1_1Fit_1_1Fitter.html){:target="_blank"} class using the [Fitter::SetFunction](https://root.cern/doc/master/classROOT_1_1Fit_1_1Fitter.html#ada9af6981d4212951f8120d848f729ab){:target="_blank"} method. 
+When creating a wrapper, the parameter values stored in {% include ref class="TF1" %} are copied to the [ROOT::Math::WrappedMultiTF1](https://root.cern/doc/master/namespaceROOT_1_1Math.html#a5c8071dfd2d9d6661de283f5e363566b){:target="_blank"} object. The function object representing the model function is given to the [ROOT::Fit::Fitter](https://root.cern/doc/master/classROOT_1_1Fit_1_1Fitter.html){:target="_blank"} class using the [Fitter::SetFunction](https://root.cern/doc/master/classROOT_1_1Fit_1_1Fitter.html#ada9af6981d4212951f8120d848f729ab){:target="_blank"} method.
 
 You can also provide a function object that implements the derivatives of the function with respect to the parameters. In this case you must
 provide the function object as a class deriving from the [ROOT::Math::IParametricGradFunctionMultiDim](https://root.cern/doc/master/namespaceROOT_1_1Math.html#a2e698159de0fa9c0bfb713f673464147){:target="_blank"} interface.
@@ -668,7 +668,7 @@ Setting the lower and upper bounds for the first parameter and a lower bound for
 
 Note that a [ROOT::Fit::ParameterSettings](https://root.cern/doc/master/classROOT_1_1Fit_1_1ParameterSettings.html){:target="_blank"} objects exists for each fit parameter and it created by the [ROOT::Fit::FitConfig](https://root.cern/doc/master/classROOT_1_1Fit_1_1FitConfig.html){:target="_blank"} class, after the model function has been set in the fitter. Only when the function is set, the number of parameter is known and automatically the `FitConfig` creates the corresponding `ParameterSetting` objects.
 
-Various minimizers can be used in the fitting process. They can be implemented in different libraries and loaded at run time. Each different minimizer (for example Minuit, Minuit2, FUMILI, etc.) consists of a different implementation of the [ROOT::Math::Minimizer](https://root.cern/doc/master/classROOT_1_1Math_1_1Minimizer.html){:target="_blank"}  interface. Within the same minimizer, thus within the same class implementing the `Minimizer` interface, different algorithms exist. 
+Various minimizers can be used in the fitting process. They can be implemented in different libraries and loaded at run time. Each different minimizer (for example Minuit, Minuit2, FUMILI, etc.) consists of a different implementation of the [ROOT::Math::Minimizer](https://root.cern/doc/master/classROOT_1_1Math_1_1Minimizer.html){:target="_blank"}  interface. Within the same minimizer, thus within the same class implementing the `Minimizer` interface, different algorithms exist.
 
 If the requested minimizer is not available in ROOT, the default one is used. The default minimizer type and algorithm can be specified by using the static function `ROOT::Math::MinimizerOptions::SetDefaultMinimizer("minimizerName")`.
 
@@ -738,36 +738,36 @@ By using [ROOT::Fit::FitResult](https://root.cern/doc/master/classROOT_1_1Fit_1_
 ### TFitResult
 
 {% include ref class="TFitResult" %} is a class deriving from [ROOT::Fit::FitResult](https://root.cern/doc/master/classROOT_1_1Fit_1_1FitResult.html){:target="_blank"} and providing in addition some convenient methods to return
-a covariance or correlation matrix as a `TMatrixDSym` object. Furthermore, {% include ref class="TFitResult" %} derives from {% include ref class="TNamed" %} and can be conveniently stored in a file. 
+a covariance or correlation matrix as a `TMatrixDSym` object. Furthermore, {% include ref class="TFitResult" %} derives from {% include ref class="TNamed" %} and can be conveniently stored in a file.
 
-When fitting an histogram (a {% include ref class="TH1" %} object) or a graph (a {% include ref class="TGraph" %} object), it is possible to return a {% include ref class="TFitResult" %} via the {% include ref class="TFitResultPtr" %} object, which behaves as a smart pointer to a  {% include ref class="TFitResult" %}. {% include ref class="TFitResultPtr" %} is the return object of [TH1::Fit](https://root.cern/doc/master/classTH1.html#a7e7d34c91d5ebab4fc9bba3ca47dabdd){:target="_blank"} or [TGraph::Fit](https://root.cern/doc/master/classTGraph.html#aa978c8ee0162e661eae795f6f3a35589){:target="_blank"}. 
+When fitting an histogram (a {% include ref class="TH1" %} object) or a graph (a {% include ref class="TGraph" %} object), it is possible to return a {% include ref class="TFitResult" %} via the {% include ref class="TFitResultPtr" %} object, which behaves as a smart pointer to a  {% include ref class="TFitResult" %}. {% include ref class="TFitResultPtr" %} is the return object of [TH1::Fit](https://root.cern/doc/master/classTH1.html#a7e7d34c91d5ebab4fc9bba3ca47dabdd){:target="_blank"} or [TGraph::Fit](https://root.cern/doc/master/classTGraph.html#aa978c8ee0162e661eae795f6f3a35589){:target="_blank"}.
 
-By default {% include ref class="TFitResultPtr" %} contains only the status of the fit and can be obtained by an automatic conversion of {% include ref class="TFitResultPtr" %} to an integer. If the fit option `S` is used instead, {% include ref class="TFitResultPtr" %} contains {% include ref class="TFitResult" %} and behaves as a smart pointer to it. 
+By default {% include ref class="TFitResultPtr" %} contains only the status of the fit and can be obtained by an automatic conversion of {% include ref class="TFitResultPtr" %} to an integer. If the fit option `S` is used instead, {% include ref class="TFitResultPtr" %} contains {% include ref class="TFitResult" %} and behaves as a smart pointer to it.
 
 _**Example**_
 
 {% highlight C++ %}
 // TFitResultPtr contains only the fit status.
-   int fitStatus = hist->Fit(myFunction); 
+   int fitStatus = hist->Fit(myFunction);
 
 // TFitResultPtr contains the TFitResult.
-   TFitResultPtr r = hist->Fit(myFunction,"S"); 
+   TFitResultPtr r = hist->Fit(myFunction,"S");
 
 // Access the covariance matrix.
-   TMatrixDSym cov = r->GetCovarianceMatrix(); 
+   TMatrixDSym cov = r->GetCovarianceMatrix();
 
 // Retrieve the fit chi2.
-   Double_t chi2 = r->Chi2(); 
+   Double_t chi2 = r->Chi2();
 
 // Retrieve the value for the parameter 0.
    Double_t par0 = r->Parameter(0);
 
 // Retrieve the error for the parameter 0.
-   Double_t err0 = r->ParError(0); 
+   Double_t err0 = r->ParError(0);
 
 // Print the full information of the fit including covariance matrix.
-   r->Print("V"); 
+   r->Print("V");
 
 // Store the result in a ROOT file.
-   r->Write(); 
+   r->Write();
 {% endhighlight %}

--- a/manual/graphs/index.md
+++ b/manual/graphs/index.md
@@ -6,12 +6,14 @@ sidebar:
 toc: true
 toc_sticky: true
 ---
+
 A graph is an object made of two arrays `X` and `Y`, holding the `x`,`y` coordinates of n points.
 
 **Un-binned data**
 
 A graph or chart is a set of categorical variables, this is un-binned data.<br>
-A histogram is used for continuous data, where the bins represent ranges of data (binned data), see → [Fitting histograms]({{ "/manual/fitting" | relative_url }}).
+A histogram is used for continuous data, where the bins represent ranges of data
+(binned data), see → [Histograms]({{ "/manual/histograms" | relative_url }}).
 
 {% include tutorials name="Graph" url="graphs" %}
 
@@ -62,9 +64,8 @@ The coordinates can be arrays of doubles or floats.
 
 ### Drawing a graph
 
-- Use the `Draw()` method to draw a graph.
-
-The {% include ref class="TGraphPainter" %} class implements all drawing options.
+  - Use the [TGraph::Draw()](https://root.cern/doc/master/classTGraph.html#a7ee6d3572ef075dd4fa1a6deb939a986) method to draw a graph.
+    The {% include ref class="TGraphPainter" %} class implements all drawing options.
 
 _**Example**_
 
@@ -91,25 +92,10 @@ _**Example**_
 >
 > The drawing options are not case sensitive.
 
-For detailed information on the drawing options for graph classes, refer to {% include ref class="TGraphPainter" %}.
-
-`L`: A simple poly-line between every point is drawn.
-
-`F`: A filled area is drawn.
-
-`F1`: As F, but the filled area is no more repartee around X=0 or Y=0.
-
-`F2`: Draws a filled area poly line connecting the center of bins.
-
-`A`: Axis are drawn around the graph.
-
-`C`: A smooth curve is drawn.
-
-`*` A star is plotted at each point.
-
-`P`: The current marker of the graph is plotted at each point.
-
-`B`: A bar chart is drawn at each point.
+The "drawing option" is the unique parameter of the [TGraph::Draw()](https://root.cern/doc/master/classTGraph.html#a7ee6d3572ef075dd4fa1a6deb939a986){:target="_blank"}
+method. It specifies how the graph will be graphically rendered.
+For detailed information on the drawing options for graph classes, refer to
+[TGraphPainter](https://root.cern/doc/master/classTGraphPainter.html#GP01).
 
 _**Example**_
 
@@ -131,7 +117,7 @@ _**Example**_
 
 ### Setting titles for a graph
 
-Before giving the axis of a graph a title you need to draw the graph first. 
+Before giving the axis of a graph a title you need to draw the graph first.
 
 You can set the title by getting the axis and calling the [TGraph::SetTitle()](https://root.cern/doc/master/classTGraph.html#a56aed9b71c9ea7dc48285c8ecc285aed){:target="_blank"} method.
 
@@ -170,7 +156,7 @@ _**Example**_
    Int_t n = 10;
    Double_t x[10] = {-.22,.05,.25,.35,.5,.61,.7,.85,.89,.95};
    Double_t y[10] = {1,2.9,5.6,7.4,9,9.6,8.7,6.3,4.5,1};
-   
+
    TGraph *gr = new TGraph(n,x,y);
    gr->SetMarkerColor(4);
    gr->SetMarkerStyle(20);
@@ -290,7 +276,7 @@ The {% include ref class="TGraph2D" %} class has the following constructors:
  {% highlight C++ %}
    TGraph2D *g = new TGraph2D(n);
  {% endhighlight %}
- 
+
 - Internal arrays are filled with the `SetPoint()` method at the position `i` with the values `x`, `y`, `z`.
 
 {% highlight C++ %}

--- a/manual/histograms/index.md
+++ b/manual/histograms/index.md
@@ -30,47 +30,47 @@ The following histogram classes are available in ROOT, among others:
 
 ### 1-D histograms
 
-  - [TH1C](https://root.cern/doc/master/classTH1C.html){:target="_blank"}: One byte per channel. Maximum bin content = 127.
+  - {% include ref class="TH1C" %} has one byte per channel. Maximum bin content = 127.
 
-  - [TH1S](https://root.cern/doc/master/classTH1S.html){:target="_blank"}: One short per channel. Maximum bin content = 32767.
+  - {% include ref class="TH1S" %} has one short per channel. Maximum bin content = 32767.
 
-  - [TH1I](https://root.cern/doc/master/classTH1I.html){:target="_blank"}: One int per channel. Maximum bin content = 2147483647.
+  - {% include ref class="TH1I" %} has one int per channel. Maximum bin content = 2147483647.
 
-  - [TH1F](https://root.cern/doc/master/classTH1F.html){:target="_blank"}: One float per channel. Maximum precision 7 digits.
+  - {% include ref class="TH1F" %} has one float per channel. Maximum precision 7 digits.
 
-  - [TH1D](https://root.cern/doc/master/classTH1D.html){:target="_blank"}: One double per channel. Maximum precision 14 digits.
+  - {% include ref class="TH1D" %} has one double per channel. Maximum precision 14 digits.
 
 ### 2-D histograms
 
-  - [TH2C](https://root.cern/doc/master/classTH2C.html){:target="_blank"}: One byte per channel. Maximum bin content = 127.
+  - {% include ref class="TH2C" %} has one byte per channel. Maximum bin content = 127.
 
-  - [TH2S](https://root.cern/doc/master/classTH2S.html){:target="_blank"}: One short per channel. Maximum bin content = 32767.
+  - {% include ref class="TH2S" %} has one short per channel. Maximum bin content = 32767.
 
-  - [TH2I](https://root.cern/doc/master/classTH2I.html){:target="_blank"}: One int per channel. Maximum bin content = 2147483647.
+  - {% include ref class="TH2I" %} has one int per channel. Maximum bin content = 2147483647.
 
-  - [TH2F](https://root.cern/doc/master/classTH2F.html){:target="_blank"}: One float per channel. Maximum precision 7 digits.
+  - {% include ref class="TH2F" %} has one float per channel. Maximum precision 7 digits.
 
-  - [TH2D](https://root.cern/doc/master/classTH2D.html){:target="_blank"}: One double per channel. Maximum precision 14 digits.
+  - {% include ref class="TH2D" %} has one double per channel. Maximum precision 14 digits.
 
 ### 3-D histograms
 
-  - [TH3C](https://root.cern/doc/master/classTH3C.html){:target="_blank"}: One byte per channel. Maximum bin content = 127.
+  - {% include ref class="TH3C" %} has one byte per channel. Maximum bin content = 127.
 
-  - [TH3S](https://root.cern/doc/master/classTH3S.html){:target="_blank"}: One short per channel. Maximum bin content = 32767.
+  - {% include ref class="TH3S" %} has one short per channel. Maximum bin content = 32767.
 
-  - [TH3I](https://root.cern/doc/master/classTH3I.html){:target="_blank"}: One int per channel. Maximum bin content = 2147483647.
+  - {% include ref class="TH3I" %} has one int per channel. Maximum bin content = 2147483647.
 
-  - [TH3F](https://root.cern/doc/master/classTH3F.html){:target="_blank"}: One float per channel. Maximum precision 7 digits.
+  - {% include ref class="TH3F" %} has one float per channel. Maximum precision 7 digits.
 
-  - [TH3D](https://root.cern/doc/master/classTH3D.html){:target="_blank"}: One double per channel. Maximum precision 14 digits.
+  - {% include ref class="TH3D" %} has one double per channel. Maximum precision 14 digits.
 
 ### Profile histograms
 
-  - [TProfile](https://root.cern/doc/master/classTProfile.html){:target="_blank"}: Profile histogram to display the mean value of Y and its error for each bin in X.
+  - {% include ref class="TProfile" %} is a 1-D profile histogram to display the mean value of Y and its error for each bin in X.
 
-  - [TProfile2D](https://root.cern/doc/master/classTProfile2D.html){:target="_blank"}: Profile2D histograms are used to display the mean value of Z and its RMS for each cell in X,Y.
+  - {% include ref class="TProfile2D" %} is a 2-D profile histogram to display the mean value of Z and its RMS for each cell in X,Y.
 
-  - [TProfile3D](https://root.cern/doc/master/classTProfile3D.html){:target="_blank"}: Profile3D histograms are used to display the mean value of T and its RMS for each cell in X,Y,Z.
+  - {% include ref class="TProfile3D" %} is a 3-D profile histogram to display the mean value of T and its RMS for each cell in X,Y,Z.
 
 ### Bin numbering
 
@@ -80,15 +80,15 @@ All histogram types support fixed or variable bin sizes. 2-D histograms may have
 
 For all histogram types: `nbins`, `xlow`, `xup`:
 
--   bin# 0 contains the underflow.
+  - bin# 0 contains the underflow.
 
--   bin# 1 contains the first bin with low-edge (`xlow` INCLUDED).
+  - bin# 1 contains the first bin with low-edge (`xlow` INCLUDED).
 
--   The second to last bin (bin# nbins) contains the upper-edge (`xup` EXCLUDED).
+  - The second to last bin (bin# nbins) contains the upper-edge (`xup` EXCLUDED).
 
--   The last bin (bin# `nbins+1`) contains the overflow.
+  - The last bin (bin# `nbins+1`) contains the overflow.
 
--   In case of 2-D or 3-D histograms, a *global bin* number is defined.
+  - In case of 2-D or 3-D histograms, a *global bin* number is defined.
 
 _**Example**_
 
@@ -101,6 +101,10 @@ This *global bin* is useful to access the bin information independently of the d
 **Re-binning**
 
 You can re-bin a histogram via the [TH1::Rebin()](https://root.cern/doc/master/classTH1.html#aff6520fdae026334bf34fa1800946790){:target="_blank"} method. It returns a new histogram with the re-binned contents. If bin errors were stored, they are recomputed during the re-binning.
+
+### Stack of histograms
+
+  - {% include ref class="THStack" %} is a collection of {% include ref class="TH1" %} or {% include ref class="TH2" %} histograms.
 
 ## Working with histograms
 
@@ -199,8 +203,9 @@ Multiplying two histograms and put the result in the third one:
 ### Drawing a histogram
 
   - Use the [TH1::Draw()](https://root.cern/doc/master/classTH1.html#aa53a024a9e94d5ec91e3ef49e49563da){:target="_blank"} method to draw a histogram.
-
-    It creates a {% include ref class="THistPainter" %} object that specializes the drawing of the histogram. The `THistPainter` class is separated from the histogram, so that the histogram does not contain the graphics overhead.
+    It creates a {% include ref class="THistPainter" %} object that specializes the drawing of the histogram.
+    The {% include ref class="THistPainter" %} class is separated
+    from the histogram, so that the histogram does not contain the graphics overhead.
 
   - Use the [TH1::DrawCopy()](https://root.cern/doc/master/classTH1.html#aa19b24b96284284d677cd73f00d29d79){:target="_blank"} method to create a copy of the histogram when drawing it.
 
@@ -240,41 +245,12 @@ _**Example**_
 
 **Drawing options for all histogram classes**
 
-For detailed information on the drawing options for all histogram classes, refer to [THistPainter](https://root.cern/doc/master/classTHistPainter.html#HP01a){:target="_blank"}.
+The "drawing option" is the unique parameter of the [TH1::Draw()](https://root.cern/doc/master/classTH1.html#aa53a024a9e94d5ec91e3ef49e49563da){:target="_blank"}
+method. It specifies how the histogram will be graphically rendered.
+For detailed information on the drawing options for all histogram classes, refer to
+[THistPainter](https://root.cern/doc/master/classTHistPainter.html#HP01a){:target="_blank"}.
 
-`AXIS`: Draws only the axis.
-
-`HIST`: When a histogram has errors, it is visualized by default with error bars. To visualize it without errors, use `HIST` together with the required option (for example "`HIST SAME C`").
-
-`SAME`: Superimposes on previous picture in the same pad.
-
-`CYL`: Uses cylindrical coordinates.
-
-`POL`: Uses polar coordinates.
-
-`SPH`: Uses spherical coordinates.
-
-`PSR`: Uses pseudo-rapidity/phi coordinates.
-
-`LEGO`: Draws a lego plot with hidden line removal.
-
-`LEGO1`: Draws a lego plot with hidden surface removal.
-
-`LEGO2`: Draws a lego plot using colors to show the cell contents.
-
-`SURF`: Draws a surface plot with hidden line removal.
-
-`SURF1`: Draws a surface plot with hidden surface removal.
-
-`SURF2`: Draws a surface plot using colors to show the cell contents.
-
-`SURF3`: Same as SURF with a contour view on the top.
-
-`SURF4`: Draws a surface plot using Gouraud shading.
-
-`SURF5`: Same as `SURF3`, but only the colored contour is drawn. Used with option `CYL`, `SPH` or `PSR`, it allows to draw colored contours on a sphere, a cylinder or in a pseudo rapidly space. In Cartesian or polar coordinates, option `SURF3` is used.
-
-_**Example**_
+_**Examples**_
 
 {% highlight C++ %}
    TH2F h2("h2","Histogram filled with random numbers",40,-4,4,40,-20,20);
@@ -300,113 +276,14 @@ _**Example**_
    caption="Histogram drawn with Draw(\"LEGO1 POL\")."
 %}
 
-**Drawing options for 1-D histogram classes**
 
-For detailed information on the drawing options for 1-D histogram classes, refer to [THistPainter](https://root.cern/doc/master/classTHistPainter.html#HP01b){:target="_blank"}.
+{% include ref class="THistPainter" %} implements drawing options for
+ [1-D](https://root.cern/doc/master/classTHistPainter.html#HP01b){:target="_blank"},
+ [2-D](https://root.cern/doc/master/classTHistPainter.html#HP01c){:target="_blank"}, and
+ [3-D](https://root.cern/doc/master/classTHistPainter.html#HP01d){:target="_blank"} histogram classes.
+It also implements specific drawing options for
+ [THStack](https://root.cern/doc/master/classTHistPainter.html#HP01e){:target="_blank"}.
 
-`AH`: Draws the histogram, but not the axis labels and tick marks.
-
-`B`: Draws a bar chart.
-
-`C`: Draws a smooth curve through the histogram bins.
-
-`E`: Draws error bars.
-
-`E0`: Draws error bars including bins with 0 contents.
-
-`E1`: Draws error bars with perpendicular lines at the edges
-
-`E2`: Draws error bars with rectangles.
-
-`E3`: Draws a filled area through the end points of the vertical error bars.
-
-`E4`: Draws a smoothed filled area through the end points of the error bars.
-
-`L`: Draws a line through the bin contents.
-
-`P`: Draws a (poly)marker at each bin using the histogram's current marker style.
-
-`P0`: Draws current marker at each bin including empty bins.
-
-`PIE`: Draws a pie chart.
-
-`H`: Draws a histogram with a * at each bin.
-
-`LF2`: Draws a histogram with option `L` but with a filled area. `L` also draws a filled area if the histogram fill color is set but the fill area corresponds to the histogram contour.
-
-`9`: Forces a histogram to be drawn in high resolution mode. By default, the histogram is drawn in low resolution in case the number of bins is greater than the number of pixels in the current pad.
-
-`][`: Draws a histogram without the vertical lines for the first and the last bin. Use this, when superposing many histograms on the same picture.
-
-**Drawing options for 2-D histogram classes**
-
-For detailed information on the drawing options for 2-D histogram classes, refer to {% include ref class="THistPainter" %}.
-
-By default, 2-D histograms are drawn as scatter plots.
-
-`ARR`: Arrow mode. Shows gradient between adjacent cells.
-
-`BOX`: Draws a box for each cell with surface proportional to contents.
-
-`BOX1`: A sunken button is drawn for negative values, a raised one for positive values
-
-`COL`: Draws a box for each cell with a color scale varying with contents.
-
-`COLZ`: Same as `COL` with a drawn color palette.
-
-`CONT`: Draws a contour plot (same as `CONT0`).
-
-`CONTZ`: Same as `CONT` with a drawn color palette.
-
-`CONT0`: Draws a contour plot using surface colors to distinguish contours.
-
-`CONT1`: Draws a contour plot using line styles to distinguish contours.
-
-`CONT2`: Draws a contour plot using the same line style for all contours.
-
-`CONT3`: Draws a contour plot using fill area colors.
-
-`CONT4`: Draws a contour plot using surface colors (`SURF2` option at `theta = 0`).
-
-`CONT5`: Uses Delaunay triangles to compute the contours.
-
-`LIST`: Generates a list of {% include ref class="TGraph" %} objects for each contour.
-
-`FB`: To be used with `LEGO` or `SURFACE`, suppresses the front-box.
-
-`BB`: To be used with `LEGO` or `SURFACE`, suppresses the back-box.
-
-`A`: To be used with `LEGO` or `SURFACE`, suppresses the axis.
-
-`SCAT`: Draws a scatter-plot (default).
-
-`SPEC`: Uses the {% include ref class="TSpectrum2Painter" %} tool for drawing.
-
-`TEXT`: Draws bin contents as text (format set via `gStyle->SetPaintTextFormat`).
-
-`TEXTnn`: Draws bin contents as text at angle nn (0 < nn < 90).
-
-`[cutg]`: Draws only the sub-range selected by the {% include ref class="TCutG" %} name "`cutg`".
-
-`Z`: The Z option can be specified with the options: `BOX`, `COL`, `CONT`, `SURF`, and `LEGO` to display.
-
-**Drawing options for 3-D histogram classes**
-
-For detailed information on the drawing options for 3-D histogram classes, refer to {% include ref class="THistPainter" %}.
-
-By default, 3-D histograms are drawn as scatter plots.
-
-`BOX`: Draws a box for each cell with volume proportional to the contents.
-
-`LEGO`: Same as `BOX`.
-
-`ISO`: Draws an iso surface.
-
-`FB`: Suppresses the front-box.
-
-`BB`: Suppresses the back-box.
-
-`A`: Suppresses the axis.
 
 ### Drawing a histogram with error bars
 


### PR DESCRIPTION
- Fitting:
   - replace the list of minimisation package by a link to a more complete list in the math page
- Histograms:
   - remove the list of drawing options. Point to the list in the ref guide instead
   - add THStack
   - cleanup
- Graphs:
   - remove the list of drawing options. Point to the list in the ref guide instead
   - cleanup