### PR TITLE
Automatically update code snippets in /install to use the latest release

### DIFF
--- a/_includes/authors_url
+++ b/_includes/authors_url
@@ -1,16 +1,16 @@
 {% assign list = {{include.list}}  %}
 
 {% for author in site.data.authors %}
-{% if author[1].tag == "founder" %}{% assign dir = "project_founders" %}{% endif %}
-{% if author[1].tag == "team" %}{% assign dir = "team" %}{% endif %}
-{% if author[1].tag == "previous" %}{% assign dir = "previous_developers" %}{% endif %}
+   {% if author[1].tag == "founder" %}{% assign dir = "project_founders" %}{% endif %}
+   {% if author[1].tag == "team" %}{% assign dir = "team" %}{% endif %}
+   {% if author[1].tag == "previous" %}{% assign dir = "previous_developers" %}{% endif %}
 
-{% capture author_url %}about/{{dir}}/#{{author[1].name}}{% endcapture %}
-{% capture url %}<a href="{{ author_url | relative_url }}">{{author[1].name}}</a>{% endcapture %}
+   {% capture author_url %}about/{{dir}}/#{{author[1].name}}{% endcapture %}
+   {% capture url %}<a href="{{ author_url | relative_url }}">{{author[1].name}}</a>{% endcapture %}
 
-{% capture list_url %}{{ list | replace: author[1].name , url }}{% endcapture %}
+   {% capture list_url %}{{ list | replace: author[1].name , url }}{% endcapture %}
 
-{% assign list = {{list_url}}  %}
+   {% assign list = {{list_url}}  %}
 
 {% endfor %}
 

--- a/_includes/ref
+++ b/_includes/ref
@@ -1,2 +1,19 @@
-{% assign c = {{include.class}}  %}{% assign s = {{include.struct}}  %}{% assign n = {{include.namespace}}  %}
-{% if c %}{% if n %}<a href="https://root.cern/doc/master/class{{ n | replace: "::", "_1_1" }}_1_1{{c}}.html" target="_blank">{{c}}</a>{% else %}<a href="https://root.cern/doc/master/class{{ c | replace: "::", "_1_1" }}.html" target="_blank">`{{c}}`</a>{% endif %}{% endif %}{% if s %}{% if n %}<a href="https://root.cern/doc/master/struct{{ n | replace: "::", "_1_1" }}_1_1{{s}}.html" target="_blank">`{{s}}`</a>{% else %}<a href="https://root.cern/doc/master/struct{{ s | replace: "::", "_1_1" }}.html" target="_blank">`{{s}}`</a>{% endif %}{% endif %}
+{%- assign c = {{include.class}}  -%}
+{%- assign s = {{include.struct}}  -%}
+{%- assign n = {{include.namespace}} -%}
+
+{%- if c -%}
+    {%- if n -%}
+        <a href="https://root.cern/doc/master/class{{ n | replace: "::", "_1_1" }}_1_1{{c}}.html" target="_blank">{{c}}</a>
+    {%- else -%}
+        <a href="https://root.cern/doc/master/class{{ c | replace: "::", "_1_1" }}.html" target="_blank">`{{c}}`</a>
+    {%- endif -%}
+{%- endif -%}
+
+{%- if s -%}
+    {%- if n -%}
+        <a href="https://root.cern/doc/master/struct{{ n | replace: "::", "_1_1" }}_1_1{{s}}.html" target="_blank">`{{s}}`</a>
+    {%- else -%}
+        <a href="https://root.cern/doc/master/struct{{ s | replace: "::", "_1_1" }}.html" target="_blank">`{{s}}`</a>
+    {%- endif -%}
+{%- endif -%}

--- a/_includes/root_stable_dir
+++ b/_includes/root_stable_dir
@@ -1,0 +1,13 @@
+{%- assign sorted = site.releases | reverse -%}
+{%- for release in sorted -%}
+   {%- if release.state == "latest" -%}
+      {%- assign content = release.content -%}
+      {%- assign pieces = content | split: '| [' -%}
+      {%- assign str = content -%}
+      {%- assign a = str | split: '.tar.gz">' -%}
+      {%- assign b = a[2] | split: '</a></td>' -%}
+      {%- assign c = b[0] | split: '.' -%}
+      {%- assign d = c[3] | split: '-' -%}
+      {{d[2]}}-{{d[1]}}-{{d[3]}}.{{c[4]}}-opt
+   {%- endif -%}
+{%- endfor -%}

