### PR TITLE
Make instructions for Docker run more readable

### DIFF
--- a/install/index.md
+++ b/install/index.md
@@ -280,16 +280,6 @@ For example, to try out the latest ROOT release just run the following command i
 docker run --rm -it rootproject/root:latest
 ```
 
-Note that the --rm flag tells Docker to remove the container, together with its data, once it is shut down. In order to persist data, it is recommended to mount a directory on the container. For example, to mount your home directory on Linux and Mac, run:
-```cmd
-docker run --rm -it -v ~:/userhome --user $(id -u) rootproject/root
-```
-
-On Windows, you have to specify the full path to your user directory:
-```cmd
-docker run --rm -it -v C:\\Users\\Username:/userhome rootproject/root
-```
-
 For more instructions on running root's docker image, visit [ROOT's official DockerHub](https://hub.docker.com/r/rootproject){:target="\_blank"}.
 
 

--- a/install/index.md
+++ b/install/index.md
@@ -277,7 +277,7 @@ ROOT Docker containers for several linux flavours are available at [ROOT's offic
 
 For example, to try out the latest ROOT release just run the following command in your terminal (after starting docker engine):
 ```cmd
-docker run --rm -it rootproject/root:latest
+docker run -it rootproject/root:latest
 ```
 
 For more instructions on running root's docker image, visit the **Get Started** section of [ROOT's official DockerHub](https://hub.docker.com/r/rootproject/root){:target="\_blank"}.

--- a/install/index.md
+++ b/install/index.md
@@ -275,7 +275,23 @@ This will drop you into a new shell where all software from the prefix is availa
 
 ROOT Docker containers for several linux flavours are available at [ROOT's official DockerHub](https://hub.docker.com/r/rootproject){:target="\_blank"}.
 
-For example, to try out the latest ROOT release just run `docker run -it rootproject/root`.
+For example, to try out the latest ROOT release just run the following command in your terminal (after starting docker engine):
+```cmd
+docker run --rm -it rootproject/root:latest
+```
+
+Note that the --rm flag tells Docker to remove the container, together with its data, once it is shut down. In order to persist data, it is recommended to mount a directory on the container. For example, to mount your home directory on Linux and Mac, run:
+```cmd
+docker run --rm -it -v ~:/userhome --user $(id -u) rootproject/root
+```
+
+On Windows, you have to specify the full path to your user directory:
+```cmd
+docker run --rm -it -v C:\\Users\\Username:/userhome rootproject/root
+```
+
+For more instructions on running root's docker image, visit [ROOT's official DockerHub](https://hub.docker.com/r/rootproject){:target="\_blank"}.
+
 
 # Run on CERN LXPLUS
 

--- a/install/index.md
+++ b/install/index.md
@@ -273,14 +273,14 @@ This will drop you into a new shell where all software from the prefix is availa
 
 # Run in a Docker container
 
-ROOT Docker containers for several linux flavours are available at [ROOT's official DockerHub](https://hub.docker.com/r/rootproject){:target="\_blank"}.
+ROOT Docker containers for several linux flavours are available at [ROOT's official DockerHub](https://hub.docker.com/u/rootproject){:target="\_blank"}.
 
 For example, to try out the latest ROOT release just run the following command in your terminal (after starting docker engine):
 ```cmd
 docker run --rm -it rootproject/root:latest
 ```
 
-For more instructions on running root's docker image, visit [ROOT's official DockerHub](https://hub.docker.com/r/rootproject){:target="\_blank"}.
+For more instructions on running root's docker image, visit the **Get Started** section of [ROOT's official DockerHub](https://hub.docker.com/r/rootproject/root){:target="\_blank"}.
 
 
 # Run on CERN LXPLUS


### PR DESCRIPTION
- Removed misleading '.' for docker run command
- Added few more steps for Docker pulls (based out of DockerHub documentation)
- Overall, made Docker section more readable.

Image to explain need for reformatted test (within Markdown code block):
![PR](https://github.com/root-project/web/assets/70965472/6dc59fda-9677-4ae4-97b3-752da2658d69)

- I personally had trouble with the given text as the fullstop after the command brought around the assumption that the current directory was to be specified during the docker dun command? Therefore, edited it out to make it more readable + Added extra run commands (based from the Docker Hub page).