### PR TITLE
release_checklist: simplify doxygen / QCH

### DIFF
--- a/for_developers/release_checklist/index.md
+++ b/for_developers/release_checklist/index.md
@@ -35,8 +35,6 @@ This assumes you try to create `v6-22-00-patches`, adjust accordingly.
         * create the branch: `git checkout -b v6-22-00-patches`
   1. Update the reference guide build procedure
       - in `documentation/doxygen/Doxyfile` set `GENERATE_QHP          = NO`
-      - in `documentation/doxygen/Doxyfile` set `QCH_FILE              =`
-      - in `documentation/doxygen/Doxyfile` set `QHG_LOCATION          =`
       - in `documentation/doxygen/Makefile` remove the line `gzip $(DOXYGEN_IMAGE_PATH)/ROOT.qch`
       - in the web site repository, in the file [`reference/index.md`]({{'reference' | relative_url }}),
         add the line corresponding to this release.


### PR DESCRIPTION
The doc for `QCH_FILE` says this variable is ignored, unless `QHG_LOCATION` is set. The doc for the latter says it's ignored unless `GENERATE_QHP` is set. So just unsetting `GENERATE_QHP` should do what we want: prevent ROOT.qch from being created.