### PR TITLE
New way to present ROOT examples in a gallery

### DIFF
--- a/_includes/example-list
+++ b/_includes/example-list
@@ -1,0 +1,30 @@
+{% assign tutorials_list = page[include.id] %}
+{% assign ref_guide_url = "https://root.cern/doc/master/" %}
+
+<table id="navtable">
+  {% assign i = 0 %}
+  {% for tut in tutorials_list %}
+    {% if i==0 %}
+      <tr>
+    {% endif %}
+    <td>
+      <a href="{{ ref_guide_url }}{{ tut.example | replace: '.C', '_8C'}}.html">
+        <img src="{{ ref_guide_url }}pict1_{{ tut.example }}.png" >
+      </a>
+    <em>
+    {% if tut.title %}{{ tut.title }}{% endif %}
+    </em>
+    </td>
+    {% if i==2 %}
+      </tr>
+    {% endif %}
+    {% assign i = i | plus:1 %}
+    {% if i==3 %}
+      {% assign i = 0 %}
+    {% endif %}
+  {% endfor %}
+  {% if i!=0 %}
+    </tr>
+  {% endif %}
+</table>
+

--- a/_includes/example-list
+++ b/_includes/example-list
@@ -1,19 +1,20 @@
 {% assign tutorials_list = page[include.id] %}
 {% assign ref_guide_url = "https://root.cern/doc/master/" %}
 
-<table id="navtable">
+<table id="navtable" class="fixed">
+    <col width="33%" />
+    <col width="33%" />
+    <col width="33%" />
   {% assign i = 0 %}
   {% for tut in tutorials_list %}
     {% if i==0 %}
       <tr>
     {% endif %}
-    <td>
+    <td style="vertical-align:bottom;">
       <a href="{{ ref_guide_url }}{{ tut.example | replace: '.C', '_8C'}}.html">
-        <img src="{{ ref_guide_url }}pict1_{{ tut.example }}.png" >
+        <img src="{{ ref_guide_url }}pict1_{{ tut.example }}.png">
       </a>
-    <em>
-    {% if tut.title %}{{ tut.title }}{% endif %}
-    </em>
+      <em> {% if tut.title %}{{ tut.title }}{% endif %} </em>
     </td>
     {% if i==2 %}
       </tr>

--- a/gallery/index.md
+++ b/gallery/index.md
@@ -3,6 +3,20 @@ title: Galleries of images produced with ROOT
 layout: single
 toc: true
 toc_sticky: true
+list1:
+  - example: thstackcolorscheme.C
+    title: This example demonstrates how to use the accessible color schemes with THStack.
+  - example: ratioplot1.C
+    title: Example creating a simple ratio plot of two histograms using the pois division option.
+  - example: fillrandom.C
+    title: Fill a 1-D histogram from a parametric function.
+list2:
+  - example: annotation3d.C
+    title: This example show how to put some annotation on a 3D plot using 3D polylines.
+  - example: exclusiongraph.C
+    title: Draw three graphs with an exclusion zone.
+  - example: graphShade.C
+    title: Show how to shade an area between two graphs
 gallery1:
   - url: /gallery/higgs_plots/Atlas_CLs_Exclusion.png
   - url: /gallery/higgs_plots/Atlas_Data_MC_Comparison.png
@@ -124,6 +138,19 @@ gallery5:
   - url: /gallery/visualisation_techniques_and_basics_graphics/Time_on_axis.gif
   - url: /gallery/visualisation_techniques_and_basics_graphics/Two_legos_plots_combined.gif
 ---
+
+## Simple examples - UNDER CONSTRUCTION
+
+Overview of various common functionalities  provided by ROOT
+
+### Histograms Examples
+
+{% include example-list id="list1" %}
+
+### Graphs Examples
+
+{% include example-list id="list2" %}
+
 
 ## Higgs Plots
 

--- a/gallery/index.md
+++ b/gallery/index.md
@@ -8,8 +8,10 @@ list1:
     title: This example demonstrates how to use the accessible color schemes with THStack.
   - example: ratioplot1.C
     title: Example creating a simple ratio plot of two histograms using the pois division option.
-  - example: fillrandom.C
-    title: Fill a 1-D histogram from a parametric function.
+  - example: ContourList.C
+    title: Getting Contours From TH2D.
+  - example: candleplotwhiskers.C
+    title: Example of candle plot showing the whiskers definition.
 list2:
   - example: annotation3d.C
     title: This example show how to put some annotation on a 3D plot using 3D polylines.

--- a/gallery/index.md
+++ b/gallery/index.md
@@ -1,5 +1,5 @@
 ---
-title: Galleries of images produced with ROOT
+title: ROOT examples and galleries of images produced with ROOT
 layout: single
 toc: true
 toc_sticky: true
@@ -139,9 +139,15 @@ gallery5:
   - url: /gallery/visualisation_techniques_and_basics_graphics/Two_legos_plots_combined.gif
 ---
 
-## Simple examples - UNDER CONSTRUCTION
+ ** UNDER CONSTRUCTION **
 
-Overview of various common functionalities  provided by ROOT
+## Examples
+
+This page features example plots. Click on any image to view it in full size along with
+the source code.
+
+For more in-depth examples, visit the [tutorials page](https://root.cern/doc/master/group__Tutorials.html).
+Visit [this page](https://root.cern/learn/) to access a comprehensive list of all available ROOT documentation sources.
 
 ### Histograms Examples
 


### PR DESCRIPTION
New way to present ROOT examples in a gallery.

Still under construction. need to be populated and polished during the hackathon.