### PR TITLE
Remove the CITE status

### DIFF
--- a/_includes/publications_list
+++ b/_includes/publications_list
@@ -5,10 +5,9 @@
 
 {% for pub in sorted %}
 
-{% if type == pub.type or (pub.status == "CITE" and status == "CITE") %}
+{% if type == pub.type %}
 <p style="margin-left:5%;">
 <em><b>{{ pub.title }}</b></em><br>
-{% if pub.status and pub.status != "CITE" %} Status: {{ pub.status }}<br>{% endif %}
 {% if pub.author %} Author: {% include authors_url list=pub.author %}<br>{% endif %}
 {% if pub.authors %} Authors: {% include authors_url list=pub.authors %}<br>{% endif %}
 {% if pub.publication %}{{ pub.publication }}, {{ pub.year }}<br>{% endif %}

--- a/_publications/1997-04-11-AIHENP96-ROOT.md
+++ b/_publications/1997-04-11-AIHENP96-ROOT.md
@@ -1,6 +1,5 @@
 ---
 layout: default
-status: CITE
 title: ROOT - An Object-Oriented Data Analysis Framework.
 authors: René Brun and Fons Rademakers
 publication: Proceedings AIHENP’96 Workshop, Lausanne, Sep. 1996, Nucl. Inst. & Meth. in Phys. Res. A 389 (1997) 81-86. See also https://root.cern/

--- a/about/publications.md
+++ b/about/publications.md
@@ -7,11 +7,7 @@ toc: true
 toc_sticky: true
 ---
 
-In case you want to cite ROOT in your own publications, this is the preferred reference:
-
-{% include publications_list status="CITE" %}
-
-## ROOT papers by topics
+## All ROOT publications by topics
 
 ### I/O
 {% include publications_list type="IO" %}
@@ -35,11 +31,11 @@ In case you want to cite ROOT in your own publications, this is the preferred re
 {% include publications_list type="PARA" %}
 
 ### CINT
-CINT was the C++ interpretor until ROOT version 5. In case you want to cite CINT, use the following references:
+CINT was the C++ interpreter until ROOT version 5. In case you want to cite CINT, use the following references:
 {% include publications_list type="CINT" %}
 
-## Overview papers on ROOT
+## Overview publications on ROOT
 {% include publications_list type="ROOT" %}
 
-## Not ROOT papers, but related
+## Not ROOT publications, but related
 {% include publications_list type="NotROOT" %}


### PR DESCRIPTION
After a discussion with Monica, we decided the CITE status in the publication was not necessary anymore as this is a duplication of the "Cite us" entry on the website. This will simplify the coming new formatting of the publications.  