### PR TITLE
The Root main page points to the reference guide latest stable version.

### DIFF
--- a/_includes/root_stable_version_short
+++ b/_includes/root_stable_version_short
@@ -1,0 +1,1 @@
+{% assign sorted = site.releases | reverse %}{% for release in sorted %}{% if release.state == "latest" %}{{release.version | replace:".","" | truncate: 3, "" }}{% endif %}{% endfor %}

--- a/index.html
+++ b/index.html
@@ -28,7 +28,7 @@ feature_row:
         <div style="padding: 20px 0"><font color="#346295" style="font-weight:bold;" size="3">Start</font></div>
     </div><!--
     --><div style="width: 25%; display:inline-block;">
-        <div><a href="https://root.cern/doc/master/index.html"><img style="box-shadow: none;" width="128" src="{{'/assets/images/doc.svg' | relative_url}}"></a></div>
+        <div><a href="https://root.cern/doc/v{% include root_stable_version_short %}"><img style="box-shadow: none;" width="128" src="{{'/assets/images/doc.svg' | relative_url}}"></a></div>
         <div style="padding: 20px 0"><font color="#346295" style="font-weight:bold;" size="3">Reference</font></div>
     </div><!--
     --><div style="width: 25%; display:inline-block;">


### PR DESCRIPTION
A new script to build the short-release-number is needed.