### PR TITLE
Mention Powershell in the documentation

### DIFF
--- a/_releases/make-release-page.py
+++ b/_releases/make-release-page.py
@@ -389,7 +389,7 @@ See [instructions to build from source](../../install/#build-from-source){{:targ
 Windows 10/7/... are supported. We offer two packaging types:
 
  * **exe**: a regular Windows installer package also setting up the required environment variables. With uninstall via "Control Panel" / "Add or Remove Programs". Simply download and start. You can double-click ROOT to run it; ROOT files get registered with Windows.
- * **tar**: unpack e.g. with [7zip](https://www.7-zip.org). Start ROOT in a Microsoft Visual Studio Prompt (in Start / Programs / Microsoft Visual Studio / Tools). If you installed ROOT to C:\\root then call C:\\root\\bin\\thisroot.bat before using ROOT to set up required environment variables.
+ * **tar**: unpack e.g. with [7zip](https://www.7-zip.org). Start ROOT in a Microsoft Visual Studio Prompt (in Start / Programs / Microsoft Visual Studio / Tools). If you installed ROOT to `C:\\root` then call `C:\\root\\bin\\thisroot.bat` before using ROOT to set up required environment variables. Call instead `thisroot.ps1` if you run from a `powershell` (the default terminal in Visual Studio Code).
 
 ### Important installation notes
 

--- a/install/index.md
+++ b/install/index.md
@@ -66,7 +66,7 @@ C:\Users\username>root
 root [0]
 ```
 
-If you want to run ROOT from within Visual Studio Code, the default terminal is `powershell`, so you need to call `C:\root\bin\thisroot.ps1` instead of `C:\root\bin\thisroot.ps1` before calling `root`.
+If you want to run ROOT from within Visual Studio Code, the default terminal is `powershell`, so you need to call `C:\root\bin\thisroot.ps1` instead of `C:\root\bin\thisroot.bat` before calling `root`.
 
 If you are interested in testing (unstable) development features, you can check out the [nightlies](nightlies){:target="\_blank"}.
 

--- a/install/index.md
+++ b/install/index.md
@@ -33,7 +33,7 @@ For example, on {% include root_stable_os %}, a user could execute the following
 ```bash
 $ wget https://root.cern/download/{% include root_stable_sample %}
 $ tar -xzvf {% include root_stable_sample %}
-$ source root/bin/thisroot.sh # also available: thisroot.{csh,fish,bat}
+$ source root/bin/thisroot.sh # also available: thisroot.{csh,fish,bat,ps1}
 ```
 
 To avoid having to `source thisroot.sh` every time one needs to use ROOT, it is typical to add the command to
@@ -65,6 +65,8 @@ C:\Users\username>root
 
 root [0]
 ```
+
+If you want to run ROOT from within Visual Studio Code, the default terminal is powershell, so you need to call C:\root\bin\thisroot.ps1 instead of C:\root\bin\thisroot.ps1 before calling `root`.
 
 If you are interested in testing (unstable) development features, you can check out the [nightlies](nightlies){:target="\_blank"}.
 
@@ -317,3 +319,5 @@ C:\Users\username>cmake -G"Visual Studio 16 2019" -A Win32 -Thost=x64 -DCMAKE_VE
 C:\Users\username>cmake --build . --config Release --target install
 C:\Users\username>..\root_install\bin\thisroot.bat
 ```
+
+If running on Windows from `Powershell` (the default on Visual Studio Code), call instead thisroot.ps1

--- a/install/index.md
+++ b/install/index.md
@@ -66,7 +66,7 @@ C:\Users\username>root
 root [0]
 ```
 
-If you want to run ROOT from within Visual Studio Code, the default terminal is powershell, so you need to call C:\root\bin\thisroot.ps1 instead of C:\root\bin\thisroot.ps1 before calling `root`.
+If you want to run ROOT from within Visual Studio Code, the default terminal is `powershell`, so you need to call `C:\root\bin\thisroot.ps1` instead of `C:\root\bin\thisroot.ps1` before calling `root`.
 
 If you are interested in testing (unstable) development features, you can check out the [nightlies](nightlies){:target="\_blank"}.
 
@@ -320,4 +320,4 @@ C:\Users\username>cmake --build . --config Release --target install
 C:\Users\username>..\root_install\bin\thisroot.bat
 ```
 
-If running on Windows from `Powershell` (the default on Visual Studio Code), call instead thisroot.ps1
+If running on Windows from `Powershell` (the default on Visual Studio Code), call instead `thisroot.ps1`.


### PR DESCRIPTION
thisroot.ps1 was added long ago: https://github.com/root-project/root/issues/6815

but the documentation on the website was not updated, so it's hard to know that it exists, and multiple Window users in the forum have asked why running ROOT from within Visual Studio terminal does not work.