### PR TITLE
[release_checklist] Clarify instructions for updating the latest-stable branch

### DIFF
--- a/for_developers/release_checklist/index.md
+++ b/for_developers/release_checklist/index.md
@@ -86,8 +86,9 @@ This assumes you try to create `v6-22-00-patches`, adjust accordingly.
       - `make` must succeed
   1. Push to GitHub
       - `git push origin v6-22-02`
-  1. Update the stable branch. Users that have cloned this branch will receive updates as a fast-forward via `git pull`
-      - `LATEST_STABLE=v6-xx-yy    # e.g. v6-22-02`
+  1. Update the stable branch. The command below creates a commit that appears as a merge to git porcelain commands, but that directly points to the tree given by the `LATEST_STABLE` commit-ish. Users that have cloned this branch will receive updates as a fast-forward via `git pull`
+      - `$ LATEST_STABLE=v6-xx-yy    # e.g. v6-22-02`
+      - `$ git fetch origin latest-stable:latest-stable`
       - `$ git update-ref refs/heads/latest-stable $(git commit-tree $LATEST_STABLE^{tree} -p refs/heads/latest-stable -p $LATEST_STABLE^{commit} -m "Updated 'latest-stable' branch to $LATEST_STABLE")`
       - `$ git push origin latest-stable`
   1. Produce binary tar-files (optional for development releases and release candidates)


### PR DESCRIPTION
Integrates small changes to the release checklist:
- Include a `git fetch` command that makes sure the `latest-stable` local branch (i.e. refs/heads/latest-stable) points to the latest thing before the update.
- Add a sentence that explains what the update-ref command does.
