### PR TITLE
Bumpt GH checkout workflow to v4:

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Build website
         uses: root-project/jekyll-action@HEAD


### PR DESCRIPTION
v2 uses deprecated old nodejs.