### PR TITLE
Update the Shifter's Instructions

### DIFF
--- a/for_developers/shifters_instructions/index.md
+++ b/for_developers/shifters_instructions/index.md
@@ -16,7 +16,7 @@ It is responsibility of the shifter to make sure this happens, either answering 
 involving the relevant expert.
 
 ### Failing tests
-The shifter has the responsibility to "keep the builds green". She needs to fix
+The shifter has the responsibility to "keep the builds green". He/she needs to fix
 the broken tests in the incremental and nightly builds and/or involve the relevant
 experts to make that happen.
 
@@ -29,19 +29,12 @@ immediately if they are acceptable (i.e. passing continuous integration and shif
 
 ### Incoming issues
 The shifter should check incoming issues for completeness and do an assignment where it is clear.
-We have a [GitHub project](https://github.com/root-project/root/projects/2) that lists issues that are waiting to be triaged.
-
-In order to do the triage, the steps below should be followed:
-1. Go through all issues that require triage in the [triage project](https://github.com/root-project/root/projects/2).
-2. For each issue, assign to the relevant people and add labels, e.g. type of issue, related ROOT components, priority,
+For each unassigned issue, the shifter should assign to the relevant people and add labels, e.g. type of issue, related ROOT components, priority,
 affected branches.
-3. In the [triage project view](https://github.com/root-project/root/projects/2), remove the triaged issues
-from the project by clicking on `... -> Remove from project`.
 
 ### Links to check daily
 
 - [Forum](https://root-forum.cern.ch/latest)
 - [Nightly builds](https://lcgapp-services.cern.ch/root-jenkins/view/ROOT%20Nightly/)
-- [Issues that need triage](https://github.com/root-project/root/projects/2)
 - [Unassigned issues](https://github.com/root-project/root/issues?q=is%3Aopen+is%3Aissue+no%3Aassignee)
 - [Unassigned pull requests](https://github.com/root-project/root/pulls?q=is%3Aopen+is%3Apr+no%3Aassignee)


### PR DESCRIPTION
Remove references to the `Issues that need triage` project, given that it is not used anymore (closed).