### PR TITLE
[Docs] Rework section on macros and shared libraries

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -79,6 +79,7 @@ manual:
       - title: Geometry
         url: manual/geometry
       - title: ROOT I/O
+        url: manual/root_io
       - title: Adding a class to ROOT (move in I/O)
         url: manual/adding_a_class_to_root
       - title: Signal/Slot communication

--- a/manual/adding_a_class_to_root/index.md
+++ b/manual/adding_a_class_to_root/index.md
@@ -50,7 +50,7 @@ You want to either create a {% include ref class="TTree" %} branch of your class
 {% endhighlight %}
 
 For this to work, ROOT needs to know about the `MyClass` type: its data members, base classes, how to construct such an object when reading it back, etc.
-This is provided through a [dictionary]({{'/manual/root_macros_and_shared_libraries/#generating-dictionaries' | relative_url }}).
+This is provided through a [dictionary]({{'/manual/root_io/#generating-dictionaries' | relative_url }}).
 
 ### Constructors
 

--- a/manual/functional_parts/index.md
+++ b/manual/functional_parts/index.md
@@ -33,5 +33,7 @@ The second part of the ROOT Manual contains:
   - [Physics vectors]({{ '/manual/physics_vectors' | relative_url }})
 
   - [Geometry]({{ '/manual/geometry' | relative_url }})
+  - 
+  - [ROOT I/O]({{ '/manual/root_io' | relative_url }})
 
   - [Python interface: PyROOT]({{ '/manual/python' | relative_url }})

