### PR TITLE
Correctly parse the new Windows binaries names (not a change of the website but of the script that builds release pages)

### DIFF
--- a/_releases/make-release-page.py
+++ b/_releases/make-release-page.py
@@ -261,12 +261,12 @@ def binaryNameToTitle(filename):
 
         return F"macOS {macOSVers} {arch} Xcode {xcodeVers}"
     elif platformCompiler.startswith('win32') or platformCompiler.startswith('win64'):
-        regexWin = re.compile(r'^win(32|64)[.](vc[0-9]+)(.debug)?')
+        regexWin = re.compile(r'^win(32|64)[.](python3[0-9]+)[.](vc[0-9]+)(.debug)?')
         matchWin = regexWin.match(platformCompiler)
         if not matchWin:
             print(F'ERROR: cannot parse Win32 MSVC version for {filename}')
             return filename
-        (bitness, vcVers, debug) = matchWin.groups()
+        (bitness, pythonVers, vcVers, debug) = matchWin.groups()
         if not debug:
             debug = ''
         else:
@@ -291,7 +291,7 @@ def binaryNameToTitle(filename):
             bitArch = "x86"
         else:
             bitArch = "x64"
-        return F"Windows Visual Studio {versYear} {bitness}-bit {bitArch} {debug}"
+        return F"Windows Visual Studio {versYear} {bitness}-bit {bitArch}{debug}"
     else:
         frameinfo = getframeinfo(currentframe())
         print(F'ERROR: unknown platform {platformCompiler} for {filename}. Please edit {frameinfo.filename}:{frameinfo.lineno}')


### PR DESCRIPTION
Before this improvement https://github.com/root-project/root/commit/1998f735fe7094e1f7fc5078f50ca40030426262 they had names like "root_v6.35.01.win64.vc17.zip". After this improvement, i.e. 2024-11-7, "root_v6.35.01.win64.python311.vc17.zip" i.e. they encode the python version.