### PR TITLE
Fix heading for "Concluding Remarks"

### DIFF
--- a/primer/index.md
+++ b/primer/index.md
@@ -2784,7 +2784,9 @@ The value of A instance is 123.
 
 This example might seem trivial, but it shows a powerful ROOT feature.
 C++ code can be JITted within PyROOT and the entities defined in C++ can be
-transparently used in Python!# Concluding Remarks
+transparently used in Python!
+
+# Concluding Remarks
 
 This is the end of our guided tour for beginners through ROOT. There is
 still a lot coming to mind to be said, but by now you are experienced


### PR DESCRIPTION
See the issue here: https://github.com/root-project/root/issues/9493, which I mistakenly opened in the wrong repo.