### PR TITLE
Add selected presentations

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -301,6 +301,8 @@ collections:
     output: true
   publications:
     output: true
+  presentations:
+    output: true
 
 github: [metadata]
 

--- a/_includes/presentations_list
+++ b/_includes/presentations_list
@@ -1,0 +1,23 @@
+{% assign type = {{include.type}}  %}
+{% assign status = {{include.status}}  %}
+
+{% assign sorted = site.presentations | sort: 'date' | reverse %}
+
+{% for pub in sorted %}
+
+{% if (type == "ALL" and pub.type != "NotROOT") or (type == pub.type) %}
+<p style="margin-left:5%;">
+<em><b>{{ pub.title }}</b></em><br>
+{% if pub.speaker %} Speaker: {% include authors_url list=pub.speaker %}<br>{% endif %}
+{% if pub.speakers %} Speakers: {% include authors_url list=pub.speakers %}<br>{% endif %}
+{% if pub.author %} Author: {% include authors_url list=pub.author %}<br>{% endif %}
+{% if pub.authors %} Authors: {% include authors_url list=pub.authors %}<br>{% endif %}
+{% if pub.publication %}{{ pub.publication }}, {{ pub.year }}<br>{% endif %}
+{% if pub.date %} Date: {{ pub.date | date_to_long_string: "ordinal" }}<br>{% endif %}
+{% if pub.doi %}{% assign number = pub.doi | split: "." %}{% if number.first == "10" %}doi: <a href="https://doi.org/{{ pub.doi }}" target="_blank">{{ pub.doi }}</a><br>{% endif %}{% endif %}
+{% if pub.www %}www: <a href="{{ pub.www }}" target="_blank">{{ pub.www }}</a><br>{% endif %}
+{% if pub.note %} Note: {{ pub.note }}{% endif %}
+</p>
+{% endif %}
+
+{% endfor %}

--- a/_includes/presentations_list
+++ b/_includes/presentations_list
@@ -5,7 +5,10 @@
 
 {% for pub in sorted %}
 
-{% if (type == "ALL" and pub.type != "NotROOT") or (type == pub.type) %}
+{% if type == pub.type or status == "ANY" %}
+{% if pub.type == "NotROOT" and status == "ANY" %}
+{% continue %}
+{% endif %}
 <p style="margin-left:5%;">
 <em><b>{{ pub.title }}</b></em><br>
 {% if pub.speaker %} Speaker: {% include authors_url list=pub.speaker %}<br>{% endif %}

--- a/_includes/presentations_list
+++ b/_includes/presentations_list
@@ -1,5 +1,7 @@
 {% assign type = {{include.type}}  %}
 {% assign status = {{include.status}}  %}
+{% assign before = {{include.before | date: '%Y-%m-%d %H:%M' }}%}
+{% assign after = {{include.after | date: '%Y-%m-%d %H:%M' }}%}
 
 {% assign sorted = site.presentations | sort: 'date' | reverse %}
 
@@ -8,6 +10,17 @@
 {% if type == pub.type or status == "ANY" %}
 {% if pub.type == "NotROOT" and status == "ANY" %}
 {% continue %}
+{% endif %}
+{% assign pubdate = {{pub.date | date: '%Y-%m-%d %H:%M' }}%}
+{% if before %}
+{% if pubdate > before %}
+{% continue %}
+{% endif %}
+{% endif %}
+{% if after %}
+{% if pubdate <= after %}
+{% continue %}
+{% endif %}
 {% endif %}
 <p style="margin-left:5%;">
 <em><b>{{ pub.title }}</b></em><br>

--- a/_includes/publications_list
+++ b/_includes/publications_list
@@ -1,16 +1,14 @@
 {% assign type = {{include.type}}  %}
 {% assign status = {{include.status}}  %}
-{% assign year = {{include.year}}  %}
-
-Type: {{include.type}}
-Status: {{include.status}}
-Year: {{include.year}}
 
 {% assign sorted = site.publications | sort: 'date' | reverse %}
 
 {% for pub in sorted %}
-{% if pub.date %} {% assign mybool =  {{type == "ALL" or type == pub.type or (pub.status == "CITE" and status == "CITE")}} %}{% endif %}
-{% if (type == "ALL" and pub.type != "NotROOT") or (type == pub.type) or (pub.status == "CITE" and status == "CITE")  %}
+
+{% if (type == pub.type or status == "ANY") or (pub.status == "CITE" and status == "CITE") %}
+{% if pub.type == "NotROOT" and status == "ANY" %}
+{% continue %}
+{% endif %}
 <p style="margin-left:5%;">
 <em><b>{{ pub.title }}</b></em><br>
 {% if pub.status and pub.status != "CITE" %} Status: {{ pub.status }}<br>{% endif %}
@@ -21,7 +19,6 @@ Year: {{include.year}}
 {% if pub.doi %}{% assign number = pub.doi | split: "." %}{% if number.first == "10" %}doi: <a href="https://doi.org/{{ pub.doi }}" target="_blank">{{ pub.doi }}</a><br>{% endif %}{% endif %}
 {% if pub.www %}www: <a href="{{ pub.www }}" target="_blank">{{ pub.www }}</a><br>{% endif %}
 {% if pub.note %} Note: {{ pub.note }}{% endif %}
-
 </p>
 {% endif %}
 

--- a/_includes/publications_list
+++ b/_includes/publications_list
@@ -1,11 +1,16 @@
 {% assign type = {{include.type}}  %}
 {% assign status = {{include.status}}  %}
+{% assign year = {{include.year}}  %}
+
+Type: {{include.type}}
+Status: {{include.status}}
+Year: {{include.year}}
 
 {% assign sorted = site.publications | sort: 'date' | reverse %}
 
 {% for pub in sorted %}