--- a/_includes/root_stable_os
+++ b/_includes/root_stable_os
@@ -1,0 +1,13 @@
+{%- assign sorted = site.releases | reverse -%}
+{%- for release in sorted -%}
+   {%- if release.state == "latest" -%}
+      {%- assign content = release.content -%}
+      {%- assign pieces = content | split: '| [' -%}
+      {%- assign str = content -%}
+      {%- assign a = str | split: '.tar.gz">' -%}
+      {%- assign b = a[2] | split: '</a></td>' -%}
+      {%- assign c = b[0] | split: '.' -%}
+      {%- assign d = c[3] | split: '-' -%}
+      {{d[1] | capitalize }}
+   {%- endif -%}
+{%- endfor -%}

--- a/_includes/root_stable_sample
+++ b/_includes/root_stable_sample
@@ -1,0 +1,11 @@
+{%- assign sorted = site.releases | reverse -%}
+{%- for release in sorted -%}
+   {%- if release.state == "latest" -%}
+      {%- assign content = release.content -%}
+      {%- assign pieces = content | split: '| [' -%}
+      {%- assign str = content -%}
+      {%- assign a = str | split: '.tar.gz">' -%}
+      {%- assign b = a[2] | split: '</a></td>' -%}
+      {{ b[0] }}
+   {%- endif -%}
+{%- endfor -%}

--- a/_includes/root_stable_version_dash
+++ b/_includes/root_stable_version_dash
@@ -1,6 +1,6 @@
 {%- assign sorted = site.releases | reverse -%}
 {%- for release in sorted -%}
    {%- if release.state == "latest" -%}
-      {{release.version}}
+      {{ release.version | replace: ".","-" | replace: "/","-" }}
    {%- endif -%}
 {%- endfor -%}

--- a/_includes/root_stable_version_date
+++ b/_includes/root_stable_version_date
@@ -1,6 +1,6 @@
 {%- assign sorted = site.releases | reverse -%}
 {%- for release in sorted -%}
    {%- if release.state == "latest" -%}
-      {{release.version}}
+      {{release.release_date | date: "%b %d %Y"}}
    {%- endif -%}
 {%- endfor -%}

--- a/_includes/root_stable_version_dot
+++ b/_includes/root_stable_version_dot
@@ -1,6 +1,6 @@
 {%- assign sorted = site.releases | reverse -%}
 {%- for release in sorted -%}
    {%- if release.state == "latest" -%}
-      {{release.version}}
+      {{ release.version | replace: "/","." }}
    {%- endif -%}
 {%- endfor -%}

--- a/_includes/root_stable_version_relative_url
+++ b/_includes/root_stable_version_relative_url
@@ -1,1 +1,6 @@
-{% assign sorted = site.releases | reverse %}{% for release in sorted %}{% if release.state == "latest" %}{{ release.url | relative_url }}{% endif %}{% endfor %}
+{%- assign sorted = site.releases | reverse -%}
+{%- for release in sorted -%}
+   {%- if release.state == "latest" -%}
+      {{ release.url | relative_url }}
+   {%- endif -%}
+{%- endfor -%}

--- a/_includes/root_stable_version_short
+++ b/_includes/root_stable_version_short
@@ -1,1 +1,6 @@
-{% assign sorted = site.releases | reverse %}{% for release in sorted %}{% if release.state == "latest" %}{{release.version | replace:".","" | truncate: 3, "" }}{% endif %}{% endfor %}
+{%- assign sorted = site.releases | reverse -%}
+   {%- for release in sorted -%}
+      {%- if release.state == "latest" -%}
+         {{release.version | replace:".","" | truncate: 3, "" }}
+   {%- endif -%}
+{%- endfor -%}

--- a/_includes/root_stable_version_url
+++ b/_includes/root_stable_version_url
@@ -1,1 +1,0 @@
-{% assign sorted = site.releases | reverse %}{% for release in sorted %}{% if release.state == "latest" %}{{ release.url }}{% endif %}{% endfor %}

