### PR TITLE
prevent ambiguity in what latest release means

### DIFF
--- a/install/all_releases/index.md
+++ b/install/all_releases/index.md
@@ -12,7 +12,7 @@ sidebar:
 <td style="border: 0px"><a href="{{ 'feed/releases.xml' | relative_url }}"><img style="width:auto; height:2.0em;" src="{{'/assets/images/feed.svg' | relative_url}}"></a></td>
 </tr></table>
 <br>
-{% include releases_list state="latest" label="LATEST" single_column="yes" %}
+{% include releases_list state="latest" label="LATEST STABLE" single_column="yes" %}
 
 ### Version 6
 


### PR DESCRIPTION
As reported by several users:
https://root-forum.cern.ch/t/latest-root-release/52243

Make the label more explicit.