### PR TITLE
[release_checklist] latest-stable: add also as parent the commit of the latest tagged version

### DIFF
--- a/for_developers/release_checklist/index.md
+++ b/for_developers/release_checklist/index.md
@@ -88,7 +88,7 @@ This assumes you try to create `v6-22-00-patches`, adjust accordingly.
   1. Update the stable branch. Users that have cloned this branch will receive updates as a fast-forward via `git pull`
       - `LATEST_STABLE=v6-xx-yy    # e.g. v6-22-02`
       - If the stable branch does not exist yet, the `-p refs/heads/latest-stable` part must be removed from the command below.
-      - `$ git update-ref refs/heads/latest-stable $(git commit-tree $LATEST_STABLE^{tree} -p refs/heads/latest-stable -m "Updated 'latest-stable' branch to $LATEST_STABLE")`
+      - `$ git update-ref refs/heads/latest-stable $(git commit-tree $LATEST_STABLE^{tree} -p refs/heads/latest-stable -p $LATEST_STABLE^{commit} -m "Updated 'latest-stable' branch to $LATEST_STABLE")`
       - `$ git push origin latest-stable`
   1. Produce binary tar-files (optional for development releases and release candidates)
       - Start the procedure [root-release-6.22](https://lcgapp-services.cern.ch/root-jenkins/job/root-release-6.22/){:target="_blank"} (or whichever branch) in Jenkins


### PR DESCRIPTION
Initially, we discussed that the `latest-stable` branch would have a unrelated
history (orphan branch). However, adding as parent the latest tagged version
has two benefits:

- Pushes take less time, as git client is able to determine that no objects should be sent (other than the commit itself).
- Comparing branches à la `git show-branch ...` is also possible.