### PR TITLE
Teach {%include ref } to handle nested namespaces:

### DIFF
--- a/_includes/ref
+++ b/_includes/ref
@@ -1,2 +1,2 @@
 {% assign c = {{include.class}}  %}{% assign n = {{include.namespace}}  %}{% capture ns %}{{ n | size }}{% endcapture %}
-{% if ns == "0" %}<a href="https://root.cern/doc/master/class{{c}}.html" target="_blank">{{c}}</a>{% else %}<a href="https://root.cern/doc/master/class{{n}}_1_1{{c}}.html" target="_blank">{{c}}</a>{% endif %}
+{% if ns == "0" %}<a href="https://root.cern/doc/master/class{{ c | replace: "::", "_1_1" }}.html" target="_blank">{{c}}</a>{% else %}<a href="https://root.cern/doc/master/class{{ n | replace: "::", "_1_1" }}_1_1{{c}}.html" target="_blank">{{c}}</a>{% endif %}


### PR DESCRIPTION
{% include ref class="N1::N2::Klass" %} will create <a href=...>N1::N2::Klass</a>, while
{% include ref class="Klass" namespace="N1::N2" %} will create <a href=...>Klass</a>.
Both will link to the documentation of N1::N2::Klass.