### PR TITLE
Update LCG link to newest `LCG_105` release and correct architecture

### DIFF
--- a/install/index.md
+++ b/install/index.md
@@ -253,10 +253,10 @@ ROOT, Geant4 and many other packages with all their dependencies are available a
 ```
 
 LCG views are available for CentOS 7, RHEL 9 (which also covers the binary-compatible AlmaLinux 9), and the latest macOS and Ubuntu releases.
-For example, on CERN LXPLUS (AlmaLinux 9), you can set up a full environment that contains ROOT 6.30 with:
+For example, on CERN LXPLUS (AlmaLinux 9), you can set up a full environment that contains ROOT 6.30.02 with:
 
 ```bash
-source /cvmfs/sft.cern.ch/lcg/views/LCG_104/aarch64-el9-gcc11-opt/setup.sh
+source /cvmfs/sft.cern.ch/lcg/views/LCG_105/x86_64-el9-gcc11-opt/setup.sh
 ```
 
 To check what ROOT version is contained in an LCG release, you can visit [lcginfo.cern.ch](http://lcginfo.cern.ch/){:target="\_blank"}.


### PR DESCRIPTION
Chore that needs to be done now that LCG_105 is released.