### PR TITLE
Remove the useless Next/Previous buttons

### DIFF
--- a/_layouts/releases.html
+++ b/_layouts/releases.html
@@ -1,5 +1,5 @@
 ---
-layout: single-no-title
+layout: single-release
 ---
 
 <h1> Release {{page.version}} - {{page.release_date}} </h1>
@@ -7,5 +7,5 @@ layout: single-no-title
 {{ content }}
 
 {% if page.state == "latest" %}
-State: <a href="{{ '/install/all_releases/latest' | relative_url }}"> {{ page.state | capitalize }}</a>
+<b>State:</b> <a href="{{ '/install/all_releases/latest' | relative_url }}"> {{ page.state | capitalize }}</a>
 {% endif %}

--- a/_layouts/single-release.html
+++ b/_layouts/single-release.html
@@ -45,50 +45,10 @@ layout: default
         {% if page.link %}<div><a href="{{ page.link }}" class="btn btn--primary">{{ site.data.ui-text[site.locale].ext_link_label | default: "Direct Link" }}</a></div>{% endif %}
       </section>
 
-      <footer class="page__meta">
-        {% if site.data.ui-text[site.locale].meta_label %}
-          <h4 class="page__meta-title">{{ site.data.ui-text[site.locale].meta_label }}</h4>
-        {% endif %}
-        {% include page__taxonomy.html %}
-        {% if page.last_modified_at %}
-          <p class="page__date"><strong><i class="fas fa-fw fa-calendar-alt" aria-hidden="true"></i> {{ site.data.ui-text[site.locale].date_label | default: "Updated:" }}</strong> <time datetime="{{ page.last_modified_at | date: "%Y-%m-%d" }}">{{ page.last_modified_at | date: "%B %d, %Y" }}</time></p>
-        {% elsif page.date %}
-          <p class="page__date"><strong><i class="fas fa-fw fa-calendar-alt" aria-hidden="true"></i> {{ site.data.ui-text[site.locale].date_label | default: "Updated:" }}</strong> <time datetime="{{ page.date | date_to_xmlschema }}">{{ page.date | date: "%B %d, %Y" }}</time></p>
-        {% endif %}
-      </footer>
-
-      {% if page.share %}{% include social-share.html %}{% endif %}
-
-      {% include post_pagination.html %}
     </div>
 
     {% if jekyll.environment == 'production' and site.comments.provider and page.comments %}
       {% include comments.html %}
     {% endif %}
   </article>
-
-  {% comment %}<!-- only show related on a post page when `related: true` -->{% endcomment %}
-  {% if page.id and page.related and site.related_posts.size > 0 %}
-    <div class="page__related">
-      <h4 class="page__related-title">{{ site.data.ui-text[site.locale].related_label | default: "You May Also Enjoy" }}</h4>
-      <div class="grid__wrapper">
-        {% for post in site.related_posts limit:4 %}
-          {% include archive-single.html type="grid" %}
-        {% endfor %}
-      </div>
-    </div>
-  {% comment %}<!-- otherwise show recent posts if no related when `related: true` -->{% endcomment %}
-  {% elsif page.id and page.related %}
-    <div class="page__related">
-      <h4 class="page__related-title">{{ site.data.ui-text[site.locale].related_label | default: "You May Also Enjoy" }}</h4>
-      <div class="grid__wrapper">
-        {% for post in site.posts limit:4 %}
-          {% if post.id == page.id %}
-            {% continue %}
-          {% endif %}
-          {% include archive-single.html type="grid" %}
-        {% endfor %}
-      </div>
-    </div>
-  {% endif %}
 </div>

--- a/install/all_releases/index.md
+++ b/install/all_releases/index.md
@@ -1,6 +1,6 @@
 ---
 title: Releases
-layout: single-no-title
+layout: single-release
 toc: true
 toc_sticky: true
 sidebar:


### PR DESCRIPTION
Remove the useless Next/Previous buttons at the bottom of each release page.