### PR TITLE
Configure custom 404 page

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -3,3 +3,4 @@
 	RewriteCond %{REQUEST_URI} /+[^\.]+$ 
 	RewriteRule ^(.+[^/])$ %{REQUEST_URI}/ [R=301,L]
 </IfModule>
+ErrorDocument 404 /404.html


### PR DESCRIPTION
Someone must've overlooked https://jekyllrb.com/tutorials/custom-404-page/#hosting-on-apache-web-servers — the custom 404 page isn't used on Apache unless it's enabled in the configuration. :wink: 

(Arguably this would be better done in whatever `/etc/httpd/conf.d/` file defines the `VirtualHost` for the site, but those configs aren't part of the repo and it "should" work to define it here as well.)