### PR TITLE
Build from source instructions: add `--depth=1` option to `git clone`

### DIFF
--- a/install/build_from_source.md
+++ b/install/build_from_source.md
@@ -29,7 +29,9 @@ The following are the basic instructions for UNIX-like systems. We will use the 
 ```bash
 # The latest stable branch gets updated automatically on each release.
 # Your may update your local copy by issuing a `git pull` command.
-$ git clone --branch latest-stable https://github.com/root-project/root.git root_src
+# The `--depth=1` option will save some download time during clone at the cost of
+# slightly increased time for the first `git pull`.
+$ git clone --branch latest-stable --depth=1 https://github.com/root-project/root.git root_src
 ```
 In the following we will refer to the directory where ROOT sources are (e.g. `root_src` above) as `<sourcedir>`.
 1. Create a directory for the build and a directory for the installation. It is not supported to build ROOT in the source directory. Then change (`cd`) to the build directory:

--- a/install/index.md
+++ b/install/index.md
@@ -261,7 +261,7 @@ As a quick summary, after installing all [required dependencies]({{'/install/dep
 ```bash
 # The latest stable branch gets updated automatically on each release.
 # You may update your local copy by issuing a `git pull` command from within `root_src/`.
-$ git clone --branch latest-stable https://github.com/root-project/root.git root_src
+$ git clone --branch latest-stable --depth=1 https://github.com/root-project/root.git root_src
 $ mkdir root_build root_install && cd root_build
 $ cmake -DCMAKE_INSTALL_PREFIX=../root_install ../root_src # && check cmake configuration output for warnings or errors
 $ cmake --build . -- install -j4 # if you have 4 cores available for compilation
@@ -273,7 +273,7 @@ And similarly, on Windows, inside a `x86 Native Tools Command Prompt for VS 2019
 ```bat
 rem The `latest-stable` branch gets updated automatically on each release.
 rem You may update your local copy by issuing a `git pull` command from within `root_src`.
-C:\Users\username>git clone --branch latest-stable https://github.com/root-project/root.git root_src
+C:\Users\username>git clone --branch latest-stable --depth=1 https://github.com/root-project/root.git root_src
 C:\Users\username>mkdir root_build root_install && cd root_build
 C:\Users\username>cmake -G"Visual Studio 16 2019" -A Win32 -Thost=x64 -DCMAKE_VERBOSE_MAKEFILE=ON -DCMAKE_INSTALL_PREFIX=../root_install ../root_src
 C:\Users\username>cmake --build . --config Release --target install


### PR DESCRIPTION
A shallow clone will benefit users who want to download a snapshot of the latest release, as it will avoid downloading objects that are not part of the tree for the latest commit.

For users that want to stay updated via `git pull`, this will be delayed until the first `git pull`.

See https://github.com/root-project/root/issues/10238 for context.