### PR TITLE
CMAKE_CXX_STANDARD is now 17

### DIFF
--- a/for_developers/root7/index.md
+++ b/for_developers/root7/index.md
@@ -22,15 +22,15 @@ The main point of the meeting and this page is to solicit *your* feedback. Most 
 
 ## Building ROOT 7
 ### Pre-requisites
-Support for the c++14 standard is required. Usage of g++ >= 5 or clang >= 3.4 is recommended.
+Support for the c++17 standard is required. Usage of g++ >= 5 or clang >= 3.4 is recommended.
 ### Relevant cmake variables
-The `CMAKE_CXX_STANDARD` cmake variables must be set to at least `14`.
+The `CMAKE_CXX_STANDARD` cmake variables must be set to at least `17`.
 
 Building from source would look similar to this:
 
     $ mkdir root7_build
     $ cd root7_build
-    $ cmake -DCMAKE_CXX_STANDARD=14 path/to/root/source
+    $ cmake -DCMAKE_CXX_STANDARD=17 path/to/root/source
     $ cmake --build . -- -j4
 
 

--- a/install/build_from_source.md
+++ b/install/build_from_source.md
@@ -125,7 +125,7 @@ For ROOT <= 6.20, an older version of PyROOT (not based on Cppyy) will be built.
 
 ROOT needs to be configured and built with the same C++ standard as the programs that will make use of it.
 The relevant cmake flag is [`CMAKE_CXX_STANDARD`](https://cmake.org/cmake/help/latest/variable/CMAKE_CXX_STANDARD.html){:target="_blank"}.
-For example, from the command line, the standard can be selected by passing one of 11, 14, 20,... such as `-DCMAKE_CXX_STANDARD=14`.
+For example, from the command line, the standard can be selected by passing one of 11, 14, 20,... such as `-DCMAKE_CXX_STANDARD=17`.
 
 ### ROOT STL backports
 


### PR DESCRIPTION
The CMAKE_CXX_STANDARD value indicated for building ROOT7 was c++14, however it now requires c++17.
This was mentioned by: https://github.com/root-project/root/issues/8743