### PR TITLE
fix instructions for building documentation with doxygen

### DIFF
--- a/for_developers/doxygen/index.md
+++ b/for_developers/doxygen/index.md
@@ -13,11 +13,11 @@ and tips to be used in source code to generate proper documentation.
 
 ## How to generate locally the doxygen documentation
 Developers can generate the documentation locally to review the results of their changes
-before committing them to the repository. The process is as follows:
+before committing them to the repository. First compile and install ROOT, then the process is as follows:
 
 {% highlight sh %}
 $ cd <root_sources>/documentation/doxygen
-$ source <root_sources>/bin/thisroot.sh
+$ source <root_install_location>/bin/thisroot.sh
 $ make
 {% endhighlight %}
 

--- a/for_developers/doxygen/index.md
+++ b/for_developers/doxygen/index.md
@@ -13,11 +13,11 @@ and tips to be used in source code to generate proper documentation.
 
 ## How to generate locally the doxygen documentation
 Developers can generate the documentation locally to review the results of their changes
-before committing them to the repository. First compile and install ROOT, then the process is as follows:
+before committing them to the repository. First build (and optionally install) ROOT, then the process is as follows:
 
 {% highlight sh %}
 $ cd <root_sources>/documentation/doxygen
-$ source <root_install_location>/bin/thisroot.sh
+$ source <root_install_or_build_location>/bin/thisroot.sh
 $ make
 {% endhighlight %}
 


### PR DESCRIPTION
Fix instructions for building documentation with doxygen.
The instructions stated to source `thisroot.sh` from source tree instead of installed ROOT