### PR TITLE
Force download for gz, pkg, exe and zip

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -3,3 +3,8 @@
 	RewriteCond %{REQUEST_URI} /+[^\.]+$ 
 	RewriteRule ^(.+[^/])$ %{REQUEST_URI}/ [R=301,L]
 </IfModule>
+# Force download for gz, pkg, exe and zip
+<FilesMatch "\.(gz|pkg|exe|zip)$">
+   ForceType application/octet-stream
+   Header set Content-Disposition attachment
+</FilesMatch>


### PR DESCRIPTION
Force download for gz, pkg, exe and zip files in .htaccess

the download only works for me if I right click on the download links and click "Download Linked File". Otherwise, the browser loads the file and tries to display it:
<img width="1256" alt="root cern" src="https://user-images.githubusercontent.com/198920/194580665-58f74656-6464-4417-a567-e2452df45918.png">