--- a/manual/python/index.md
+++ b/manual/python/index.md
@@ -277,14 +277,14 @@ x = ROOT.f(3)  # x = 9
 For larger analysis frameworks, one may not want to compile the headers each time the Python interpreter is started. One may also
 want to read or write custom C++/C objects in ROOT files, and use them with [RDataFrame](https://root.cern/doc/master/classROOT_1_1RDataFrame.html){:target="_blank"} or similar tools.
 
-A large analysis framework might further have multiple libraries. In these cases, you generate [ROOT dictionaries]({{ 'manual/root_macros_and_shared_libraries' | relative_url }}), and add these to the libraries, which provides ROOT
+A large analysis framework might further have multiple libraries. In these cases, you generate [ROOT dictionaries]({{ 'manual/root_io/#generating-dictionaries' | relative_url }}), and add these to the libraries, which provides ROOT
 with the necessary information on how to generate Python bindings on the fly.
 This is what the large LHC experiments do to steer their analysis frameworks from Python.
 
 1. Create one or multiple C++ libraries. <br/>For example create a library as a CMake project that uses ROOT, see → [CMake details]({{ '/manual/integrate_root_into_my_cmake_project' | relative_url }})
 1. [Optional] Add [`ClassDef` macros]({{ 'manual/adding_a_class_to_root' | relative_url }}) for classes that should be read or written from or into files.
-1. Generate a dictionary of all classes that should receive I/O capabilities, i.e. that can be written into ROOT files, see → [Generating dictionaries]({{ '/manual/root_macros_and_shared_libraries/#generating-dictionaries' | relative_url }})
-   <br>Use a [`LinkDef.h` file]({{ '/manual/root_macros_and_shared_libraries/#selecting-dictionary-entries-linkdefh' | relative_url }})
+1. Generate a dictionary of all classes that should receive I/O capabilities, i.e. that can be written into ROOT files, see → [Generating dictionaries]({{ '/manual/root_io/#generating-dictionaries' | relative_url }})
+   <br>Use a [`LinkDef.h` file]({{ '/manual/root_io/#selecting-dictionary-entries-linkdefh' | relative_url }})
    to select which classes or functions ROOT should be included in the dictionary.
 
    The corresponding cmake instructions would look similar to this:

--- a/manual/root_io/index.md
+++ b/manual/root_io/index.md
@@ -1,0 +1,266 @@
+---
+title: "Generating dictionaries"
+layout: single
+sidebar:
+  nav: "manual"
+toc: true
+toc_sticky: true
+---
+
+## Generating dictionaries
+
+A dictionary ("reflection database") contains information about the types and functions that are available in a library.
+
+With a dictionary you can call functions inside libraries. Dictionaries are also needed to write a class into a ROOT file (→ see [ROOT files]({{ '/manual/root_files' | relative_url }})).
+
+A dictionary consists of a source file, which contains the type information needed by Cling and ROOT's I/O subsystem. This source file needs to be generated from the library's headers and then compiled, linked and loaded. Only then does Cling and ROOT know what is inside a library.
+
+There are two ways to generate a dictionary:
+
+- using ACLiC
+
+- using `rootcling`
+
+### Using ACLiC to generate dictionaries
+
+With a given header file `MyHeader.h`, ACliC automatically generates a dictionary:
+
+```
+      root[] .L MyHeader.h+
+```
+
+### Using rootcling to generate dictionaries manually
+
+You can manually create a dictionary by using `rootcling`:
+
+{% highlight C++ %}
+   rootcling -f DictOutput.cxx -c OPTIONS Header1.h Header2.h ... Linkdef.h
+{% endhighlight %}
+
+- `DictOutput.cxx` Specifies the output file that will contain the dictionary. It will be accompanied by a header file `DictOutput.h`.
+
+- `OPTIONS` are:
+
+	- `Isomething`: Adding an include path, so that `rootcling` can find the files included in `Header1.h`, `Header2.h`, etc.
+
+    - `DSOMETHING`: Define a preprocessor macro, which is sometimes needed to parse the header files.
+
+- `Header1.h Header2.h...`: The headers files.
+
+- `Linkdef.h`: Tells `rootcling`, which classes should be added to the dictionary, → see [Selecting dictionary entries: Linkdef.h](#selecting-dictionary-entries-linkdefh).
+
+> **Note**
+>
+> Dictionaries that are used within the same project must have unique names.
+>
+> Compiled object files relative to dictionary source files cannot reside in the same library or in two libraries loaded by the same application if the original source files have the same name.
+_**Example**_
+
+In the first step, a `TEvent` and a `TTrack` class is defined. Next an event object is created to add tracks to it. The track objects have a pointer to their event. This shows that the I/O system correctly handles circular references.
+
+In the second step, a `TEvent` and a `TTrack` call are implemented.<br/>After that you can use `rootcling` to manually generate a directory. This generates the `eventdict.cxx` file.
+
+**The TEvent.h header**
+
+{% highlight C++ %}
+#ifndef __TEvent__
+#define __TEvent__
+#include "TObject.h"
+class TCollection;
+class TTrack;
+
+class TEvent : public TObject {
+private:
+   Int_t fId; // Event sequential id
+   Float_t fTotalMom;       // Total momentum.
+   TCollection *fTracks;    // Collection of tracks.
+public:
+   TEvent() { fId = 0; fTracks = 0; }
+   TEvent(Int_t id);
+   ~TEvent();
+   void AddTrack(TTrack *t);
+   Int_t GetId() const { return fId; }
+   Int_t GetNoTracks() const;
+   void Print(Option_t *opt="");
+   Float_t TotalMomentum();
+   ClassDef(TEvent,1);     //Simple event class.
+};
+{% endhighlight %}
+
+**The TTrack.h header**
+
+{% highlight C++ %}
+#ifndef __TTrack __
+#define __TTrack__
+#include "TObject.h"
+
+class TEvent;
+class TTrack : public TObject {
+private:
+   Int_t fId;       // Track sequential id.
+   TEvent *fEvent;  // TEvent to which track belongs.
+   Float_t fPx;     // x part of track momentum.
+   Float_t fPy;     // y part of track momentum.
+   Float_t fPz;     // z part of track momentum.
+public:
+   TTrack() { fId = 0; fEvent = 0; fPx = fPy = fPz = 0; }
+   TTrack(Int_t id, Event *ev, Float_t px,Float_t py,Float_t pz);
+   Float_t Momentum() const;
+   TEvent *GetEvent() const { return fEvent; }
+   void Print(Option_t *opt="");
+   ClassDef (TTrack,1);    //Simple track class.
+};
+{% endhighlight %}
+
+**Implementation of TEvent and TTrack class**
+
+{% highlight C++ %}
+TEvent.cxx:
+#include <iostream.h>
+#include "TOrdCollection.h"
+#include "TEvent.h"
+#include "TTrack.h"
+...
+
+TTrack.cxx:
+#include <iostream.h>
+#include "TMath.h"
+#include "Track.h"
+#include "Event.h"
+...
+{% endhighlight %}
+
+**Using rootcling to generate the dictionary**
+
+{% highlight C++ %}
+rootcling eventdict.cxx -c TEvent.h TTrack.h
+{% endhighlight %}
+
+**eventdict.cxx - the generated dictionary**
+
+{% highlight C++ %}
+void TEvent::Streamer(TBuffer &R__b) {
+
+// Stream an object of class TEvent.
+   if (R__b.IsReading()) {
+      Version_t R__v = R__b.ReadVersion();
+      TObject::(R__b);
+      R__b >> fId;
+      R__b >> fTotalMom;
+      R__b >> fTracks;
+   } else {
+      R__b.WriteVersion(TEvent::IsA());
+      TObject::Streamer(R__b);
+      R__b << fId;
+      R__b << fTotalMom;
+      R__b << fTracks;
+   }
+}
+{% endhighlight %}
+
+## Selecting dictionary entries: Linkdef.h
+
+To select which types and functions should go into a dictionary, create a `Linkdef.h` file that you use when you call `rootcint` manually. The `Linkdef.h` file is passed as the last argument to `rootcint`. It must end on `Linkdef.h, LinkDef.h`, or `linkdef.h`. For example, `My_Linkdef.h` is correct, `Linkdef_mine.h` is not.
+
+The `Linkdef.h` file contains directives for `rootcint`, for what a dictionary should be created: select the types and functions that will be accessible from the prompt (or in general through CINT) and for I/O.
+
+### Preamble: deselection
+
+A `Linkdef.h` file starts with the following preamble:
+
+```
+#ifdef __CINT__
+#pragma link off all globals;
+#pragma link off all classes;
+#pragma link off all functions;
+#pragma link C++ nestedclasses;
+```
+The first line protects the compiler from seeing the `rootcint` directives. The `rootcint` directives are in the form of `#pragma` statements. A `#pragma` link of all _something_ says that by default, `rootcint` should not generate the dictionary for anything it sees.
+
+The nested classes directive tells `rootcint` not to ignore `nestedclasses`, this is, classes defined inside classes like here:
+
+```
+class Outer {
+public:
+  class Inner {
+  public:
+    // we want a dictionary for this one, too!
+    ...
+  };
+  ...
+};
+```
+
+
+### Selection
+
+In the next step, tell `rootcint` for which objects the dictionary should be generated for:
+
+```
+#pragma link C++ class AliEvent+;
+#pragma link C++ function StrDup;
+#pragma link C++ function operator+(const TString&amp;,const TString&amp;);
+#pragma link C++ global gROOT;
+#pragma link C++ global gEnv;
+#pragma link C++ enum EMessageTypes;
+```
+
+
+> **Note**
+>
+> **The `+` after the class name: This enables an essential feature for `rootcint`. It is not a default setting, so you must add `+`at the end.
+
+### Selection by file name
+
+Sometimes it is easier to say: Create a dictionary for everything defined in the `MyHeader.h` file.
+<br>Write the following statement into the `Linkdef.h` file:
+
+```
+#pragma link C++ defined_in "subdir/MyHeader.h";
+```
+
+Make sure that `subdir/MyHeader.h` corresponds to one of the header files that is passed to `rootcint`.
+
+### Closing
+
+Add the following line at the end of the `Linkdef.h` file:
+
+```
+#endif /* __CINT__ */.
+```
+
+### Example of a Linkdef.h file
+
+```
+#ifdef __CINT__
+#pragma link off all globals;
+#pragma link off all classes;
+#pragma link off all functions;
+#pragma link C++ nestedclasses;
+#pragma link C++ global gHtml;
+#pragma link C++ class THtml;
+#endif
+```
+
+
+## Embedding the rootcling call into a GNU Makefile
+
+Use the following statement to compile and run the code.
+
+```
+.L MyCode.C+
+```
+
+If you need to use a Makefile, there is the following rule for generating a dictionary (see code snippet below). It will create a new source file, which you should
+compile like all the other sources in your library. In addition, you need to
+add the include path for ROOT, and you might have to link against ROOT's libraries: `libCore`.
+
+This rule generates the `rootcling` dictionary for the headers `$(HEADERS)` and a library
+containing the dictionary and the compiled `$(SOURCES)`:
+
+```
+MyDict.cxx: $(HEADERS) Linkdef.h
+[TAB]     rootcling -f $@ -c $(CXXFLAGS) -p $^
+libMyLib.so: MyDict.cxx $(SOURCES)
+[TAB]     g++ -shared -o$@ `root-config --ldflags` $(CXXFLAGS) -I$(ROOTSYS)/include $^
+```

--- a/manual/root_macros_and_shared_libraries/index.md
+++ b/manual/root_macros_and_shared_libraries/index.md
@@ -13,7 +13,7 @@ ROOT objects (→ see [ROOT classes, data types and global variables]({{ '/manua
 
 You can save a ROOT macro in a file and execute it at the ROOT prompt or the system prompt (→ see [Creating ROOT macros](#creating-root-macros)).
 
-You also can compile a ROOT macro (→ see [Compiling ROOT macros](#compiling-root-macros)).
+You also can compile a ROOT macro with ACLiC (→ see [Compiling ROOT macros with ACLiC](#compiling-root-macros-with-aclic)).
 
 ROOT provides many tutorials that are available as ROOT macros (→ see [ROOT tutorial page](https://root.cern/doc/master/group__Tutorials.html)).
 
@@ -24,7 +24,7 @@ The name of the ROOT macro and the file name (without file extension) in which t
 
 1. Create a new file in your preferred text editor.
 
-2. Use the following general structure for the ROOT macro:
+2. Use the following general structure for the ROOT macro, preferably with a function that has the same name as the file:
 
 {% highlight C++ %}
       void MacroName() {
@@ -40,41 +40,39 @@ The name of the ROOT macro and the file name (without file extension) in which t
 
 ### Executing ROOT macros
 
-You can execute a ROOT macro:
+You can execute a ROOT macro in one of three ways:
 
-  - at the system prompt,
-  - at the ROOT prompt,
-  - by loading it to a ROOT session.
 
-To execute a ROOT macro at the system prompt, type:
+1. Execute a ROOT macro at the system prompt:
 
    ```
-   root MacroName.C
+   $ root MacroName.C
    ```
 
--- or --
-
-To execute a ROOT macro at the ROOT prompt, type:
+2. Execute a macro at the ROOT prompt:
 
    ```
-   .x MacroName.C
+   root [0] .x MacroName.C
    ```
 
--- or --
-
-To load a ROOT macro to a ROOT session, type (at the ROOT prompt):
+3. Load a macro from within a ROOT session and then call the function:
 
    ```
-   .L MacroName.C
-   MacroName()
+   root [0] .L MacroName.C
+   root [1] MacroName()
    ```
 
-> **Note**
->
-> You can load multiple ROOT macros, as each ROOT macro has a unique name in the ROOT name space.
+   > **Note**
+   >
+   > You can load multiple ROOT macros, as each ROOT macro has a unique name in the ROOT namespace.
 
-In addition, you can:
- - [execute a ROOT macro from a ROOT macro](#executing-a-ROOT-macro-from-a ROOT-macro)
+It is also possible to pass parameters directly to the macro function:
+```
+$ root 'MacroName.C("some String", 12)'
+```
+
+In addition, you can execute a ROOT macro from a ROOT macro.
+
  - [execute a ROOT macro from the invocation of ROOT](#executing-a-root-macro-from-the-invocation-of-root)
 
 <p><a name="executing-a-ROOT-macro-from-a ROOT-macro"></a></p>
@@ -100,33 +98,21 @@ The example {% include tutorial name="cernstaff" %} calls a ROOT macro to build 
    }
 {% endhighlight %}
 
-<p><a name="executing-a-root-macro-from-the-invocation-of-root"></a></p>
-**Executing a ROOT macro from the invocation of ROOT**
 
-You can pass a macro to ROOT in its invocation.
+## Compiling ROOT macros with ACLiC
 
-_**Example**_
+ROOT macros are by default just-in-time compiled with Cling based on the Clang compiler. Alternatively, you can use ACLiC to compile your macro from within a ROOT session to a shard library using the system compiler such as gcc.
 
-The exact kind of quoting depends on the used shell. This example works for bash-like shells.
-
-```
-   $ root -l -b 'myCode.C("some String", 12)'
-```
-
-## Compiling ROOT macros
-
-You can use ACLiC (*Compiling Your Code*) to compile your code and to build a dictionary and a shared library from your ROOT macro. ACliC is implemented in [TSystem::CompileMacro()](https://root.cern/doc/master/classTSystem.html).
-
-When using ACliC, ROOT checks what library really needs to be build and calls your system's C++ compiler, linker and dictionary generator. Then ROOT loads a native shared library.
+ACLiC is implemented in [TSystem::CompileMacro()](https://root.cern/doc/master/classTSystem.html#ac557d8f24d067a9b89d2b8fb261d7e18). When using ACLiC, ROOT checks what library really needs to be build and calls your system's C++ compiler, linker and dictionary generator.
 
 ACLiC executes the following steps:
 
-1. Calls `rootcling` to create automatically a dictionary.
+1. Calling `rootcling` to create automatically a dictionary.
 <br/>For creating a dictionary manually, → see [Using rootcling to generate dictionaries manually](#using-rootcling-to-generate-dictionaries-manually).
 
-2. Calls the the system's C++ compiler to build the shared library.
+2. Calling the system's C++ compiler to build the shared library.
 
-3. If there are errors, it calls the C++ compiler to build a dummy executable to clearly report the unresolved symbols.
+3. Load the shared library and optionally execute the macro.
 
 ACLiC adds the classes and functions declared in included files with the same name as the
 ROOT macro files with one of following extensions: `.h`, `.hh`, `.hpp`, `.hxx`,` .hPP`, `.hXX`.
@@ -136,14 +122,13 @@ library by using `#include` statements; you will need to compile each ROOT macro
 ### Compiling a ROOT macro with ACLiC
 
 Before you can compile your interpreted ROOT macro, you need to add the include statements for
-the classes used in the ROOT macro. Only then you can build and load a shared library containing
-your ROOT macro.
+the classes used in the ROOT macro. Only then you can build and load a shared library containing your ROOT macro.
 
 You can compile a ROOT macro with:
 
   - default optimizations
 
-  - optimizations
+  - different optimizations
 
   - debug symbols
 
@@ -156,7 +141,7 @@ Compilation ensures that the shared library is rebuilt.
 To compile a ROOT macro and build a shared library, type:
 
 ```
-   root[] .L MyScript.C+
+root [0] .L MyScript.C+
 ```
 
 The `+` option compiles the code and generates a shared library. The name of the shared library is the filename
@@ -168,28 +153,24 @@ _**Example**_
 On most platforms, `hsimple.cxx` will generate `hsimple_cxx.so`.
 
 The `+` command rebuilds the library only if the ROOT macro or any of the files it includes
-are newer than the library.
-
-When checking the timestamp, ACLiC generates a dependency file, which name is the same as
-the library name, just replacing the `so` extension by the `d` extension.
-
-
-To compile a ROOT macro with default optimizations, type:
+are newer than the library. To force recompiling the library in any case, use `++`:
 
 ```
-      root[] .L MyScript.C++g
+root [0] .L MyScript.C++
 ```
 
-To compile a ROOT macro with optimizations, type:
+By default, the library will be built with the same optimizations as your ROOT libraries.
+
+To force compilation with optimizations, type:
 
 ```
-      root[] .L MyScript.C++O
+root [0] .L MyScript.C+O
 ```
 
-To compile a ROOT macro with debug symbols, type:
+To force compilation with debug symbols, type:
 
 ```
-      root[] .L MyScript.C++
+root [0] .L MyScript.C+g
 ```
 
 ### Setting the include path
@@ -199,281 +180,37 @@ The `$ROOTSYS/include` directory is automatically appended to the include path.
 To get the include path, type:
 
 ```
-   root[] .include
+root [0] .include
 ```
 
 To append the include path, type:
 
 ```
-   root[] .include $HOME/mypackage/include
+root [0] .include $HOME/mypackage/include
 ```
 
-Append the following line in the ROOT macro to include the include path:
+Add the following line in the ROOT macro to append a new path to the existing include paths:
 
 ```
-   gSystem->AddIncludePath(" -I$HOME/mypackage/include")
+gSystem->AddIncludePath(" -I$HOME/mypackage/include")
 ```
 
 To overwrite an existing include path, type:
 
 ```
-   gSystem->SetIncludePath(" -I$HOME/mypackage/include")
+gSystem->SetIncludePath(" -I$HOME/mypackage/include")
 ```
 
 To add a static library that should be used during linking, type:
 
 ```
-   gSystem->AddLinkedLibs("-L/my/path -l*anylib*");
+gSystem->AddLinkedLibs("-L/my/path -l*anylib*");
 ```
 
 For adding a shared library, you can load it before you compile the ROOT macros, by
 
 ```
-   gSystem->Load("mydir/mylib");
-```
-
-
-## Generating dictionaries
-
-A dictionary ("reflection database") contains information about the types and functions that are available in a library.
-
-With a dictionary you can call functions inside libraries. Dictionaries are also needed to write a class into a ROOT file (→ see [ROOT files]({{ '/manual/root_files' | relative_url }})).
-
-A dictionary consists of a source file, which contains the type information needed by Cling and ROOT's I/O subsystem. This source file needs to be generated from the library's headers and then compiled, linked and loaded. Only then does Cling and ROOT know what is inside a library.
-
-There are two ways to generate a dictionary:
-
-- using ACLiC
-
-- using `rootcling`
-
-### Using ACLiC to generate dictionaries
-
-With a given header file `MyHeader.h`, ACliC automatically generates a dictionary:
-
-```
-      root[] .L MyHeader.h+
-```
-
-### Using rootcling to generate dictionaries manually
-
-You can manually create a dictionary by using `rootcling`:
-
-{% highlight C++ %}
-   rootcling -f DictOutput.cxx -c OPTIONS Header1.h Header2.h ... Linkdef.h
-{% endhighlight %}
-
-- `DictOutput.cxx` Specifies the output file that will contain the dictionary. It will be accompanied by a header file `DictOutput.h`.
-
-- `OPTIONS` are:
-
-	- `Isomething`: Adding an include path, so that `rootcling` can find the files included in `Header1.h`, `Header2.h`, etc.
-
-    - `DSOMETHING`: Define a preprocessor macro, which is sometimes needed to parse the header files.
-
-- `Header1.h Header2.h...`: The headers files.
-
-- `Linkdef.h`: Tells `rootcling`, which classes should be added to the dictionary, → see [Selecting dictionary entries: Linkdef.h](#selecting-dictionary-entries-linkdefh).
-
-> **Note**
->
-> Dictionaries that are used within the same project must have unique names.
->
-> Compiled object files relative to dictionary source files cannot reside in the same library or in two libraries loaded by the same application if the original source files have the same name.
-
-_**Example**_
-
-In the first step, a `TEvent` and a `TTrack` class is defined. Next an event object is created to add tracks to it. The track objects have a pointer to their event. This shows that the I/O system correctly handles circular references.
-
-In the second step, a `TEvent` and a `TTrack` call are implemented.<br/>After that you can use `rootcling` to manually generate a directory. This generates the `eventdict.cxx` file.
-
-**The TEvent.h header**
-
-{% highlight C++ %}
-#ifndef __TEvent__
-#define __TEvent__
-#include "TObject.h"
-class TCollection;
-class TTrack;
-
-class TEvent : public TObject {
-private:
-   Int_t fId; // Event sequential id
-   Float_t fTotalMom;       // Total momentum.
-   TCollection *fTracks;    // Collection of tracks.
-public:
-   TEvent() { fId = 0; fTracks = 0; }
-   TEvent(Int_t id);
-   ~TEvent();
-   void AddTrack(TTrack *t);
-   Int_t GetId() const { return fId; }
-   Int_t GetNoTracks() const;
-   void Print(Option_t *opt="");
-   Float_t TotalMomentum();
-   ClassDef(TEvent,1);     //Simple event class.
-};
-{% endhighlight %}
-
-**The TTrack.h header**
-
-{% highlight C++ %}
-#ifndef __TTrack __
-#define __TTrack__
-#include "TObject.h"
-
-class TEvent;
-class TTrack : public TObject {
-private:
-   Int_t fId;       // Track sequential id.
-   TEvent *fEvent;  // TEvent to which track belongs.
-   Float_t fPx;     // x part of track momentum.
-   Float_t fPy;     // y part of track momentum.
-   Float_t fPz;     // z part of track momentum.
-public:
-   TTrack() { fId = 0; fEvent = 0; fPx = fPy = fPz = 0; }
-   TTrack(Int_t id, Event *ev, Float_t px,Float_t py,Float_t pz);
-   Float_t Momentum() const;
-   TEvent *GetEvent() const { return fEvent; }
-   void Print(Option_t *opt="");
-   ClassDef (TTrack,1);    //Simple track class.
-};
-{% endhighlight %}
-
-**Implementation of TEvent and TTrack class**
-
-{% highlight C++ %}
-TEvent.cxx:
-#include <iostream.h>
-#include "TOrdCollection.h"
-#include "TEvent.h"
-#include "TTrack.h"
-...
-
-TTrack.cxx:
-#include <iostream.h>
-#include "TMath.h"
-#include "Track.h"
-#include "Event.h"
-...
-{% endhighlight %}
-
-**Using rootcling to generate the dictionary**
-
-{% highlight C++ %}
-rootcling eventdict.cxx -c TEvent.h TTrack.h
-{% endhighlight %}
-
-**eventdict.cxx - the generated dictionary**
-
-{% highlight C++ %}
-void TEvent::Streamer(TBuffer &R__b) {
-
-// Stream an object of class TEvent.
-   if (R__b.IsReading()) {
-      Version_t R__v = R__b.ReadVersion();
-      TObject::(R__b);
-      R__b >> fId;
-      R__b >> fTotalMom;
-      R__b >> fTracks;
-   } else {
-      R__b.WriteVersion(TEvent::IsA());
-      TObject::Streamer(R__b);
-      R__b << fId;
-      R__b << fTotalMom;
-      R__b << fTracks;
-   }
-}
-{% endhighlight %}
-
-## Selecting dictionary entries: Linkdef.h
-
-To select which types and functions should go into a dictionary, create a `Linkdef.h` file that you use when you call `rootcint` manually. The `Linkdef.h` file is passed as the last argument to `rootcint`. It must end on `Linkdef.h, LinkDef.h`, or `linkdef.h`. For example, `My_Linkdef.h` is correct, `Linkdef_mine.h` is not.
-
-The `Linkdef.h` file contains directives for `rootcint`, for what a dictionary should be created: select the types and functions that will be accessible from the prompt (or in general through CINT) and for I/O.
-
-### Preamble: deselection
-
-A `Linkdef.h` file starts with the following preamble:
-
-```
-#ifdef __CINT__
-#pragma link off all globals;
-#pragma link off all classes;
-#pragma link off all functions;
-#pragma link C++ nestedclasses;
-```
-The first line protects the compiler from seeing the `rootcint` directives. The `rootcint` directives are in the form of `#pragma` statements. A `#pragma` link of all _something_ says that by default, `rootcint` should not generate the dictionary for anything it sees.
-
-The nested classes directive tells `rootcint` not to ignore `nestedclasses`, this is, classes defined inside classes like here:
-
-```
-class Outer {
-public:
-  class Inner {
-  public:
-    // we want a dictionary for this one, too!
-    ...
-  };
-  ...
-};
-```
-
-
-### Selection
-
-In the next step, tell `rootcint` for which objects the dictionary should be generated for:
-
-```
-#pragma link C++ class AliEvent+;
-#pragma link C++ function StrDup;
-#pragma link C++ function operator+(const TString&amp;,const TString&amp;);
-
-#pragma link C++ global gROOT;
-#pragma link C++ global gEnv;
-
-#pragma link C++ enum EMessageTypes;
-```
-
-
-> **Note**
->
-> **The `+` after the class name: This enables an essential feature for `rootcint`. It is not a default setting, so you must add `+`at the end.
-
-
-### Selection by file name
-
-Sometimes it is easier to say: Create a dictionary for everything defined in the `MyHeader.h` file.
-<br>Write the following statement into the `Linkdef.h` file:
-
-```
-#pragma link C++ defined_in "subdir/MyHeader.h";
-```
-
-Make sure that `subdir/MyHeader.h` corresponds to one of the header files that is passed to `rootcint`.
-
-### Closing
-
-Add the following line at the end of the `Linkdef.h` file:
-
-```
-#endif /* __CINT__ */.
-
-```
-
-### Example of a Linkdef.h file
-
-```
-#ifdef __CINT__
-
-#pragma link off all globals;
-#pragma link off all classes;
-#pragma link off all functions;
-#pragma link C++ nestedclasses;
-
-#pragma link C++ global gHtml;
-
-#pragma link C++ class THtml;
-#endif
+gSystem->Load("mydir/mylib");
 ```
 
 
@@ -556,28 +293,3 @@ If you try this, `rootcling` and compiling will be error free. However, instanti
 `subTree` object from the Cling command line will cause a fatal error.
 
 In general, it is recommended to let `rootcling` see as many header files as possible.
-
-
-## Embedding the rootcling call into a GNU Makefile
-
-Use the following statement to compile and run the code.
-
-```
-.L MyCode.C+
-```
-
-If you need to use a Makefile, there is the following rule for generating a dictionary (see code snippet below). It will create a new source file, which you should
-compile like all the other sources in your library. In addition, you need to
-add the include path for ROOT, and you might have to link against ROOT's libraries: `libCore`.
-
-This rule generates the `rootcling` dictionary for the headers `$(HEADERS)` and a library
-containing the dictionary and the compiled `$(SOURCES)`:
-
-```
-MyDict.cxx: $(HEADERS) Linkdef.h
-[TAB]     rootcling -f $@ -c $(CXXFLAGS) -p $^
-
-libMyLib.so: MyDict.cxx $(SOURCES)
-[TAB]     g++ -shared -o$@ `root-config --ldflags` $(CXXFLAGS) -I$(ROOTSYS)/include $^
-```
-

--- a/manual/root_macros_and_shared_libraries/index.md
+++ b/manual/root_macros_and_shared_libraries/index.md
@@ -108,7 +108,7 @@ ACLiC is implemented in [TSystem::CompileMacro()](https://root.cern/doc/master/c
 ACLiC executes the following steps:
 
 1. Calling `rootcling` to create automatically a dictionary.
-<br/>For creating a dictionary manually, → see [Using rootcling to generate dictionaries manually](#using-rootcling-to-generate-dictionaries-manually).
+<br/>For creating a dictionary manually, → see [Using rootcling to generate dictionaries manually]({{ '/manual/root_io/#using-rootcling-to-generate-dictionaries-manually' | relative_url }}).
 
 2. Calling the system's C++ compiler to build the shared library.
 


### PR DESCRIPTION
  * rewrite first part about ROOT macros and ACLiC

  * remove dictionary/cling part to be added back later in functional
    I/O manual