### PR TITLE
Fix incorrect wording of minor version backward compatibility

### DIFF
--- a/about/versioning.md
+++ b/about/versioning.md
@@ -8,7 +8,7 @@ sidebar:
 
 The naming convention for ROOT versions is `v<MAJOR>.<MINOR>/<PATCH>` (e.g. `v6.20/04`).
 
-Minor version numbers that are even (e.g. `v6.18`, `v6.20`) indicate *stable* branches, typically available as a release. Odd minor version numbers (e.g. `v6.19`, `v6.21`) are *development* branches and are never released. Patch versions follow a similar convention: all releases have even patch version number, e.g. `v6.20/02` or `v6.18/04`. Always make sure to use the latest patch release for your ROOT version to benefit from the latest bug fixes.
+Minor version numbers that are even (e.g. `v6.28`, `v6.30`) indicate *stable* branches, typically available as a release. Odd minor version numbers (e.g. `v6.29`, `v6.31`) are *development* branches and are never released. Patch versions follow a similar convention: all releases have even patch version number, e.g. `v6.30.02` or `v6.28.10`. Always make sure to use the latest patch release for your ROOT version to benefit from the latest bug fixes.
 
 # Backward and forward compatibility
 
@@ -16,6 +16,8 @@ Major version changes in ROOT are exceedingly rare, and indicate large backward 
 
 **Across all versions**, ROOT guarantees **I/O backward and forward compatibility**: any file written by older ROOT versions must be readable by newer ROOT versions, and any file written by newer ROOT versions should be readable by older ROOT versions (more precisely, because of possible introduction of new compression algorithms: by the latest release of any of the active previous ROOT versions).
 
-**Across minor versions** ROOT guarantees **source backward compatibility**, i.e. "your source code will still compile". You can expect that any breakage to existing code should be called out in the release notes, and it will most commonly be preceded by deprecation warnings. If not, please [report the problem](https://sft.its.cern.ch/jira/projects/ROOT?selectedItem=com.atlassian.jira.jira-projects-plugin%3Asummary-page) as a bug. We reserve the right to add default parameters to function signatures and make other minor changes to APIs that will not break the vast majority of client code.
+**Across minor versions** ROOT does not fully guarantee **user code backward compatibility**, i.e. "your source code might not compile in some cases". You can expect that any breakage to existing code should be called out in the release notes, and it will most commonly be preceded by deprecation warnings. If not, please [report the problem](https://github.com/root-project/root/issues/new/choose) as a bug.
+
+**Across patch releases** ROOT guarantees **user code backward compatibility**, i.e. "your source code will still compile". If not, please [report the problem](https://github.com/root-project/root/issues/new/choose) as a bug. We reserve the right to add default parameters to function signatures and make other minor changes to APIs that will not break the vast majority of client code.
 
 **ROOT does not guarantee ABI backward compatibility** across versions.

--- a/about/versioning.md
+++ b/about/versioning.md
@@ -18,6 +18,6 @@ Major version changes in ROOT are exceedingly rare, and indicate large backward 
 
 **Across minor versions** (e.g. between 6.28 and 6.30) ROOT does not fully guarantee **user code backward compatibility**, i.e. "your source code might not compile in some cases". You can expect that any such breakage to existing code should be called out in the release notes, and it will most commonly be preceded by deprecation warnings. If not, please [report the problem](https://github.com/root-project/root/issues/new/choose) as a bug.
 
-**Across patch releases** ROOT guarantees **user code backward compatibility**, i.e. "your source code will still compile". If not, please [report the problem](https://github.com/root-project/root/issues/new/choose) as a bug. We reserve the right to add default parameters to function signatures and make other minor changes to APIs that will not break the vast majority of client code.
+**Across patch releases** (e.g. between 6.28.04 and 6.28.08) ROOT guarantees **user code backward compatibility**, i.e. "your source code will still compile". If not, please [report the problem](https://github.com/root-project/root/issues/new/choose) as a bug. We reserve the right to add default parameters to function signatures and make other minor changes to APIs that will not break the vast majority of client code.
 
 **ROOT does not guarantee ABI backward compatibility** across versions.

--- a/about/versioning.md
+++ b/about/versioning.md
@@ -16,7 +16,7 @@ Major version changes in ROOT are exceedingly rare, and indicate large backward 
 
 **Across all versions**, ROOT guarantees **I/O backward and forward compatibility**: any file written by older ROOT versions must be readable by newer ROOT versions, and any file written by newer ROOT versions should be readable by older ROOT versions (more precisely, because of possible introduction of new compression algorithms: by the latest release of any of the active previous ROOT versions).
 
-**Across minor versions** ROOT does not fully guarantee **user code backward compatibility**, i.e. "your source code might not compile in some cases". You can expect that any breakage to existing code should be called out in the release notes, and it will most commonly be preceded by deprecation warnings. If not, please [report the problem](https://github.com/root-project/root/issues/new/choose) as a bug.
+**Across minor versions** (e.g. between 6.28 and 6.30) ROOT does not fully guarantee **user code backward compatibility**, i.e. "your source code might not compile in some cases". You can expect that any such breakage to existing code should be called out in the release notes, and it will most commonly be preceded by deprecation warnings. If not, please [report the problem](https://github.com/root-project/root/issues/new/choose) as a bug.
 
 **Across patch releases** ROOT guarantees **user code backward compatibility**, i.e. "your source code will still compile". If not, please [report the problem](https://github.com/root-project/root/issues/new/choose) as a bug. We reserve the right to add default parameters to function signatures and make other minor changes to APIs that will not break the vast majority of client code.
 


### PR DESCRIPTION
https://root-forum.cern.ch/t/root-version-compatibily-clarification/57345/4

And update old JIRA link

as well as semantic slash by dot