### PR TITLE
Modifying the outreach section of the website

### DIFF
--- a/get_started/index.md
+++ b/get_started/index.md
@@ -7,21 +7,23 @@ sidebar:
 
 On behalf of the developers, contributors and user community: **welcome to ROOT!**
 
-The [ROOT beginners' guide (aka "Primer")]({{ '/primer' | relative_url }})
-is certainly the first document to read to master the power of ROOT.
+If you have never used ROOT before and don't know where to start, we recommend that you first explore: https://github.com/root-project/student-course
 
-The [Manual]({{ '/manual' | relative_url }}) introduces you to the main parts of ROOT.
+For that purpose you don't need to install ROOT on your machine, you can directly run all the examples and exercises 
+on [SWAN](https://swan.cern.ch){:target="_blank"} (if you have a CERN computing account), otherwise either using github codespaces or binder. 
 
-After this introduction,
-[tutorial presentations (and video!)](https://indico.cern.ch/event/395198){:target="_blank"} offer a
-different, more direct approach to the ROOT fundamental
-concepts as well as some hands-on exercise. In order to integrate the information present
-in the aforementioned sources, [this collection of ROOT courses](courses){:target="_blank"}
-is definitively useful. Once the fundamental concepts have been acquired, a rich set of
-[tutorials]({{ '/tutorials' | relative_url }}) are available to dive into the code.
+The course is written in python. We use jupyter notebooks as the basis to both explain the fundamental concepts and show the code examples. 
+We also provide a few exercises that you can attempt on your own. If you want to know a bit more and complete a few more exercises, 
+we added some extra material that can be found in the above repository as well. 
 
-Remember, you can always resort to the
-[ROOT Forum](https://root-forum.cern.ch){:target="_blank"}
-to find out if someone already solved the problem you are facing or to get help!
+Once you are a bit more familiar with what ROOT offers and how to use it online, you can take a look at how to install it on your machine 
+[install]({{ '/install' | relative_url }}). 
 
+Finally, if you wish to delve a bit further into ROOT functionalities, check the following: 
+* The [ROOT beginners' guide (aka "Primer")]({{ '/primer' | relative_url }})
+* The [Manual]({{ '/manual' | relative_url }}) where more in depth information can be found
+* The full [API Documentation](https://root.cern/doc/master/){:target="_blank"}
+* The [tutorials]({{ '/tutorials' | relative_url }})
+
+Lastly, in case you have a problem or a question, don't hesitate to use the [ROOT Forum](https://root-forum.cern.ch){:target="_blank"}
 

--- a/manual/index.md
+++ b/manual/index.md
@@ -29,36 +29,6 @@ of data analysis with ROOT.
 </div>
 
 <br>
-<h1>Further information</h1>
-
-<div style="border:1px; border-style:solid; border-color:#AAAAAA; background-color:#f5fffa; padding: 0.5em;">
-
-<b><a href="https://root.cern/doc/master/group__Tutorials.html" target="_blank">Tutorials</a></b><br>
-Tutorials are available for all parts of the ROOT.
-Beginners can start with the <a href="{{ "/primer" | relative_url }}">Primer</a>.
-
-<br><br>
-
-<b><a href="https://root.cern/doc/master/" target="_blank">Reference Guide</a></b><br>
-The ROOT Manual provides a high-level explanation of ROOT's functionality and its functional parts.
-Refer to the ROOT Reference Guide instead for detailed information about each ROOT class or function.
-The Reference Guide is <a href="{{ "/reference" | relative_url }}">available for all major ROOT releases</a>.
-
-<br><br>
-
-
-<b><a href="{{ "/topical" | relative_url }}">Topical Manuals</a></b><br>
-Topical manuals are available for some functional parts of ROOT. They contain in-depth
-information for specific topics that are not explained in detail in the ROOT Manual.
-
-<br><br>
-
-<b><a href="https://root-forum.cern.ch/" target="_blank">Forum & Help</a></b><br>
-For ROOT users, developers, and friends we provide a Forum
-in which are also listed some <a href="https://root-forum.cern.ch/c/howto/">frequently asked questions</a>.
-
-</div>
-
 
 > As ROOT is based on the <a href="{{ "/cling" | relative_url }}">Cling</a> C++ interpreter
 > you need  to understand the basics of C++ (or Python) to use it. As C++ language


### PR DESCRIPTION
Our outreach/learning section of the website is a bit outdated and not well organised. The idea is to, first of all, update the links to the most recent student-course and remove link duplications so if we are to share a link to a person who's only starting with ROOT we have it all nicely described and organised (and up to date). 

### Questions to be addressed later (maybe here or with separate PRs): 
- Do we leave the section as "Get Started" or do we rename it to, for example "Learn" (get started could be confusing as we also have a section "Install") 
- We keep adding links to the same things in many places (I started by deleting it from the Manual section), I think we should clean the ROOT Reference Documentation: https://root.cern/doc/master/index.html entry page? 
-  It would be a great time to also sort out our Tutorials and make sure what we have is really relevant and not outdated 
-  Shall we add a "Teachers' corner" somewhere where we point external instructors to the newest and best material they should teach as well? And our recommendation what they should teach about? 