-
-{% if type == pub.type or (pub.status == "CITE" and status == "CITE") %}
+{% if pub.date %} {% assign mybool =  {{type == "ALL" or type == pub.type or (pub.status == "CITE" and status == "CITE")}} %}{% endif %}
+{% if (type == "ALL" and pub.type != "NotROOT") or (type == pub.type) or (pub.status == "CITE" and status == "CITE")  %}
 <p style="margin-left:5%;">
 <em><b>{{ pub.title }}</b></em><br>
 {% if pub.status and pub.status != "CITE" %} Status: {{ pub.status }}<br>{% endif %}
@@ -16,6 +21,7 @@
 {% if pub.doi %}{% assign number = pub.doi | split: "." %}{% if number.first == "10" %}doi: <a href="https://doi.org/{{ pub.doi }}" target="_blank">{{ pub.doi }}</a><br>{% endif %}{% endif %}
 {% if pub.www %}www: <a href="{{ pub.www }}" target="_blank">{{ pub.www }}</a><br>{% endif %}
 {% if pub.note %} Note: {{ pub.note }}{% endif %}
+
 </p>
 {% endif %}
 

--- a/_includes/publications_list
+++ b/_includes/publications_list
@@ -1,5 +1,7 @@
 {% assign type = {{include.type}}  %}
 {% assign status = {{include.status}}  %}
+{% assign before = {{include.before | date: '%Y-%m-%d %H:%M' }}%}
+{% assign after = {{include.after | date: '%Y-%m-%d %H:%M' }}%}
 
 {% assign sorted = site.publications | sort: 'date' | reverse %}
 
@@ -8,6 +10,17 @@
 {% if (type == pub.type or status == "ANY") or (pub.status == "CITE" and status == "CITE") %}
 {% if pub.type == "NotROOT" and status == "ANY" %}
 {% continue %}
+{% endif %}
+{% assign pubdate = {{pub.date | date: '%Y-%m-%d %H:%M' }}%}
+{% if before %}
+{% if pubdate > before %}
+{% continue %}
+{% endif %}
+{% endif %}
+{% if after %}
+{% if pubdate <= after %}
+{% continue %}
+{% endif %}
 {% endif %}
 <p style="margin-left:5%;">
 <em><b>{{ pub.title }}</b></em><br>

--- a/_presentations/2024-05-14-ROOT-Status-and-Future-Directions.md
+++ b/_presentations/2024-05-14-ROOT-Status-and-Future-Directions.md
@@ -1,0 +1,8 @@
+---
+layout: default
+title: "The ROOT Project: Status and Future Directions"
+speaker: Danilo Piparo
+author: Danilo Piparo
+type: ROOT
+www: https://indico.cern.ch/event/1369601/contributions/5867782/
+---

--- a/_presentations/2024-05-15-RNTuple-dev-Status.md
+++ b/_presentations/2024-05-15-RNTuple-dev-Status.md
@@ -1,0 +1,8 @@
+---
+layout: default
+title: Development Status of RNtuple, the future HEP Columnar Storage Software Technology 
+speaker: Danilo Piparo
+authors: Danilo Piparo, Jakob Blomer
+type: IO
+www: https://indico.cern.ch/event/1369601/contributions/5867783/
+---

--- a/about/publications.md
+++ b/about/publications.md
@@ -11,6 +11,12 @@ In case you want to cite ROOT in your own publications, this is the preferred re
 
 {% include publications_list status="CITE" %}
 
+## ROOT presentations
+{% include publications_list year="2022" %}
+
+## ROOT papers
+{% include publications_list type="ALL" %}
+
 ## ROOT papers by topics
 
 ### I/O

--- a/about/publications.md
+++ b/about/publications.md
@@ -11,11 +11,11 @@ In case you want to cite ROOT in your own publications, this is the preferred re
 
 {% include publications_list status="CITE" %}
 
-## ROOT presentations
-{% include publications_list year="2022" %}
+## ROOT selected presentations
+{% include presentations_list type="ALL" %}
 
 ## ROOT papers
-{% include publications_list type="ALL" %}
+{% include publications_list status="ANY" %}
 
 ## ROOT papers by topics
 

--- a/about/publications.md
+++ b/about/publications.md
@@ -12,7 +12,7 @@ In case you want to cite ROOT in your own publications, this is the preferred re
 {% include publications_list status="CITE" %}
 
 ## ROOT selected presentations
-{% include presentations_list type="ALL" %}
+{% include presentations_list status="ANY" %}
 
 ## ROOT papers
 {% include publications_list status="ANY" %}

--- a/about/publications.md
+++ b/about/publications.md
@@ -15,7 +15,21 @@ In case you want to cite ROOT in your own publications, this is the preferred re
 {% include presentations_list status="ANY" %}
 
 ## ROOT papers
-{% include publications_list status="ANY" %}
+
+### 2023
+{% include publications_list status="ANY" before="2024-01-01" after="2023-01-01" %}
+
+### 2022
+{% include publications_list status="ANY" before="2023-01-01" after="2022-01-01" %}
+
+### 2021
+{% include publications_list status="ANY" before="2022-01-01" after="2021-01-01" %}
+
+### 2020
+{% include publications_list status="ANY" before="2021-01-01" after="2020-01-01" %}
+
+### Older
+{% include publications_list status="ANY" before="2020-01-01" %}
 
 ## ROOT papers by topics
 


### PR DESCRIPTION
This PR
- introduces a ROOT selected presentations section where relevant public presentations can be listed
- introduces a comprehensive list of ROOT publications listed in reverse chronological order and divided by year

 