### PR TITLE
Revise "Editing the ROOT web site"

### DIFF
--- a/for_developers/web/index.md
+++ b/for_developers/web/index.md
@@ -66,7 +66,13 @@ new branch with your work, which you can use to create a pull request to update
    in the `web` directory, does it:
 ```
 bundle install
-```  
+```
+If you'd rather install the packages in a local directory, configure `bundle` to do so
+before running `bundle install`. This can be done with:
+```
+bundle config set --local path 'vendor/bundle'
+```
+
 7. Build the site and make it available on a local server.
 ```
 bundle exec jekyll serve --baseurl="/base"

--- a/for_developers/web/index.md
+++ b/for_developers/web/index.md
@@ -41,7 +41,7 @@ gem install jekyll bundler
 
 3. Get the ROOT web site source from GitHub.
 ```
-git clone https://github.com/root-project/web.git web
+git clone https://github.com/root-project/web.git
 ```
 You can also clone a forked copy from you own GitHub as explained in the
 [section on getting the sources](#get-the-root-web-site-sources)

--- a/for_developers/web/index.md
+++ b/for_developers/web/index.md
@@ -10,7 +10,7 @@ sidebar:
 The ROOT team has adopted [Jekyll](https://jekyllrb.com/){:target="_blank"} for generating
 the ROOT web site. The ROOT web site uses [a forked copy of the
 "Minimal-Mistakes" theme](https://github.com/root-project/minimal-mistakes){:target="_blank"}.
-Many scripts and functionalities have been added compare to this original theme.
+Many scripts and functionalities have been added compared to this original theme.
 
 This page gives you the instructions to:
 
@@ -81,7 +81,7 @@ This branch is the one from which the official web site is built. You can create
 new branch with your work, which you can use to create a pull request to update
 `root-project/web/main`.
 
-6. Some missing gems might need to be installed. The following command, ran
+6. Some missing gems might need to be installed. The following command, run
    in the `web` directory, does it:
 ```
 bundle install

--- a/for_developers/web/index.md
+++ b/for_developers/web/index.md
@@ -28,7 +28,7 @@ The prerequisites/requirements are the same presented on the
 The install instructions differ a bit from the ones you can find on the
 [Jekyll web site](https://jekyllrb.com/docs/){:target="_blank"}
 as you do not need to create a new web site but instead
-get it from github. So the steps are:
+get it from GitHub. So the steps are:
 
 1. Install a full [Ruby development environment](https://jekyllrb.com/docs/installation/){:target="_blank"}.
 
@@ -39,11 +39,11 @@ get it from github. So the steps are:
 gem install jekyll bundler
 ```
 
-3. Get the ROOT web site source from github.
+3. Get the ROOT web site source from GitHub.
 ```
 git clone https://github.com/root-project/web.git web
 ```
-You can also clone a forked copy from you own github as explained in the
+You can also clone a forked copy from you own GitHub as explained in the
 [section on getting the sources](#get-the-root-web-site-sources)
 
 4. Change into your new directory.
@@ -116,7 +116,7 @@ Once you are happy with your modifications, you can publish them via a
 can either push a branch to your fork of the website repository, and create the pull
 request from your fork to [https://github.com/root-project/web](https://github.com/root-project/web), or
 if you have write access to the `root-project/web` repository, you can directly push a new branch.
-If you create a pull request "inside" `root-project/web`, github can create a preview website, which
+If you create a pull request "inside" `root-project/web`, GitHub can create a preview website, which
 will be served at `https://root.cern/<PRNumber>` (after the build step completes).
 
 When a pull request is merged, [`https://root.cern/`](https://root.cern/) will be updated automatically

--- a/for_developers/web/index.md
+++ b/for_developers/web/index.md
@@ -12,33 +12,11 @@ the ROOT web site. The ROOT web site uses [a forked copy of the
 "Minimal-Mistakes" theme](https://github.com/root-project/minimal-mistakes){:target="_blank"}.
 Many scripts and functionalities have been added compared to this original theme.
 
-This page gives you the instructions to:
-
-1. Get the sources of the ROOT web site and edit them
-2. Generate a local running version of this web site.
-
-## Get the ROOT web site sources
-
-You need to follow the following steps:
-
-1. Make sure have set up git on our system
-2. You should have registered a GitHub account and [forked the ROOT web site repository](https://github.com/root-project/web/fork){:target="_blank"}.
-3. Clone your forked ROOT web repository locally on your machine using:
-```
-git clone https://github.com/<your GitHub username>/web
-```
-
-You now have a copy of the ROOT web site sources from github. You can
-work on them, play with a locally served website (next section), and finally
-create ["Pull Requests"]({{ 'for_developers/creating_pr' | relative_url}})
-to get changes upstream.
-
+This page provides instructions to generate a local running version of this web site.
+The informations presented here are largely inspired from the
+[quick start page of the Jekyll web site](https://jekyllrb.com/docs/){:target="_blank"}.
 
 ## Generate a local running version of the ROOT web site
-
-This section gives you the instructions to generate a local running version
-of the ROOT web site. The informations presented here are largely inspired from the
-[quick start page of the Jekyll web site](https://jekyllrb.com/docs/){:target="_blank"}.
 
 ### Prerequisites
 

--- a/for_developers/web/index.md
+++ b/for_developers/web/index.md
@@ -31,13 +31,11 @@ as you do not need to create a new web site but instead
 get it from GitHub. So the steps are:
 
 1. Install a full [Ruby development environment](https://jekyllrb.com/docs/installation/){:target="_blank"}.
-
 There might be compatibility issues with Ruby 3. If that is the version that comes with your system pacakge manager,
 you can install Ruby 2.7 next to it using tools like `rbenv`.
 
 2. Install Jekyll and [bundler](https://jekyllrb.com/docs/ruby-101/#bundler){:target="_blank"}
-   [gems](https://jekyllrb.com/docs/ruby-101/#gems){:target="_blank"}. This command
-   might need to be run in `sudo` mode.
+   [gems](https://jekyllrb.com/docs/ruby-101/#gems){:target="_blank"}.
 ```
 gem install jekyll bundler
 ```

--- a/for_developers/web/index.md
+++ b/for_developers/web/index.md
@@ -32,6 +32,9 @@ get it from GitHub. So the steps are:
 
 1. Install a full [Ruby development environment](https://jekyllrb.com/docs/installation/){:target="_blank"}.
 
+There might be compatibility issues with Ruby 3. If that is the version that comes with your system pacakge manager,
+you can install Ruby 2.7 next to it using tools like `rbenv`.
+
 2. Install Jekyll and [bundler](https://jekyllrb.com/docs/ruby-101/#bundler){:target="_blank"}
    [gems](https://jekyllrb.com/docs/ruby-101/#gems){:target="_blank"}. This command
    might need to be run in `sudo` mode.

--- a/for_developers/web/index.md
+++ b/for_developers/web/index.md
@@ -1,5 +1,5 @@
 ---
-title: Editing the ROOT web site
+title: Editing the ROOT website
 layout: single
 toc: true
 toc_sticky: true
@@ -8,15 +8,15 @@ sidebar:
 ---
 
 The ROOT team has adopted [Jekyll](https://jekyllrb.com/){:target="_blank"} for generating
-the ROOT web site. The ROOT web site uses [a forked copy of the
+the ROOT website. The ROOT website uses [a forked copy of the
 "Minimal-Mistakes" theme](https://github.com/root-project/minimal-mistakes){:target="_blank"}.
 Many scripts and functionalities have been added compared to this original theme.
 
-This page provides instructions to generate a local running version of this web site.
+This page provides instructions to generate a local running version of this website.
 The informations presented here are largely inspired from the
-[quick start page of the Jekyll web site](https://jekyllrb.com/docs/){:target="_blank"}.
+[quick start page of the Jekyll website](https://jekyllrb.com/docs/){:target="_blank"}.
 
-## Generate a local running version of the ROOT web site
+## Generate a local running version of the ROOT website
 
 ### Prerequisites
 
@@ -26,8 +26,8 @@ The prerequisites/requirements are the same presented on the
 ### Install instructions
 
 The install instructions differ a bit from the ones you can find on the
-[Jekyll web site](https://jekyllrb.com/docs/){:target="_blank"}
-as you do not need to create a new web site but instead
+[Jekyll website](https://jekyllrb.com/docs/){:target="_blank"}
+as you do not need to create a new website but instead
 get it from GitHub. So the steps are:
 
 1. Install a full [Ruby development environment](https://jekyllrb.com/docs/installation/){:target="_blank"}.
@@ -40,7 +40,7 @@ you can install Ruby 2.7 next to it using tools like `rbenv`.
 gem install jekyll bundler
 ```
 
-3. Get the ROOT web site source from GitHub.
+3. Get the ROOT website source from GitHub.
 ```
 git clone https://github.com/root-project/web.git
 ```
@@ -56,7 +56,7 @@ You will notice that the current git branch is `main`
 % git checkout
 Your branch is up to date with 'origin/main'.
 ```
-This branch is the one from which the official web site is built. You can create a
+This branch is the one from which the official website is built. You can create a
 new branch with your work, which you can use to create a pull request to update
 `root-project/web/main`.
 
@@ -97,7 +97,7 @@ similar to `https://127.0.0.1:4000/`.
 
 9. Work on the website.
    Each time you create a new file or save a modified version of a file
-   the server will notice it and will regenerate the web site. You will get an output
+   the server will notice it and will regenerate the website. You will get an output
    similar to:
 ```
 Regenerating: 1 file(s) changed at 2020-02-19 10:40:02
@@ -105,14 +105,14 @@ Regenerating: 1 file(s) changed at 2020-02-19 10:40:02
  Jekyll Feed: Generating feed for posts
               ...done in 9.877795 seconds.
 ```
-once "`... done`" is displayed you can reload the web site from your browser to see your
+once "`... done`" is displayed you can reload the website from your browser to see your
 changes. Remember the `--incremental` can speed up serving times considerably.
 
 It is not necessary to restart the server each time you do a modification except if you
 modify the file `web/_config.yml`
 
 You may notice that the command `bundle exec jekyll serve --baseurl="/base"` generates a folder `_site` in
-the `/path/to/the/directory/web/` folder. This is the html version of the web site. Do not
+the `/path/to/the/directory/web/` folder. This is the html version of the website. Do not
 modify or create files in that folder. This folder is ignored by git.
 
 

--- a/for_developers/web/index.md
+++ b/for_developers/web/index.md
@@ -46,8 +46,8 @@ gem install jekyll bundler
 ```
 git clone https://github.com/root-project/web.git
 ```
-You can also clone a forked copy from you own GitHub as explained in the
-[section on getting the sources](#get-the-root-web-site-sources)
+You can also use your own fork, of course, but see
+[Get modifications upstream](https://github.com/root-project/web/#get-modifications-upstream) below.
 
 4. Change into your new directory.
 ```
@@ -118,9 +118,12 @@ Once you are happy with your modifications, you can publish them via a
 ["Pull Request"]({{ 'for_developers/creating_pr' | relative_url}}). You
 can either push a branch to your fork of the website repository, and create the pull
 request from your fork to [https://github.com/root-project/web](https://github.com/root-project/web), or
-if you have write access to the `root-project/web` repository, you can directly push a new branch.
-If you create a pull request "inside" `root-project/web`, GitHub can create a preview website, which
-will be served at `https://root.cern/<PRNumber>` (after the build step completes).
+if you have write access to the `root-project/web` repository, you can directly push a new branch upstream.
 
-When a pull request is merged, [`https://root.cern/`](https://root.cern/) will be updated automatically
+Note that only pull requests that originate from branches that belong to the upstream repo (not forks) benefit from the
+[test deployment of pull requests](https://github.com/root-project/web/#test-deployment-of-pull-requests): a preview
+website with the changes contained in the PR is served from `https://root.cern/<PRNumber>` after the CI job for the PR
+completes.
+
+When a pull request is merged, [`https://root.cern`](https://root.cern/) will be updated automatically
 after a short while.


### PR DESCRIPTION
- fix some typos and spelling of GitHub, web site vs website
- remove detailed instructions on how to grab a repo from GitHub 
- remove redundant git clone argument
- mention compatibility issues between Jekyll and Ruby 3
- advertise the PR preview feature more clearly
- show how to install bundle packages locally (does not require sudo)
- do not suggest running gem under sudo