### PR TITLE
Fix `ClassDef` macro call in code example for custom classes

### DIFF
--- a/manual/io_custom_classes/index.md
+++ b/manual/io_custom_classes/index.md
@@ -235,7 +235,7 @@ _**Example**_
 class MyClass {
    // Note that the initial version number should be greater than the number of previously, unnumbered (i.e. lacking a
    // explicit `ClassDef`) versions of the class. If unsure, `3` is typically a good compromise.
-   ClassDef("MyClass", 3)
+   ClassDef(MyClass, 3)
 };
 {% endhighlight %}
 


### PR DESCRIPTION
The class name passed to the `ClassDef` macro should not be put into double quotes.

Closes https://github.com/root-project/root/issues/12869.