### PR TITLE
Minor fixes to root_files/index.md

### DIFF
--- a/manual/root_files/index.md
+++ b/manual/root_files/index.md
@@ -138,11 +138,12 @@ For the particular case of TTree, cycles only store metadata, see [Baskets, clus
 
 ### Reading an object from a ROOT file
 
-- Use the `GetObject()` method to retrieve the objects from a ROOT file.
+In C++, use the `Get<T>()` method to retrieve the objects from a ROOT file.<br>
+In Python, objects in the file are accessible as attributes.
 
 _**Example**_
 
-From the ROOT file `file.root`, the histogram `MyHist` is retrieved.
+The histogram `MyHist` is retrieved from the ROOT file `file.root`.
 
 {% highlight C++ %}
 std::unique_ptr<TFile> myFile( TFile::Open("file.root") );


### PR DESCRIPTION
- suggest `Get<T>` instead of `GetObject`
- mention the Python way in the text other than showing it in the example
- wording