### PR TITLE
Apply improvements on the PyROOT manual

### DIFF
--- a/manual/python/index.md
+++ b/manual/python/index.md
@@ -7,16 +7,16 @@ toc: true
 toc_sticky: true
 ---
 
-With PyROOT, ROOT's Python-C++ bindings, you can use ROOT from Python. PyROOT is HEP's entrance to all C++ from Python, for example, for frameworks and their steering code. The PyROOT bindings are *automatic* and *dynamic*: no pre-generation of Python wrappers is necessary.
+PyROOT allows the creation of bindings between Python and C++ in a *dynamic* and *automatic* way. It is HEP's entrance to all C++ from Python, for example, for frameworks and their steering code.
 
-With PyROOT you can access the full ROOT functionality from Python while benefiting from the performance of the ROOT C++ libraries.
+With PyROOT you can access the full ROOT C++ functionality from Python while benefiting from the performance of the ROOT C++ libraries.
 
 PyROOT is compatible with both Python2 (>= 2.7) and Python3.
 
 > The usage of PyROOT requires working knowledge of Python.<br/>
 > For detailed information on Python, refer to the [Python Language Reference](https://docs.python.org/3/reference/){:target="_blank"}.
 
-Together with ROOT 6.22, a major revision of PyROOT has been released. The new PyROOT has extensive support for *modern C++* (it operates on top of [cppyy](https://cppyy.readthedocs.io/){:target="_blank"}), is more *pythonic* and is able to *interoperate* with widely-used Python data-science libraries (for example, [NumPy](https://numpy.org/){:target="_blank"}, [pandas](https://pandas.pydata.org/){:target="_blank"}, [Numba](https://numba.pydata.org/){:target="_blank"}).<br/>Therefore, we strongly recommend to use the new PyROOT.
+Since ROOT 6.22, PyROOT has extensive support for *modern C++* (it operates on top of [cppyy](https://cppyy.readthedocs.io/){:target="_blank"}), is more *pythonic* and is able to *interoperate* with widely-used Python data-science libraries (for example, [NumPy](https://numpy.org/){:target="_blank"}, [pandas](https://pandas.pydata.org/){:target="_blank"}, [Numba](https://numba.pydata.org/){:target="_blank"}).
 
 {% include tutorials name="PyROOT" url="pyroot" %}
 
@@ -32,7 +32,7 @@ Then you can access the ROOT C++ classes, functions, etc. via the `ROOT` module.
 
 _**Example**_
 
-This examples shows how you can create a histogram (an instance of the {% include ref class="TH1F" %} class) and randomly fill it with a gaussian distribution.
+This example shows how you can create a histogram (an instance of the {% include ref class="TH1F" %} class) and randomly fill it with a gaussian distribution.
 
 ```python
 h = ROOT.TH1F("myHist", "myTitle", 64, -4, 4)
@@ -41,7 +41,7 @@ h.FillRandom("gaus")
 
 ## Interactive graphics
 
-Just like from C++, you can also create interactive ROOT graphics from Python with PyROOT.
+Just like from the ROOT command prompt, you can also create interactive ROOT graphics with PyROOT.
 
 _**Example**_
 
@@ -72,7 +72,7 @@ Besides being the entry point to all ROOT functionality, the `ROOT` module also 
 
 ### Configuration options
 
-After importing the ROOT module, you can access the PyROOT configuration object as `ROOT.PyConfig`. Such an object has a set of properties that you can modify to steer the behaviour of PyROOT. For the configuration to be taken into account, it needs to be applied right after the `ROOT` module is imported.
+After importing the ROOT module, you can access the PyROOT configuration object as `ROOT.PyConfig`. This object has a set of properties that you can modify to steer the behaviour of PyROOT. For the configuration to be taken into account, it needs to be applied right after the `ROOT` module is imported.
 
 _**Example**_
 
@@ -86,21 +86,21 @@ The available configuration options are:
 
 - `DisableRootLogon` (default `False`): Just like in C++, PyROOT also supports [rootlogon](https://root.cern/doc/master/rootlogon_8C.html){:target="_blank"}. When PyROOT starts, it looks for a file called `.rootlogon.py` in the user's home directory. If such file exists, PyROOT imports it. You can use it to make some settings every time PyROOT is launched, for example, defining some style for your plots:
 
-```python
-# Content of .rootlogon.py
-import ROOT
-myStyle = ROOT.TStyle('MyStyle','My graphics style')
-myStyle.SetCanvasColor(ROOT.kBlue) # My canvases are blue!
-ROOT.gROOT.SetStyle('MyStyle')
-```
+    ```python
+    # Content of .rootlogon.py
+    import ROOT
+    myStyle = ROOT.TStyle('MyStyle','My graphics style')
+    myStyle.SetCanvasColor(ROOT.kBlue) # My canvases are blue!
+    ROOT.gROOT.SetStyle('MyStyle')
+    ```
 
-If PyROOT cannot find `.rootlogon.py` in the user's home directory, it looks for the equivalent in C++ (`.rootlogon.C`), first in [ROOT's etc directory](https://root.cern/doc/master/classTROOT.html#ab8e51627a12d886d6c8177b46481352a){:target="_blank"}, then in the user's home directory and finally in the current working directory.
+    If PyROOT cannot find `.rootlogon.py` in the user's home directory, it looks for the equivalent in C++ (`.rootlogon.C`), first in [ROOT's etc directory](https://root.cern/doc/master/classTROOT.html#ab8e51627a12d886d6c8177b46481352a){:target="_blank"}, then in the user's home directory and finally in the current working directory.
 
-Note that it is also possible to use both the Python and the C++ rootlogons, since the latter can be loaded from the former, for example with `ROOT.gROOT.LoadMacro('.rootlogon.C')`.
+    Note that it is also possible to use both the Python and the C++ rootlogons, since the latter can be loaded from the former, for example with `ROOT.gROOT.LoadMacro('.rootlogon.C')`.
 
-If you want to disable the rootlogon functionality, set `PyConfig.DisableRootLogon` to `True`.
+    If you want to disable the rootlogon functionality, set `PyConfig.DisableRootLogon` to `True`.
 
-- `IgnoreCommandLineOptions` (default `True`): If a PyROOT script is run with some command line arguments, ROOT ignores them by default, so you can process them as you wish. However, by setting `PyConfig.IgnoreCommandLineOptions` to `False`, those arguments are forwarded to ROOT for parsing, for example, to enable the batch mode from the command line.<br/>For a complete list of the arguments accepted by ROOT, → see [Starting ROOT with command line options]({{ '/manual/first_steps_with_root/#command-line-options' | relative_url }}).
+- `IgnoreCommandLineOptions` (default `True`): If a PyROOT script is run with some command line arguments, ROOT ignores them by default, so you can process them as you wish. However, by setting `PyConfig.IgnoreCommandLineOptions` to `False`, those arguments are forwarded to ROOT for parsing, for example, to enable the batch mode from the command line.<br/>For a complete list of the arguments accepted by ROOT, see [Starting ROOT with command line options]({{ '/manual/first_steps_with_root/#command-line-options' | relative_url }}).
 
 - `ShutDown` (default `True`): When the application is finished, more precisely during PyROOT's cleanup phase, the ROOT C++ interpreter is shut down by default.<br/>If PyROOT is executed as part of a longer-running application that needs the C++ interpreter, you can set `PyConfig.ShutDown` to `False` to prevent that shutdown.
 
@@ -110,14 +110,14 @@ If you want to disable the rootlogon functionality, set `PyConfig.DisableRootLog
 
 When running in batch mode, PyROOT does not display any graphics. You can activate the batch mode as follows:
 
-1. Pass `-b` as a command line argument, for example, `python -b my_pyroot_script.py`.<br/>For this to work, you must set `PyConfig.IgnoreCommandLineOptions` to `False` inside the PyROOT script, see → [Configuration options]({{ '/manual/python/#configuration-options' | relative_url }}).
+1. Pass `-b` as a command line argument, for example, `python -b my_pyroot_script.py`.<br/>For this to work, you must set `PyConfig.IgnoreCommandLineOptions` to `False` inside the PyROOT script, see [Configuration options]({{ '/manual/python/#configuration-options' | relative_url }}).
 
-2. Call `gROOT.SetBatch` in the PyROOT script, right after importing `ROOT`:
+2. Call `gROOT.SetBatch` in the PyROOT script, *right after* importing `ROOT`:
 
-```python
-import ROOT
-ROOT.gROOT.SetBatch(True)
-```
+    ```python
+    import ROOT
+    ROOT.gROOT.SetBatch(True)
+    ```
 
 ### Low-level manipulation of objects
 
@@ -128,24 +128,24 @@ You can access these functions with the `ROOT.NameOfFunction` pattern as follows
 
 - `addressof(obj, field, byref)`: Similarly to `AddressOf`, you can use it to obtain the address of an internal C++ object from its Python proxy. However, `addressof` returns that address as an integer, not as an indexable buffer. Furthermore, `addressof` accepts two more parameters: `field` and `byref`. You can use `field` to specify the name of a field in a struct, in order to get the address of that field. If you set `byref` to `True`, `addressof` returns the address of the address of the C++ object. This function is equivalent to [cppyy's `addressof`](https://cppyy.readthedocs.io/en/latest/lowlevel.html#capsules).
 
-_**Example**_
+    _**Example**_
 
-```python
->>> import ROOT
->>> ROOT.gInterpreter.Declare("struct MyStruct { int foo; float bar; };")
-True
->>> mys = ROOT.MyStruct()
->>> ROOT.addressof(mys) # Address of mys' C++ object
-94352024283040L
->>> ROOT.addressof(mys, 'foo') # Address of "foo" field (same as address of object)
-94352024283040L
->>> ROOT.addressof(mys, 'bar') # Address of "bar" field
-94352024283044L
->>> ROOT.addressof(mys, byref = True) # Address of address of mys' C++ object
-140376843834640L
-```
+    ```python
+    >>> import ROOT
+    >>> ROOT.gInterpreter.Declare("struct MyStruct { int foo; float bar; };")
+    True
+    >>> mys = ROOT.MyStruct()
+    >>> ROOT.addressof(mys) # Address of mys' C++ object
+    94352024283040L
+    >>> ROOT.addressof(mys, 'foo') # Address of "foo" field (same as address of object)
+    94352024283040L
+    >>> ROOT.addressof(mys, 'bar') # Address of "bar" field
+    94352024283044L
+    >>> ROOT.addressof(mys, byref = True) # Address of address of mys' C++ object
+    140376843834640L
+    ```
 
-Moreover, you can use `addressof` in conjunction with `TTree::Branch` from Python as shown in [ttree_branch.py](https://github.com/root-project/root/blob/d1d035e17b9b8dd97bcd146dd6e0c84a0d1aa4a1/bindings/pyroot/pythonizations/test/ttree_branch.py#L134).
+    Moreover, you can use `addressof` in conjunction with `TTree::Branch` from Python as shown in [ttree_branch.py](https://github.com/root-project/root/blob/d1d035e17b9b8dd97bcd146dd6e0c84a0d1aa4a1/bindings/pyroot/pythonizations/test/ttree_branch.py#L134).
 
 - `AsCObject`: Equivalent to [cppyy's `as_cobject`](https://cppyy.readthedocs.io/en/latest/lowlevel.html#capsules){:target="_blank"}.
 
@@ -154,6 +154,93 @@ Moreover, you can use `addressof` in conjunction with `TTree::Branch` from Pytho
 - `MakeNullPointer(class_proxy)`: Equivalent to `BindObject(0, class_proxy)`, it returns a proxy object of the class represented by `class_proxy` that is bound to a C++ null pointer.<br/>For example, `MakeNullPointer(TTree)` returns a `TTree` proxy object that internally points to null. This function is kept for backwards compatibility with old PyROOT versions.
 
 - `SetOwnership(obj, python_owns)`: A Python proxy can either own or not own its internal C++ object. If a Python proxy owns its C++ object and the proxy is being destroyed, the C++ object is deleted too. This ownership can be modified for a given Python proxy with `SetOwnership`.<br>For example, by calling `SetOwnership(obj, False)`, you make sure that the C++ object proxied by `obj` is not deleted by PyROOT when `obj` is garbage collected. This is useful for example, if you know that the deletion will happen in C++ and you want to prevent a double delete.<br/>Use this functionality with care not to produce any memory leaks.
+
+## Creating C++ templated class instances
+
+You can create an instance of any C++ templated class. Remember to instatiate the template first, before creating the object instance.
+
+Below you can find an example of instantiating an `std::vector`.
+
+_**Example**_
+
+```python
+>>> import ROOT
+>>> v = ROOT.std.vector[int]()
+>>> for i in range(0, 10):
+...    v.push_back(i)
+...
+>>> for i in v:
+...     print(i, end=' ')
+1 2 3 4 5 6 7 8 9
+>>>
+>>> list(v)
+[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+>>>
+```
+
+The parameters to the template instantiation can either be an actual type or value (as is used here, `int`), or a string representation of the parameters (e.g. `'double'`), or a mixture of both (e.g. `'TCanvas, 0'` or `'double', 0` ).
+
+## Passing Python callables to C++
+
+It is possible to pass a Python callable to a C++ callable (e.g. a function) that expects an `std::function` or a function pointer.
+
+_**Example**_
+
+```python
+import ROOT
+
+ROOT.gInterpreter.Declare("""
+    void call_with_1(const std::function<void(int)> &f) { f(1); }
+    """)
+
+def print_arg(x):
+    print(x)
+
+ROOT.call_with_1(print_arg)  # prints 1
+```
+
+A common usecase is to construct objects of the `TF{1,2,3}` family of classes with Python functions as arguments, which allows to perform operations as plotting and fitting of histograms with such functions.
+
+The signature of the Python callable must accept exactly two arrays. The first array contains the `x`, `y`, `z`, and `t` values for the call; the second array contains the values that parameterize the function. For more details, see the {% include ref class="TF1" %} documentation and the examples below.
+
+_**Example**_
+
+This is an example of a parameterless Python function that is plotted on a default canvas:
+
+```python
+import ROOT
+
+def identity(arr, par):
+    return arr[0]
+
+# create an identity function
+f = ROOT.TF1('pyf1', identity, -1., 1.)
+
+# plot the function
+c = ROOT.TCanvas()
+f.Draw()
+```
+
+The following is an example of a parameterized Python callable instance that is plotted on a default canvas:
+
+```python
+import ROOT
+
+class Linear:
+    def __call__(self, arr, par):
+        return par[0] + arr[0]*par[1]
+
+# create a linear function with offset 5, and pitch 2
+l = Linear()
+f = ROOT.TF1('pyf2', l, -1., 1., 2)
+f.SetParameters(5., 2.)
+
+# plot the function
+c = ROOT.TCanvas()
+f.Draw()
+```
+
+Note that this time the constructor is told that there are two parameters, and note in particular how these parameters are set. It is also possible to keep the parameters as data members of the callable instance and use and set them directly from Python.
 
 ## Loading user libraries and Just-In-Time compilation (JITting)
 
@@ -275,52 +362,31 @@ x = ROOT.f(3)  # x = 9
 ### Loading C++ libraries with dictionaries
 
 For larger analysis frameworks, one may not want to compile the headers each time the Python interpreter is started. One may also
-want to read or write custom C++/C objects in ROOT files, and use them with [RDataFrame](https://root.cern/doc/master/classROOT_1_1RDataFrame.html){:target="_blank"} or similar tools.
+want to read or write custom C++/C objects in ROOT files, and use them with {% include ref class="RDataFrame" namespace="ROOT" %} or similar tools.
 
-A large analysis framework might further have multiple libraries. In these cases, you generate [ROOT dictionaries]({{ 'manual/io_custom_classes/#generating-dictionaries' | relative_url }}), and add these to the libraries, which provides ROOT
-with the necessary information on how to generate Python bindings on the fly.
+A large analysis framework might further have multiple libraries. In these cases, you generate ROOT dictionaries, and add these to the libraries, which provides ROOT with the necessary information on how to generate Python bindings on the fly.
 This is what the large LHC experiments do to steer their analysis frameworks from Python.
 
-1. Create one or multiple C++ libraries. <br/>For example create a library as a CMake project that uses ROOT, see → [CMake details]({{ '/manual/integrate_root_into_my_cmake_project' | relative_url }})
-2. Generate a dictionary of all classes that should receive I/O capabilities, i.e. that can be written into ROOT files, see → [Generating dictionaries]({{ '/manual/io_custom_classes/#generating-dictionaries' | relative_url }})
-   <br>Use a [`LinkDef.h` file]({{ '/manual/io_custom_classes/#selecting-dictionary-entries-linkdefh' | relative_url }})
-   to select which classes or functions ROOT should be included in the dictionary.
+For more information on how to generate ROOT dictionaries, please refer to [this section]({{ 'manual/io_custom_classes/#generating-dictionaries' | relative_url }}) of the manual. 
 
-   The corresponding cmake instructions would look similar to this:
+Once the library with dictionaries is available, load it with high-performance C++ in one step:
 
-   ```cmake
-   # Generate G__AnalysisLib.cxx with all the necessary class info:
-   ROOT_GENERATE_DICTIONARY(G__AnalysisLib inc/classA.h inc/classB.h ...
-                             LINKDEF LinkDef.h)
+```python
+import ROOT
+ROOT.gSystem.Load('./libAnalysisLib.so')
+```
 
-    add_library(AnalysisLib SHARED
-       src/classA.cxx
-       src/classB.cxx
-       ...
-       G__AnalysisLib.cxx) # Important: Here, all dictionary info is directly compiled into the library.
+> **Note**
+> If either ROOT or the headers that were used to create the dictionaries were moved to a different location, and ROOT cannot
+> find them (it returns an error in this case), the location of the headers has to be communicated to ROOT:
 
-    # Ensure dictionary is generated before compiling the library:
-    add_dependencies(AnalysisLib G__AnalysisLib)
-   ```
-1. Implement the C++ side, and compile the library using CMake.
-2. On the Python side, load the libraries with high-performance C++ in one step:
+> ```python
+> import ROOT
+> ROOT.gInterpreter.AddIncludePath('path/to/headers/')
+> ROOT.gSystem.Load('./libAnalysisLib.so')
+> ```
 
-   ```python
-   import ROOT
-   ROOT.gSystem.Load('./libAnalysisLib.so')
-   ```
-
-   > **Note**
-   > If either ROOT or the headers that were used to create the dictionaries were moved to a different location, and ROOT cannot
-   > find them (it returns an error in this case), the location of the headers has to be communicated to ROOT:
-
-   > ```python
-   > import ROOT
-   > ROOT.gInterpreter.AddIncludePath('path/to/headers/')
-   > ROOT.gSystem.Load('./libAnalysisLib.so')
-   > ```
-
-   The loading of C++ libraries can even be automated using the `__init__.py` of the Python package.
+The loading of C++ libraries can even be automated using the `__init__.py` of the Python package.
 
 
 ## Pythonizing C++ user classes
@@ -339,7 +405,7 @@ def pythonizor_for_C(klass):
 
 The very same mechanism is used internally in ROOT to pythonize ROOT classes, and it can be applied to user classes too since ROOT v6.26.
 
-A more thorough explanation of the `@pythonization` decorator, its parameters and more examples of usage can be found in this tutorial → {% include tutorial_py name="pyroot002_pythonizationDecorator" %}
+A more thorough explanation of the `@pythonization` decorator, its parameters and more examples of usage can be found in the tutorial {% include tutorial_py name="pyroot002_pythonizationDecorator" %}.
 
 
 ## TPython: running Python from C++
@@ -361,7 +427,7 @@ root [2] TPython::Prompt()
 2
 ```
 
-For a more complete description of the `TPython` interface, see → {% include ref class="TPython" %}.
+For a more complete description of the `TPython` interface, see {% include ref class="TPython" %}.
 
 ## JupyROOT: (Py)ROOT for Jupyter notebooks
 
@@ -369,20 +435,20 @@ For a more complete description of the `TPython` interface, see → {% include r
 
 ### How to use ROOT with Jupyter notebooks
 
-Two kernels (or language flavours) allow to run ROOT from Jupyter: *Python* (2 and 3) and *C++*. In order to use such kernels, there are mainly two options:
+Two kernels (or language flavours) allow to use ROOT from Jupyter: *Python* (2 and 3) and *C++*. In order to use such kernels, there are mainly two options:
 
-- Local ROOT installation: to install ROOT locally, see → [Installing ROOT]({{ '/install' | relative_url }}).<br/>In addition to ROOT, two Python packages are required that you can install, for example, with `pip`:
+- Local ROOT installation: to install ROOT locally, see [Installing ROOT]({{ '/install' | relative_url }}).<br/>In addition to ROOT, two Python packages are required that you can install, for example, with `pip`:
 
-```shell
-pip install jupyter
-pip install metakernel
-```
+    ```shell
+    pip install jupyter
+    pip install metakernel
+    ```
 
-When all requirements fulfilled, you can start a Jupyter server with the Python and C++ kernels from a terminal:
+    When all requirements fulfilled, you can start a Jupyter server with the Python and C++ kernels from a terminal:
 
-```shell
-root --notebook
-```
+    ```shell
+    root --notebook
+    ```
 
 - SWAN: CERN provides an online service to create and run Jupyter notebooks, called [SWAN](https://swan.cern.ch){:target="_blank"}. With this option no installation is required: a browser and a working Internet connection are enough. Both the Python and C++ kernels are available in SWAN.
 
@@ -418,7 +484,10 @@ If you execute the above code in a cell, the output shows the following interact
 ## New PyROOT: Backwards-incompatible changes
 
 The new PyROOT has the following backwards-incompatible changes with respect to its predecessor:
-- Instantiation of function templates must be done using square brackets instead of parentheses.
+
+### Instantiation of function templates
+
+Instantiation of function templates must be done using square brackets instead of parentheses.
 
 _**Example**_
 
@@ -448,7 +517,9 @@ Note that the above code does not affect class templates, which can be instantia
 <class cppyy.gbl.std.vector<int> at 0x5528378>
 ```
 
-- Overload resolution in new cppyy has been significantly rewritten, which sometimes can lead to a different overload choice
+### Overload resolution
+
+Overload resolution in new cppyy has been significantly rewritten, which sometimes can lead to a different overload choice
 (but still a compatible one).
 
 _**Example**_
@@ -462,7 +533,9 @@ string (const string& str, size_t pos, size_t len = npos)  (2)
 
 when invoking `ROOT.std.string(s, len(s))`, where `s` is a Python string. The new PyROOT picks (2) whereas the old picks (1).
 
-- The conversion between `None` and C++ pointer types is not allowed anymore. Use `ROOT.nullptr` instead:
+### Conversion between None and C++ pointer types
+
+The conversion between `None` and C++ pointer types is not allowed anymore. Use `ROOT.nullptr` instead:
 
 ```python
 >>> ROOT.gInterpreter.Declare("""
@@ -477,7 +550,9 @@ TypeError: void ::foo(A* a) =>
 TypeError: could not convert argument 1
 ```
 
-- Old PyROOT has `ROOT.Long` and `ROOT.Double` to pass integer and floating point numbers by reference. In the new PyROOT, you must use `ctypes` instead.
+### Passing fundamental types by reference
+
+Old PyROOT has `ROOT.Long` and `ROOT.Double` to pass integer and floating point numbers by reference. In the new PyROOT, you must use `ctypes` instead.
 
 ```python
 >>> ROOT.gInterpreter.Declare("""
@@ -497,7 +572,9 @@ c_int(2)
 c_double(2.0)
 ```
 
-- When a character array is converted to a Python string, the new PyROOT only considers the characters before the end-of-string character:
+### Conversion to Python strings
+
+When a character array is converted to a Python string, the new PyROOT only considers the characters before the end-of-string character:
 
 ```python
 >>> ROOT.gInterpreter.Declare('char MyWord[] = "Hello";')
@@ -511,7 +588,9 @@ c_double(2.0)
 'Hello'
 ```
 
-- Any Python class derived from a base C++ class now requires the base class to define a virtual destructor:
+### Inheritance from C++ classes
+
+Any Python class derived from a base C++ class now requires the base class to define a virtual destructor:
 
 ```python
 >>> ROOT.gInterpreter.Declare("class CppBase {};")
@@ -522,7 +601,9 @@ File "<stdin>", line 1, in <module>
 TypeError: CppBase not an acceptable base: no virtual destructor
 ```
 
-- There are the following name changes for what concerns cppyy APIs and proxy object attributes:
+### Changes of the cppyy APIs
+
+There are the following name changes for what concerns cppyy APIs and proxy object attributes:
 
 | Old PyROOT/cppyy                          | New PyROOT/cppyy                |
 |-------------------------------------------|---------------------------------|
@@ -541,7 +622,10 @@ TypeError: CppBase not an acceptable base: no virtual destructor
 | callable.\_mempolicy                      | callable.\_\_mempolicy\_\_      |
 | callable.\_threaded                       | callable.\_\_release\_gil\_\_   |
 
-- New PyROOT does not parse command line arguments by default anymore.
+
+### Parsing of command line arguments
+
+New PyROOT does not parse command line arguments by default anymore.
 <br/>For example, when running `python my_script.py -b`, the `-b` argument is not parsed by PyROOT, and therefore the
 batch mode is not activated. If you want to enable the PyROOT argument parsing again, start your Python script with:
 
@@ -550,7 +634,9 @@ import ROOT
 ROOT.PyConfig.IgnoreCommandLineOptions = False
 ```
 
-- In new PyROOT, use `addressof` to retrieve the address of fields in a `struct`.
+### Addressing fields in structures
+
+In new PyROOT, use `addressof` to retrieve the address of fields in a `struct`.
 
 
 ```python
@@ -581,7 +667,9 @@ of such address being contained in the first position of the buffer.
 Note that in the new PyROOT `AddressOf(o)` can still be invoked, and it still returns a buffer
 whose first position contains the address of object `o`.
 
-- In old PyROOT, there were two C++ classes called `TPyMultiGenFunction` and `TPyMultiGradFunction`
+### Alternative for TPyMultiGenFunction and TPyMultiGradFunction
+
+In old PyROOT, there were two C++ classes called `TPyMultiGenFunction` and `TPyMultiGradFunction`
 which inherited from `ROOT::Math::IMultiGenFunction` and `ROOT::Math::IMultiGradFunction`, respectively.
 The purpose of these classes was to serve as a base class for Python classes that wanted to inherit
 from the ROOT::Math classes. This allowed to define Python functions that could be used for fitting
@@ -623,7 +711,9 @@ if __name__ == '__main__':
     main()
 ```
 
-- When iterating over an `std::vector<std::string>` from Python, the elements returned by
+### Iterating over an std::vector<std::string>
+
+When iterating over an `std::vector<std::string>` from Python, the elements returned by
 the iterator are no longer of type Python `str`, but `cppyy.gbl.std.string`. This is an
 optimization to make the iteration faster (copies are avoided) and it allows to call
 modifier methods on the `std::string` objects.
@@ -645,12 +735,14 @@ modifier methods on the `std::string` objects.
 <class cppyy.gbl.std.string at 0x4cd41b0>
 ```
 
-- When obtaining the boolean value of a C++ instance proxy, both old and new PyROOT return
+### Conversion to boolean value
+
+When obtaining the boolean value of a C++ instance proxy, both old and new PyROOT return
 `False` when such proxy points to null. On the other hand, when the proxy points to a C++ object,
 old PyROOT just returns `True`, while new PyROOT has slightly modified this behaviour: in new
 cppyy, if `__len__` is available, the result of `__len__` is used to determine truth. This is
 done to comply with the default Python behaviour, where `__len__` is tried if `__bool__` is not
-present (see → [object.__bool__](https://docs.python.org/3.8/reference/datamodel.html#object.__bool__){:target="_blank"}).
+present (see [object.__bool__](https://docs.python.org/3.8/reference/datamodel.html#object.__bool__){:target="_blank"}).
 
 _**Example**_
 
@@ -669,7 +761,9 @@ True
 False
 ```
 
-- In new cppyy, buffer objects are represented by the `LowLevelView` type. If such a buffer
+### Iterating over buffer objects
+
+In new cppyy, buffer objects are represented by the `LowLevelView` type. If such a buffer
 points to null, it is not iterable, unlike in the old PyROOT.
 <br/>For example, in the following code, `GetX()` returns a null pointer and therefore an exception is thrown when calling `list(x)`:
 


### PR DESCRIPTION
* ~~Changed the code sections to proper highlights.~~ Not done since `{% highlight Python %}` breaks the markdown indentation!
* Added subsections in the last section ("New PyROOT:
Backwards-incompatible changes"), so it is easier to follow.
* Minor wording reformulations.
* Added functionalities from the user guide.