### PR TITLE
Allow to download reference guides in xz format.

### DIFF
--- a/_includes/download
+++ b/_includes/download
@@ -1,0 +1,1 @@
+{% assign n = {{include.name}}  %}[{{n}}.tar.gz](https://root.cern/download/{{n}}.tar.gz){:target="_blank"} - [{{n}}.tar.xz](https://root.cern/download/{{n}}.tar.xz){:target="_blank"}

--- a/reference/index.md
+++ b/reference/index.md
@@ -8,27 +8,27 @@ sidebar:
 The Reference Guide is available for all major ROOT releases.
 This page gives the list of all the past versions.
 
-| ROOT Version           | HTML link                                                                  | Download link                                                           | Link to the Tag file                                                |
-|------------------------|----------------------------------------------------------------------------|------------------------------------------------------------------------ |---------------------------------------------------------------------|
-| HEAD of the git master | [browse](https://root.cern/doc/master/){:target="_blank"}                  |                                                                         | [tag file](https://root.cern/doc/master/ROOT.tag){:target="_blank"} |
-| 6.24                   | [browse](https://root.cern/doc/v624/){:target="_blank"}                    | [download](https://root.cern/download/html624.tar.gz){:target="_blank"} | [tag file](https://root.cern/doc/v624/ROOT.tag){:target="_blank"}   |
-| 6.22                   | [browse](https://root.cern/doc/v622/){:target="_blank"}                    | [download](https://root.cern/download/html622.tar.gz){:target="_blank"} | [tag file](https://root.cern/doc/v622/ROOT.tag){:target="_blank"}   |
-| 6.20                   | [browse](https://root.cern/doc/v620/){:target="_blank"}                    | [download](https://root.cern/download/html620.tar.gz){:target="_blank"} | [tag file](https://root.cern/doc/v620/ROOT.tag){:target="_blank"}   |
-| 6.18                   | [browse](https://root.cern/doc/v618/){:target="_blank"}                    | [download](https://root.cern/download/html618.tar.gz){:target="_blank"} | [tag file](https://root.cern/doc/v618/ROOT.tag){:target="_blank"}   |
-| 6.16                   | [browse](https://root.cern/doc/v616/){:target="_blank"}                    | [download](https://root.cern/download/html616.tar.gz){:target="_blank"} | [tag file](https://root.cern/doc/v616/ROOT.tag){:target="_blank"}   |
-| 6.14                   | [browse](https://root.cern/doc/v614/){:target="_blank"}                    | [download](https://root.cern/download/html614.tar.gz){:target="_blank"} | [tag file](https://root.cern/doc/v614/ROOT.tag){:target="_blank"}   |
-| 6.12                   | [browse](https://root.cern/doc/v612/){:target="_blank"}                    | [download](https://root.cern/download/html612.tar.gz){:target="_blank"} | [tag file](https://root.cern/doc/v612/ROOT.tag){:target="_blank"}   |
-| 6.10                   | [browse](https://root.cern/doc/v610/){:target="_blank"}                    | [download](https://root.cern/download/html610.tar.gz){:target="_blank"} | [tag file](https://root.cern/doc/v610/ROOT.tag){:target="_blank"}   |
-| 6.08                   | [browse](https://root.cern/doc/v608/){:target="_blank"}                    | [download](https://root.cern/download/html608.tar.gz){:target="_blank"} | [tag file](https://root.cern/doc/v608/ROOT.tag){:target="_blank"}   |
-| 6.06                   | [browse](https://root.cern/root/html606/){:target="_blank"}                | [download](https://root.cern/download/html606.tar.gz){:target="_blank"} | [tag file](https://root.cern/doc/v606/ROOT.tag){:target="_blank"}   |
-| 6.04                   | [browse](https://root.cern/root/html604/ClassIndex.html){:target="_blank"} | [download](https://root.cern/download/html604.tar.gz){:target="_blank"} |
-| 6.02                   | [browse](https://root.cern/root/html602/ClassIndex.html){:target="_blank"} | [download](https://root.cern/download/html602.tar.gz){:target="_blank"} |
-| 5.34                   | [browse](https://root.cern/root/html534/ClassIndex.html){:target="_blank"} | [download](https://root.cern/download/html534.tar.gz){:target="_blank"} |
-| 5.32                   | [browse](https://root.cern/root/html532/ClassIndex.html){:target="_blank"} | [download](https://root.cern/download/html532.tar.gz){:target="_blank"} |
-| 5.30                   | [browse](https://root.cern/root/html530/ClassIndex.html){:target="_blank"} | [download](https://root.cern/download/html530.tar.gz){:target="_blank"} |
-| 5.28                   | [browse](https://root.cern/root/html528/ClassIndex.html){:target="_blank"} | [download](https://root.cern/download/html528.tar.gz){:target="_blank"} |
-| 5.26                   | [browse](https://root.cern/root/html526/ClassIndex.html){:target="_blank"} | [download](https://root.cern/download/html526.tar.gz){:target="_blank"} |
-| 5.24                   | [browse](https://root.cern/root/html524/ClassIndex.html){:target="_blank"} | [download](https://root.cern/download/html524.tar.gz){:target="_blank"} |
+| ROOT Version           | HTML link                                                                  | Download links                        | Link to the Tag file                                                |
+|------------------------|----------------------------------------------------------------------------|---------------------------------------|---------------------------------------------------------------------|
+| HEAD of the git master | [browse](https://root.cern/doc/master/){:target="_blank"}                  |                                       | [tag file](https://root.cern/doc/master/ROOT.tag){:target="_blank"} |
+| 6.24                   | [browse](https://root.cern/doc/v624/){:target="_blank"}                    | {% include download name="html624" %} | [tag file](https://root.cern/doc/v624/ROOT.tag){:target="_blank"}   |
+| 6.22                   | [browse](https://root.cern/doc/v622/){:target="_blank"}                    | {% include download name="html622" %} | [tag file](https://root.cern/doc/v622/ROOT.tag){:target="_blank"}   |
+| 6.20                   | [browse](https://root.cern/doc/v620/){:target="_blank"}                    | {% include download name="html620" %} | [tag file](https://root.cern/doc/v620/ROOT.tag){:target="_blank"}   |
+| 6.18                   | [browse](https://root.cern/doc/v618/){:target="_blank"}                    | {% include download name="html618" %} | [tag file](https://root.cern/doc/v618/ROOT.tag){:target="_blank"}   |
+| 6.16                   | [browse](https://root.cern/doc/v616/){:target="_blank"}                    | {% include download name="html616" %} | [tag file](https://root.cern/doc/v616/ROOT.tag){:target="_blank"}   |
+| 6.14                   | [browse](https://root.cern/doc/v614/){:target="_blank"}                    | {% include download name="html614" %} | [tag file](https://root.cern/doc/v614/ROOT.tag){:target="_blank"}   |
+| 6.12                   | [browse](https://root.cern/doc/v612/){:target="_blank"}                    | {% include download name="html612" %} | [tag file](https://root.cern/doc/v612/ROOT.tag){:target="_blank"}   |
+| 6.10                   | [browse](https://root.cern/doc/v610/){:target="_blank"}                    | {% include download name="html610" %} | [tag file](https://root.cern/doc/v610/ROOT.tag){:target="_blank"}   |
+| 6.08                   | [browse](https://root.cern/doc/v608/){:target="_blank"}                    | {% include download name="html608" %} | [tag file](https://root.cern/doc/v608/ROOT.tag){:target="_blank"}   |
+| 6.06                   | [browse](https://root.cern/root/html606/){:target="_blank"}                | {% include download name="html606" %} | [tag file](https://root.cern/doc/v606/ROOT.tag){:target="_blank"}   |
+| 6.04                   | [browse](https://root.cern/root/html604/ClassIndex.html){:target="_blank"} | {% include download name="html604" %} |                                                                     |
+| 6.02                   | [browse](https://root.cern/root/html602/ClassIndex.html){:target="_blank"} | {% include download name="html602" %} |                                                                     |
+| 5.34                   | [browse](https://root.cern/root/html534/ClassIndex.html){:target="_blank"} | {% include download name="html534" %} |                                                                     |
+| 5.32                   | [browse](https://root.cern/root/html532/ClassIndex.html){:target="_blank"} | {% include download name="html532" %} |                                                                     |
+| 5.30                   | [browse](https://root.cern/root/html530/ClassIndex.html){:target="_blank"} | {% include download name="html530" %} |                                                                     |
+| 5.28                   | [browse](https://root.cern/root/html528/ClassIndex.html){:target="_blank"} | {% include download name="html528" %} |                                                                     |
+| 5.26                   | [browse](https://root.cern/root/html526/ClassIndex.html){:target="_blank"} | {% include download name="html526" %} |                                                                     |
+| 5.24                   | [browse](https://root.cern/root/html524/ClassIndex.html){:target="_blank"} | {% include download name="html524" %} |                                                                     |
 
 If your project documentation is done via Doxygen and it depends on ROOT, you may want to
 link your project documentation to the ROOT reference guide. This can be done using ROOT


### PR DESCRIPTION
As requested [here](https://github.com/root-project/web/issues/572), this PR allows to download the reference guide in gz and xz formats.