### PR TITLE
Use relative URLs

### DIFF
--- a/blog/_posts/2021-10-30-debuging-root-scripts-in-eclipse.md
+++ b/blog/_posts/2021-10-30-debuging-root-scripts-in-eclipse.md
@@ -4,9 +4,9 @@ layout: archive
 author: Petr Stepanov
 ---
 
-<p style="text-align: center">
-   <img src="/assets/images/setup-eclipse-ide-with-cern-root.jpg" alt="Eclipse IDE dependencies" style="width: 60%" width="1600" height="749" />
-</p>
+<center>
+   <img src="{{'/assets/images/setup-eclipse-ide-with-cern-root.jpg' | relative_url}}" alt="Eclipse IDE dependencies" style="width: 60%" width="1600" height="749" />
+</center>
 
 > **NOTE:** originally this post outlined a setup of a ROOT-based project in Eclipse IDE based on the [Eclipse CDT4 CMake generator](https://cmake.org/cmake/help/latest/generator/Eclipse%20CDT4.html) functionality. However, [CMake4eclipse](https://github.com/15knots/cmake4eclipse) plugin provides a better integration of ROOT-based projects in Eclipse. Therefore post is updated in September 2022 to demonstrate the new approach. Former notes can be found [here](https://github.com/petrstepanov/root-eclipse/blob/main/md/root-post-cmake-generator.md).
 
@@ -32,13 +32,13 @@ Following milestones are required to complete the setup of the development envir
 * **Install Eclipse IDE on your computer**. Eclipse is an all-in-one development solution that automates many things: source highlighting and formatting, invokes the CMake build, lets users set breakpoints in code, attaches the debugger to the executable, and many more.
 * **Obtain ROOT source code on your computer**. Once attached to the project, this allows easy inspection and navigation between your script (or program) and ROOT source files within the IDE user interface. It also allows modification of the frameworks’ source files while debugging your program, which makes it easy to fix bugs and issue Pull Requests to the ROOT open-source code.
 * **Compile ROOT with debug symbols**. This provides the ability to set up breakpoints in your code and original ROOT (and/or Geant4) source files, inspect variables, access data types and object members in the program source code.
-* **Transform ROOT script into a standalone program**. ROOT scripts designed to run with C++ interpreter (executed line-by-line), need to be transformed into a compiled C++ program - with an entry point in "main()" function.   
+* **Transform ROOT script into a standalone program**. ROOT scripts designed to run with C++ interpreter (executed line-by-line), need to be transformed into a compiled C++ program - with an entry point in "main()" function.
 * **Set up your ROOT-based program in Eclipse IDE**. During the main project setup, ROOT project is marked as a reference. This automatically triggers the rebuild and re-install of corresponding ROOT components prior to the main project build. Additionally, ROOT project indexer database becomes shared with your project.
 
 Eclipse IDE Setup
 -----------------
 
-In this section we demonstrate how to install Eclipse IDE on a personal Linux computer. We will use Eclipse with the **cmake4eclipse plugin** - a powerful tool for use with CMake-based projects. Cmake4eclipse automates the project setup and allows for automatic rebuild of the frameworks’ libraries (ROOT and/or Geant4) once their source code was changed. 
+In this section we demonstrate how to install Eclipse IDE on a personal Linux computer. We will use Eclipse with the **cmake4eclipse plugin** - a powerful tool for use with CMake-based projects. Cmake4eclipse automates the project setup and allows for automatic rebuild of the frameworks’ libraries (ROOT and/or Geant4) once their source code was changed.
 
 Today (Aug 2022) CMake4eclipse plugin provides better integration of CMake-based projects in Eclipse compared to other options as:
 * Using CMake generator to create Eclipse project.
@@ -51,20 +51,20 @@ Each of the above options have its own drawbacks that are a subject of a separat
    **A**. Recent Eclipse versions come with bundled Java Runtime Environment (JRE). As of July 2022, specify the built-in JRE version 11. Otherwise there will be an error accessing Eclipse help. This may be fixed in later Eclipse releases.
 
    **B**. On Linux it is a good practice to install software that is not included in your distribution under the `/opt`, `/usr/local/` folder or home folder. In this article we will stick to the latter option and install Eclipse in the home folder under `~/Applications/` for consistency with the setup on macOS.
-   
-   ![Eclipse CDT installer](/assets/images/install-eclipse.png)
+
+   ![Eclipse CDT installer]({{'/assets/images/install-eclipse.png' | relative_url}})
 
    **C**. Wizard will provide a required list of packages to be installed on your system. Ensure all of the package dependencies are installed on your system.
 
    <p style="text-align: center">
-      <img src="/assets/images/eclipse-installer-dependencies.png" alt="Eclipse IDE dependencies" style="width: 60%" />
+      <img src="{{'/assets/images/eclipse-installer-dependencies.png' | relative_url}}" alt="Eclipse IDE dependencies" style="width: 60%" />
    </p>
 
-   **D**. Exit the wizard. There is no need to launch Eclipse right away. We will tweak its configuration file first. 
+   **D**. Exit the wizard. There is no need to launch Eclipse right away. We will tweak its configuration file first.
 
-2. **Increase Eclipse memory limits**. ROOT libraries contain thousands of source files. Usually, when indexing a ROOT-based project, memory use fluctuates around 2GB. Eclipse memory use be inspected with the [VisualVM application](https://visualvm.github.io/). 
+2. **Increase Eclipse memory limits**. ROOT libraries contain thousands of source files. Usually, when indexing a ROOT-based project, memory use fluctuates around 2GB. Eclipse memory use be inspected with the [VisualVM application](https://visualvm.github.io/).
 
-   ![VisualVM inspects Eclipse memory use](https://root.cern/assets/images/eclipse-heap-use.png)
+   ![VisualVM inspects Eclipse memory use]({{'assets/images/eclipse-heap-use.png' | relative_url}})
 
    Memory limits are specified in the `eclipse.ini` file located inside the Eclipse install folder. Use text editor to update following lines:
 
@@ -91,24 +91,25 @@ echo StartupWMClass=Eclipse >> ~/.local/share/applications/epp.package.cpp.deskt
 
    In the modal dialog select everything but uncheck the older version of CMake4eclipse (v2). Keep only version v3. Follow the wizard steps and restart Eclipse. Refer to the screenshot below:
 
-   ![cmake4eclipse installation](/assets/images/install-cmake4eclipse.png)
+   ![cmake4eclipse installation]({{'/assets/images/install-cmake4eclipse.png' | relative_url}})
 
-7. **Tweak cmake4eclipse settings**. Set default workbench for CMake4eclipse. In the Eclipse menu select Window → Preferences → C/C++ → Cmake4eclipse → Default build system → Set "**Unix Makefiles**". 
+7. **Tweak cmake4eclipse settings**. Set default workbench for CMake4eclipse. In the Eclipse menu select Window → Preferences → C/C++ → Cmake4eclipse → Default build system → Set "**Unix Makefiles**".
 
    On the "CMake cache entries" tab, **specify the C++ standard** used for the build. Add corresponding CMake cache entry:
-   
+
    | Name | Type | Value |
    |------|------|-------|
    | CMAKE_CXX_STANDARD | STRING | 17 |
 
-   It is important for the ROOT-based programs to be compiled with the same C++ standard as the ROOT libraries. Therefore, in this guide we will explicitly set the C++ standard for ROOT, Geant4 and their based programs, [more info here](https://root.cern/install/build_from_source/#setting-the-c-standard). We will use the C++17 standard.
+   It is important for the ROOT-based programs to be compiled with the same C++ standard as the ROOT libraries. Therefore, in this guide we will explicitly set the C++ standard for ROOT, Geant4 and their based programs,
+   [more info here]({{ "/install/build_from_source/#setting-the-c-standard" | relative_url }}). We will use the C++17 standard.
 
-   ![specify cmake4eclipse settings for ROOT](/assets/images/cmake4eclipse-settings.png)
+   ![specify cmake4eclipse settings for ROOT]({{'/assets/images/cmake4eclipse-settings.png' | relative_url}})
 
    **Tip**: if having problems with the build later, check "**Force re-creation with each build**". This will trigger the CMakeLists.txt update and re-generation of the Unix makefile at every build, reflecting possible changes in the CMake cache entries (variables) and ROOT components' source code.
 
 
-Optionally apply following useful tweaks to the Eclipse workflow: 
+Optionally apply following useful tweaks to the Eclipse workflow:
 * **Hide the Launch Bar**. It indeed takes quite some space on smaller screens. In the Eclipse menu  go to: Window → Preferences → Run/Debug → Launching → Launch Bar. Uncheck "Enable the Launch Bar".
 * **Display line numbers**. In the Eclipse menu  go to: Window → Preferences → General → Editors → Text Editors. Check "Show line numbers".
 * **Kill the previous application run** upon starting a new one. In the Eclipse menu, select Window → Preferences → Run/Debug → Launching → "Terminate and relaunch while launching".
@@ -122,11 +123,11 @@ Building ROOT with Debug Symbols
 
 In this section we address the setup of ROOT libraries as a project in Eclipse IDE. Framework will be built with debug symbols. This allows for setting breakpoints in the ROOT code, inspecting memory and variable values during the program run.
 
-1. **Install dependencies**. Refer to [this page on ROOT website](https://root.cern/install/dependencies/) to satisfy the dependencies for your particular Linux distribution.
+1. **Install dependencies**. Refer to [this page on ROOT website]({{ "/install/dependencies/" | relative_url}}) to satisfy the dependencies for your particular Linux distribution.
 
-2. **Obtain the source code**. There are a few options here. 
+2. **Obtain the source code**. There are a few options here.
 
-   A straightforward way is to download ROOT sources for a specific release [from the ROOT website](https://root.cern/install/all_releases/). Extract ROOT sources under the `~/Development` home folder. We will keep all the source code and Git repositories in this folder for consistency purposes. 
+   A straightforward way is to download ROOT sources for a specific release [from the ROOT website]({{ "/install/all_releases/" | relative_url}}). Extract ROOT sources under the `~/Development` home folder. We will keep all the source code and Git repositories in this folder for consistency purposes.
 
    Alternatively, if a user plans on contributing towards the ROOT repository it is recommended to fork the latest `master` branch [on GitHub](https://github.com/root-project/root), create a new branch in your forked repository and check it out:
 
@@ -136,16 +137,16 @@ git clone https://github.com/<your-username>/root
 git checkout -b <your-feature-branch>
    ```
 
-   This allows for issuing Pull Requests to the original repository. More details can be found [on this page](https://root.cern/for_developers/creating_pr/).
+   This allows for issuing Pull Requests to the original repository. More details can be found [on this page]({{ "/for_developers/creating_pr/" | relative_url}}).
 
 
 3. **Set up a project in Eclipse**. Launch Eclipse. In the menu open File → New → Project... Expand "C/C++" and select "C++ Project" (not "C/C++ Project").
 
-   ![cmake4eclipse project setup](/assets/images/project-setup-1.png)
+   ![cmake4eclipse project setup]({{'/assets/images/project-setup-1.png' | relative_url}})
 
    On the next dialog, specify "root" as the project name. Uncheck "Use default location" and "Browse..." for ROOT sources location (e.g. `~/Development/root`). In "Project Type" expand "Cmake4eclipse" and select "Empty Project". In "Toolchains" select "CMake driven". Click "Next >".
 
-   ![cmake4eclipse build configuration setup](/assets/images/project-setup-2.png)
+   ![cmake4eclipse build configuration setup]({{'/assets/images/project-setup-2.png' | relative_url}})
 
    We are building ROOT with debug symbols. Therefore, uncheck "Default" and "Release" build options and only keep the "Debug". Essentially this dialog box specifies the CMake `-DCMAKE_BUILT_TYPE` variable.
 
@@ -158,25 +159,25 @@ git checkout -b <your-feature-branch>
 
    When specifying variables of a PATH type, it is handy to use the "File System…" button. It will display the folder picker dialog and minimize the chance of specifying a wrong path. Refer to the screenshot below:
 
-   ![cmake4eclipse build variable](/assets/images/cmake-vars.png)
+   ![cmake4eclipse build variable]({{'/assets/images/cmake-vars.png' | relative_url}})
 
-   In this tutorial we build ROOT with all optional components turned on (`-Dall=ON`). Find a complete list of the [ROOT CMake build variables](https://root.cern/install/build_from_source/#all-build-options) on the ROOT website and tailor the build for your needs. 
-   
+   In this tutorial we build ROOT with all optional components turned on (`-Dall=ON`). Find a complete list of the [ROOT CMake build variables]({{ "/install/build_from_source/#all-build-options" | relative_url}}) on the ROOT website and tailor the build for your needs.
+
    Click "Apply and Close". Click "Finish".
 
    Notice that Eclipse will start indexing the project. However, we will reschedule this operation later - after the build is completed. Reveal the "Progress" panel (tiny scrollbar animation in the very bottom right corner). Stop the indexer operation.
 
-   ![Stop Eclipse indexer operation](/assets/images/eclipse-02-stop-indexer.png)
+   ![Stop Eclipse indexer operation]({{'/assets/images/eclipse-02-stop-indexer.png' | relative_url}})
 
 4. **Build framework in Eclipse**. Reveal the "Build Targets" tab (on the right side) and select "root" project. Right-click and select "New…" build target. Name target "install". Click "Ok". Expand "root" in the "Build Targets" tab and double-click the "install" target.
 
-   ![cmake4eclipse build variable](/assets/images/build-target.png)
+   ![cmake4eclipse build variable]({{'/assets/images/build-target.png' | relative_url}})
 
    Build process speed depends on your computer speed and provided build variables. It may take up to a few hours to finish.
 
    **Tip**: to switch between the CMake console and Linux make console, locate the "Display Selected Console" dropdown on the bottom actions panel.
 
-   ![cmake4eclipse build variable](/assets/images/display-console.png)
+   ![cmake4eclipse build variable]({{'/assets/images/display-console.png' | relative_url}})
 
 5. **Exclude build folder from indexing**. Cmake4eclipse plugin performs a so-called in-source build. Meaning that the build folder is located within a project file tree. During the build ROOT header files are copied and duplicated inside the "_build" folder. To avoid indexing duplicate sources and headers, right click "root" project → Properties → C/C++ General → Paths and Symbols → Source Location. Expand the "/root" folder. Select "Filter". Click "Edit filter…". Add the "_build" folder to the filter. Click "Apply and Close".
 
@@ -204,7 +205,7 @@ Skip to the next section if you already have a ROOT-based program code ready.
 
 Next we elaborate how to convert a ROOT script into a CMake ROOT-based program. Generally speaking, this involves following:
 
-1. Compose CMakeLists.txt file containing a set of instructions that: 
+1. Compose CMakeLists.txt file containing a set of instructions that:
    * Locate necessary libraries (ROOT, Geant4).
    * Find and compile source and header files in your project.
    * Create a ROOT dictionary and shared library for your program.
@@ -226,7 +227,7 @@ In this section we will set up a ROOT-based CMake project in Eclipse IDE.
 
    On the next dialog, specify your project name.  Uncheck "Use default location" and "Browse…" for your project "CMakeLists.txt" location. In "Project Type" expand "Cmake4eclipse" and select "Empty Project". In "Toolchains" select "CMake driven". Click "Next >".
 
-   For the development purpose we uncheck "Default" and "Release" build configurations and keep the "Debug" option only. 
+   For the development purpose we uncheck "Default" and "Release" build configurations and keep the "Debug" option only.
 
    Next we need to provide the CMake plugin with corresponding build variables. Click "Advanced Settings…". Go to C/C++ Build → Cmake4eclipse. Open the "CMake cache entries" tab.
 
@@ -256,11 +257,11 @@ env | grep 'G4\|ROOTSYS\|^LD_LIBRARY_PATH\|^PATH'
 
    Required environment variables are output in the Terminal window:
 
-   ![cmake4eclipse build variable](/assets/images/root-environment-variables.png)
+   ![cmake4eclipse build variable]({{'/assets/images/root-environment-variables.png' | relative_url}})
 
    Now go back to the project setup dialog in Eclipse, open C/C++ Build → Environment. Manually "Add..." each environment variable name and value into the Eclipse project settings:
 
-   ![eclipse environmant variables for ROOT-based project](/assets/images/eclipse-environment-variables.png)
+   ![eclipse environment variables for ROOT-based project]({{'/assets/images/eclipse-environment-variables.png' | relative_url}})
 
    Also, select "Replace native environment with specified one" option. This will isolate Eclipse project environment variables containing paths to frameworks built with debug symbols from potentially installed ROOT or Geant4 release versions on the system. Click "Finish" button.
 
@@ -274,7 +275,7 @@ env | grep 'G4\|ROOTSYS\|^LD_LIBRARY_PATH\|^PATH'
 
    Select "C/C++ Application". Press the "New launch configuration" button (on the very top left). Click the "Search Project…" button and locate the corresponding executable file.
 
-   ![Eclipse run and debug configurations](https://root.cern/assets/images/eclipse-04-debug-configuration.png)
+   ![Eclipse run and debug configurations]({{'/assets/images/eclipse-04-debug-configuration.png' | relative_url}})
 
    If necessary, specify any command-line parameters on the "Arguments" tab. Click "Debug".
 
@@ -284,15 +285,15 @@ This is it. Now you can enjoy full-scale debugging of your ROOT-based applicatio
 Summary
 -------
 
-In this post, we learned how to pair Eclipse IDE and cmake4eclipse plugins to setup an effective development environment for CERN ROOT scripts and ROOT-based programs. It was a process, so let's draw a line and summarize what we learned today:
+In this post, we learned how to pair Eclipse IDE and cmake4eclipse plugins to setup an effective development environment for CERN ROOT scripts and ROOT-based programs. It was a process, so let's draw a line and summarise what we learned today:
 
 * Learned how to install and setup the Eclipse IDE and cmake4eclipse.
 * Compiled ROOT project with debug symbols in Eclipse.
 * Investigated how to transform a ROOT script into a ROOT-based program with CMake configuration file.
 * Got familiar with Eclipse IDE user interface. Set up our ROOT-based project, created and run the Debug configurations.
 
-I hope you enjoyed this technical note. If not yet familiar, you can now continue learning fundamental Eclipse CDT hotkeys and debugging capabilities [on YouTube](https://www.youtube.com/results?search_query=eclispe+cdt+debug). 
+I hope you enjoyed this technical note. If not yet familiar, you can now continue learning fundamental Eclipse CDT hotkeys and debugging capabilities [on YouTube](https://www.youtube.com/results?search_query=eclipse+cdt+debug).
 
-> For those who are interested in setting up the same devlopment environment for a project that utilizes both - Geant4 and ROOT, [please follow this link](https://docs.google.com/document/d/1Q-ypwku8ZTR53uW4Djy3ANzRnxk1sokEeYrwvJ3JOSE/edit?usp=sharing).
+> For those who are interested in setting up the same development environment for a project that utilizes both - Geant4 and ROOT, [please follow this link](https://docs.google.com/document/d/1Q-ypwku8ZTR53uW4Djy3ANzRnxk1sokEeYrwvJ3JOSE/edit?usp=sharing).
 
 Feel free to leave comments below if you have any questions or recommendations.


### PR DESCRIPTION
- Use relative URLs for images. Images were not visible in local website builds.
- Use also relative URLs for links inside the ROOT website
- fix a wrong link to Youtube (eclipse was miss-spelled)
- fix typos