### PR TITLE
Make the front page more responsive...

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,7 +25,7 @@ feature_row:
     <center>
     <div style="width: 25%; display:inline-block;">
         <div><a href="{{ '/get_started' | relative_url }}"><img width="128" src="{{'/assets/images/start.svg' | relative_url}}"></a></div>
-        <div style="padding: 20px 0"><font color="#346295" style="font-weight:bold;" size="3">Get Started</font></div>
+        <div style="padding: 20px 0"><font color="#346295" style="font-weight:bold;" size="3">Start</font></div>
     </div><!--
     --><div style="width: 25%; display:inline-block;">
         <div><a href="https://root.cern/doc/master/index.html"><img width="128" src="{{'/assets/images/doc.svg' | relative_url}}"></a></div>
@@ -33,7 +33,7 @@ feature_row:
     </div><!--
     --><div style="width: 25%; display:inline-block;">
         <div><a href="https://root-forum.cern.ch"><img width="128" src="{{'/assets/images/forum.svg' | relative_url}}"></a></div>
-        <div style="padding: 20px 0"><font color="#346295" style="font-weight:bold;" size="3">Forum & Help</font></div>
+        <div style="padding: 20px 0"><font color="#346295" style="font-weight:bold;" size="3">Forum</font></div>
     </div><!--
     --><div style="width: 25%; display:inline-block;">
         <div><a href="{{ '/gallery' | relative_url }}"><img width="128" src="{{'/assets/images/gallery.svg' | relative_url}}"></a></div>


### PR DESCRIPTION
... by shortening the titles below the icons in order to avoid mis alignments.
This problem was pointed in this issue: 
https://github.com/root-project/web/issues/257