--- a/install/index.md
+++ b/install/index.md
@@ -24,11 +24,11 @@ The steps to install a pre-compiled binary are simple:
 1. Unpack the archive
 1. Add the ROOT libraries and executables to your environment by sourcing the appropriate `thisroot.*` script. These setup scripts can be found in the ROOT binary release, in the `bin` directory.
 
-For example, on Ubuntu 20, a user could execute the following bash commands to install ROOT v6.24/02, after installing all [required dependencies]({{'/install/dependencies' | relative_url}}):
+For example, on {% include root_stable_os %}, a user could execute the following bash commands to install ROOT v{% include root_stable_version %}, after installing all [required dependencies]({{'/install/dependencies' | relative_url}}):
 
 ```bash
-$ wget https://root.cern/download/root_v6.24.02.Linux-ubuntu20-x86_64-gcc9.3.tar.gz
-$ tar -xzvf root_v6.24.02.Linux-ubuntu20-x86_64-gcc9.3.tar.gz
+$ wget https://root.cern/download/{% include root_stable_sample %}
+$ tar -xzvf {% include root_stable_sample %}
 $ source root/bin/thisroot.sh # also available: thisroot.{csh,fish,bat}
 ```
 
@@ -51,10 +51,10 @@ C:\Users\username>c:\root\bin\thisroot.bat
 
 C:\Users\username>root
    ------------------------------------------------------------------
-  | Welcome to ROOT 6.25/01                        https://root.cern |
+  | Welcome to ROOT {% include root_stable_version %}                        https://root.cern |
   | (c) 1995-2021, The ROOT Team; conception: R. Brun, F. Rademakers |
-  | Built for win32 on Sep 20 2021, 11:34:39                         |
-  | From heads/master@v6-25-01-1903-g6928212418                      |
+  | Built for win32 on {% include root_stable_version_date %}, 11:34:39                         |
+  | From tags/{% include root_stable_version_dash %}@{% include root_stable_version_dash %}                                        |
   | With MSVC 19.29.30133.0                                          |
   | Try '.help', '.demo', '.license', '.credits', '.quit'/'.q'       |
    ------------------------------------------------------------------
@@ -230,10 +230,10 @@ ROOT installations with minimal external dependencies are available for Fedora, 
 /cvmfs/sft.cern.ch/lcg/app/releases/ROOT/<version>/<platform>
 ```
 
-For example, to set up ROOT 6.24/02 on a CentOS7 machine, just run:
+For example, to set up ROOT {% include root_stable_version %} on a {% include root_stable_os %} machine, just run:
 
 ```
-source /cvmfs/sft.cern.ch/lcg/app/releases/ROOT/6.24.02/x86_64-centos7-gcc48-opt/bin/thisroot.sh
+source /cvmfs/sft.cern.ch/lcg/app/releases/ROOT/{% include root_stable_version_dot %}/{% include root_stable_dir %}/bin/thisroot.sh
 ```
 
 Make sure you use your system's default compiler, just like this ROOT build.
@@ -247,10 +247,10 @@ ROOT, Geant4 and many other packages with all their dependencies are available a
 ```
 
 LCG views are available for CentOS7, CentOS8 and the latest MacOS and Ubuntu releases.
