### PR TITLE
Update Arch install instructions

### DIFF
--- a/install/index.md
+++ b/install/index.md
@@ -152,10 +152,8 @@ $ yum install root
 Arch's [ROOT package](https://www.archlinux.org/packages/community/x86_64/root){:target="\_blank"} can be installed with
 
 ```sh
-$ pacman -Syu root
+$ sudo pacman -S root
 ```
-
-The Arch package uses C++17.
 
 ### Gentoo
 


### PR DESCRIPTION
One should not use `-Syu` when installing packages, because system updates should be separate from installing individual packages.

Also, mentioning that Arch used C++17 is not worth it anymore since this is the default C++ standard of ROOT anyway.