### PR TITLE
Mention select-component in VisualStudio

### DIFF
--- a/_releases/make-release-page.py
+++ b/_releases/make-release-page.py
@@ -393,7 +393,7 @@ Windows 10/7/... are supported. We offer two packaging types:
 
 ### Important installation notes
 
- * You must download the binary built with the exact same version of Visual Studio than the one installed on your system.
+ * You must download the binary built with the exact same version of Visual Studio than the one installed on your system. Don't forget to select the component “Desktop development with C++" when running the Visual Studio Installer.
  * Do not untar in a directory with a name containing blank characters.
  * Take the release version if performance matters.
  * If you want to debug your code you need the ROOT debug build (you cannot mix release / debug builds due to a Microsoft restriction).


### PR DESCRIPTION
If this option isn't selected ROOT will not work. If you don't know much about VS and ROOT it will take you some time to figure that out so I'm suggesting to add it to the guide:

### Important installation notes

 * You must download the binary built with the exact same version of Visual Studio than the one installed on your system. **_Don't forget to select the component “Desktop development with C++" when running the Visual Studio Installer._**
 * Do not untar in a directory with a name containing blank characters.
 * Take the release version if performance matters.
 * If you want to debug your code you need the ROOT debug build (you cannot mix release / debug builds due to a Microsoft restriction).