-For example, on CERN LXPLUS, you can set up a full environment that contains ROOT 6.24/00 with:
+For example, on CERN LXPLUS, you can set up a full environment that contains ROOT {% include root_stable_version %} with:
 
 ```
-source /cvmfs/sft.cern.ch/lcg/views/LCG_100/x86_64-centos7-gcc10-opt/setup.sh
+source /cvmfs/sft.cern.ch/lcg/views/LCG_100/{% include root_stable_dir %}/setup.sh
 ```
 
 To check what ROOT version is contained in an LCG release, you can visit [lcginfo.cern.ch](http://lcginfo.cern.ch/){:target="\_blank"}.

--- a/manual/cling/index.md
+++ b/manual/cling/index.md
@@ -21,10 +21,10 @@ Start up a ROOT session by typing `root` at the system prompt.
 {% highlight C++ %}
 $ root
    ------------------------------------------------------------------
-  | Welcome to ROOT 6.27/01                        https://root.cern |
+  | Welcome to ROOT {% include root_stable_version %}                        https://root.cern |
   | (c) 1995-2022, The ROOT Team; conception: R. Brun, F. Rademakers |
-  | Built for linuxx8664gcc on Apr 07 2022, 13:00:54                 |
-  | From heads/master@v6-25-01-3805-ge505630f86                      |
+  | Built for linuxx8664gcc on {% include root_stable_version_date %}, 13:00:54                 |
+  | From tags/{% include root_stable_version_dash %}@{% include root_stable_version_dash %}                                        |
   | With c++ (Ubuntu 8.4.0-1ubuntu1~18.04) 8.4.0                     |
   | Try '.help'/'.?', '.demo', '.license', '.credits', '.quit'/'.q'  |
    ------------------------------------------------------------------
@@ -587,7 +587,7 @@ gROOT->ProcessLine(".L MyScript.C++")
 
 To change the compilation output directory in order not to pollute your source directory,
 see [TSystem::SetBuildDir](https://root.cern/doc/master/classTSystem.html#ae8790897e77f60ff37876b944f9f0091).
-	
+
 ### Setting the Include Path
 
 

--- a/manual/first_steps_with_root/index.md
+++ b/manual/first_steps_with_root/index.md
@@ -26,10 +26,10 @@ and the ROOT prompt is displayed:
 
 ```
    ------------------------------------------------------------------
-  | Welcome to ROOT 6.27/01                        https://root.cern |
+  | Welcome to ROOT {% include root_stable_version %}                        https://root.cern |
   | (c) 1995-2022, The ROOT Team; conception: R. Brun, F. Rademakers |
-  | Built for linuxx8664gcc on Apr 07 2022, 13:00:54                 |
-  | From heads/master@v6-25-01-3805-ge505630f86                      |
+  | Built for linuxx8664gcc on {% include root_stable_version_date %}, 13:00:54                 |
+  | From tags/{% include root_stable_version_dash %}@{% include root_stable_version_dash %}                                        |
   | With c++ (Ubuntu 8.4.0-1ubuntu1~18.04) 8.4.0                     |
   | Try '.help'/'.?', '.demo', '.license', '.credits', '.quit'/'.q'  |
    ------------------------------------------------------------------

--- a/primer/index.md
+++ b/primer/index.md
@@ -345,7 +345,6 @@ file="canvases.root" object="TF1_DoubleSlit"
 caption="Output of slits.C with parameters 0.2 and 2."
 %}
 
-
 The example first asks for user input, namely the ratio of slit width
 over slit distance, and the number of slits. After entering this
 information, you should see the graphical output as is shown in Figure [2.1](#f21).
@@ -360,19 +359,18 @@ full interference pattern is given by the product of a function
 depending on the ratio of the width and distance of the slits, and a
 second one depending on the number of slits. More important for us here
 is the definition of the interface of these functions to make them
-usable for the ROOT class {% include ref class="TF1" %}: the first argument is the pointer to
-*x*, the second one points to the array of parameters.
+usable for the ROOT class {% include ref class="TF1" %}:
+the first argument is the pointer to *x*, the second one points to the
+array of parameters.
 
 The main program starts at line 21 with the definition of a function
 `slits()` of type `void`. After asking for user input, a ROOT function
 is defined using the C-type function given in the beginning. We can now
-use all methods of the {% include ref class="TF1" %} class to control the behaviour of our
-function -- nice, isn't it ?
+use all methods of the {% include ref class="TF1" %} class to control the behaviour of our function -- nice, isn't it ?
 
 If you like, you can easily extend the example to also plot the
 interference pattern of a single slit, using function `double single`,
-or of a grid with narrow slits, function `double nslit0`, in {% include ref class="TF1" %}
-instances.
+or of a grid with narrow slits, function `double nslit0`, in {% include ref class="TF1" %} instances.
 
 Here, we used a macro, some sort of lightweight program, that the
 interpreter distributed with ROOT, Cling, is able to execute. This is a


### PR DESCRIPTION
- Use the latest release in the code snippets shown in various places. it fixes https://github.com/root-project/web/issues/317

- make some scripts more readable

- fix some formatting in the Primer