### PR TITLE
fix broken links

### DIFF
--- a/for_developers/root7/index.md
+++ b/for_developers/root7/index.md
@@ -34,13 +34,13 @@ Building from source would look similar to this:
 ## ROOT 7 Features
 
 ROOT's new interface personality is already in production with {% include ref class="RDataFrame" namespace="ROOT" %}.
-Next up is the `TTree` successor {% include ref class="RNTuple" namespace="ROOT::Experimental" %}.
+Next up is the `TTree` successor {% include ref class="RNTuple" namespace="ROOT" %}.
 
 
 Still in the design phase are ROOT's new graphics and histogram packages, with tutorials such as
-for [ROOT 7 graphics](https://github.com/root-project/root/tree/master/tutorials/rcanvas),
-for [histograms and ntuple](https://github.com/root-project/root/tree/master/tutorials/v7),
-and specifically for [drawing and styling the new histograms](https://github.com/root-project/root/blob/master/tutorials/rcanvas/rh1.cxx).
+for [ROOT 7 graphics](https://github.com/root-project/root/tree/master/tutorials/experimental/rcanvas),
+for histograms and ntuple,
+and specifically for [drawing and styling the new histograms](https://github.com/root-project/root/blob/master/tutorials/experimental/rcanvas/rh1.cxx).
 
 ## RBrowser
 

--- a/manual/data_frame/index.md
+++ b/manual/data_frame/index.md
@@ -20,7 +20,7 @@ RDataFrame provides the necessary methods to perform all operations required by 
 
 Every RDataFrame program follows this workflow:
 
-1. Construct a dataframe object by specifying a dataset. RDataFrame supports single TTrees as well as multiple TTrees (i.e., {% include ref class="TChain" %}), [CSV files](https://root.cern/doc/master/df014__CSVDataSource_8C.html), [SQLite files](https://root.cern/doc/master/df027__SQliteDependencyOverVersion_8C.html), [RNTuples](https://root.cern/doc/master/structROOT_1_1Experimental_1_1RNTuple.html), and it can be extended to custom data formats. From Python, [NumPy arrays can be imported into RDataFrame](https://root.cern/doc/master/df032__RDFFromNumpy_8py.html) as well.
+1. Construct a dataframe object by specifying a dataset. RDataFrame supports single TTrees as well as multiple TTrees (i.e., {% include ref class="TChain" %}), [CSV files](https://root.cern/doc/master/df014__CSVDataSource_8C.html), [SQLite files](https://root.cern/doc/master/df027__SQliteDependencyOverVersion_8C.html), [RNTuples](https://root.cern/doc/master/classROOT_1_1RNTuple.html), and it can be extended to custom data formats. From Python, [NumPy arrays can be imported into RDataFrame](https://root.cern/doc/master/df032__RDFFromNumpy_8py.html) as well.
 
 2. Transform the dataframe by:
 
@@ -73,7 +73,7 @@ df2.Snapshot("newtree", "newfile.root", ("x","y"))
 {% endhighlight %}
 
 
-Some Python functions can be injected into RDataFrame thanks to [Numba](https://numba.pydata.org), see [this tutorial](https://root.cern/doc/master/pyroot004__NumbaDeclare_8py.html).
+Some Python functions can be injected into RDataFrame thanks to [Numba](https://numba.pydata.org), see [this tutorial](https://root.cern/doc/master/df038__NumbaDeclare_8py.html).
 
 For more examples see [the RDataFrame tutorials](https://root.cern/doc/master/group__tutorial__dataframe.html){:target="_blank"}.
 

--- a/manual/embed_root_in_gui/index.md
+++ b/manual/embed_root_in_gui/index.md
@@ -16,7 +16,7 @@ In the past we [described](https://root-forum.cern.ch/t/how-to-embed-a-tcanvas-i
    caption="TCanvas embedded in a Qt application."
 %}
 
-In this case we recommend to embed the new web-based widgets in [Qt](https://www.qt.io/) application using QWebEngine, as described in [this page](https://github.com/root-project/root/tree/master/tutorials/webgui/qt5web)
+In this case we recommend to embed the new web-based widgets in [Qt](https://www.qt.io/) application using QWebEngine, as described in [this page](https://github.com/root-project/root/tree/master/tutorials/visualisation/webgui/qtweb)
 
 {% include figure_image
    img="qt_rcanvas.png"

--- a/manual/graphics/index.md
+++ b/manual/graphics/index.md
@@ -128,7 +128,7 @@ method:
 - _Arrows_: Use {% include ref class="TArrow" %} to create an arrow.
 - _Polylines_: Use {% include ref class="TPolyLine" %} to create a polyline.
 - _Ellipses_: Use {% include ref class="TEllipse" %} to create an ellipse.
-- _Rectangles_: Use {% include ref class="TBox" %} or {% include ref class="TWBox" %} to create a rectangle.
+- _Rectangles_: Use {% include ref class="TBox" %} or {% include ref class="TWbox" %} to create a rectangle.
 - _Markers_: Use {% include ref class="TMarker" %} to create a marker.
 - _Curly lines and arcs_: Use {% include ref class="TCurlyLine" %} and {% include ref class="TCurlyArc" %} to create curly lines and arcs for Feynman diagrams.
 - _Text and Latex_: Use {% include ref class="TText" %} to draw simple text. {% include ref class="TLatex" %} for complex text like mathematical formulas. Text can be embedded in a box using {% include ref class="TPaveLabel" %}, {% include ref class="TPaveText" %} and {% include ref class="TPavesText" %}.
@@ -338,10 +338,10 @@ _**Example**_
 ### Drawing an axis independently of a graph or a histogram
 
 - Use the {% include ref class="TGaxis" %} class to draw an axis
-[independently of a graph or a histogram](https://root.cern/doc/master/xyplot_8C.html).
+[independently of a graph or a histogram](https://root.cern/doc/master/hist055__Graphics__xyplot_8C.html).
 
 This may be useful if you want to draw a
-[supplementary axis](https://root.cern/doc/master/twoscales_8C.html) for a plot.
+[supplementary axis](https://root.cern/doc/master/hist010__TH1__two__scales_8C.html) for a plot.
 
 
 ## Legends

--- a/manual/histograms/index.md
+++ b/manual/histograms/index.md
@@ -66,7 +66,7 @@ standard multi-dimensional histogram plots such as scatter plots.
 - {% include ref class="TProfile3D" %} is a profile histogram for (X,Y,Z,T) data to display the mean value of T and its error for each cell in X,Y,Z.
 
 Profile plots have the option to display instead of the default sample mean error the sample standard deviation (the spread of the data). A similar plot to a profile, which shows the quantiles of the
-Y input data, is the candle plot, called also box plot,  (see [tutorial](https://root.cern/doc/master/candleplot_8C.html)), which can be obtained directly from the 2D histogram using the `candle`
+Y input data, is the candle plot, called also box plot,  (see [tutorial](https://root.cern/doc/master/hist049__Graphics__candle__plot_8C.html)), which can be obtained directly from the 2D histogram using the `candle`
 draw option.
 
 
@@ -101,11 +101,11 @@ ROOT supports also automatic binning, see [Histograms with automatic bins](https
 **Re-binning**
 
 You can re-bin a histogram via the [TH1::Rebin()](https://root.cern/doc/master/classTH1.html#aff6520fdae026334bf34fa1800946790){:target="_blank"} method. It returns a new histogram with the re-binned contents. If bin errors were stored, they are recomputed during the re-binning.
-You can see this [tutorial](https://root.cern/doc/master/rebin_8C.html) as a re-binning example.
+You can see this [tutorial](https://root.cern/doc/master/hist013__TH1__rebin_8C.html) as a re-binning example.
 
 ### Stack of histograms
 
-{% include ref class="THStack" %} is a collection of {% include ref class="TH1" %} or {% include ref class="TH2" %} histograms. The tutorial {%include tutorial name="hstack" %} is a good example of how using the `THStack` class.
+{% include ref class="THStack" %} is a collection of {% include ref class="TH1" %} or {% include ref class="TH2" %} histograms. The tutorial {%include tutorial name="hist023_THStack_simple" %} is a good example of how using the `THStack` class.
 
 ## Working with histograms
 

--- a/manual/jsroot/index.md
+++ b/manual/jsroot/index.md
@@ -16,7 +16,7 @@ The flexible and powerful [JSROOT API](https://root.cern/js/latest/api.htm) used
 The JSROOT code, documentation, and many examples can be found on the [JSROOT website](https://root.cern/js/),
 with many [examples](https://root.cern/js/latest/examples.htm).
 Its source code repository is [in GitHub](https://github.com/root-project/jsroot/) and there is also a
-[reference guide](https://root.cern/js/latest/jsdoc/JSROOT.html).
+[reference guide](https://github.com/root-project/jsroot/blob/master/docs/JSROOT.md).
 
 ## Users's Guide
 
@@ -43,7 +43,7 @@ Here is a couple of *interactive* examples you can also find in the [main JSROOT
 
 In the [JSROOT user's guide](https://github.com/root-project/jsroot/blob/master/docs/JSROOT.md), there is also a [short introduction](https://github.com/root-project/jsroot/blob/master/docs/JSROOT.md#use-with-openui5) on using JSROOT with [OpenUI5](https://openui5.org/) to create interactive Web based GUI. [OpenUI5](https://openui5.org/) is a web toolkit for developers to ease and speed up the development of full-blown HTML5 web applications. You can find its impressive list of controls [here](https://openui5.hana.ondemand.com/controls)
 
-The association of JSROOT and OpenUI5 allowed us to create the new web based [RCanvas](https://root.cern/doc/master/classROOT_1_1Experimental_1_1RCanvas.html) and [RBrowser](https://root.cern/doc/master/classROOT_1_1Experimental_1_1RBrowser.html) classes.
+The association of JSROOT and OpenUI5 allowed us to create the new web based [RCanvas](https://root.cern/doc/master/classROOT_1_1Experimental_1_1RCanvas.html) and [RBrowser](https://root.cern/doc/master/classROOT_1_1RBrowser.html) classes.
 
 {% include figure_image
    img="rcanvas.png"

--- a/manual/python/index.md
+++ b/manual/python/index.md
@@ -18,7 +18,7 @@ PyROOT is compatible with both Python2 (>= 2.7) and Python3.
 
 Since ROOT 6.22, PyROOT has extensive support for *modern C++* (it operates on top of [cppyy](https://cppyy.readthedocs.io/){:target="_blank"}), is more *pythonic* and is able to *interoperate* with widely-used Python data-science libraries (for example, [NumPy](https://numpy.org/){:target="_blank"}, [pandas](https://pandas.pydata.org/){:target="_blank"}, [Numba](https://numba.pydata.org/){:target="_blank"}).
 
-{% include tutorials name="PyROOT" url="pyroot" %}
+Many ROOT [tutorials]({{'tutorials' | relative_url }}){:target="_blank"} are also available in Python. These tutorials are listed alongside their C++ counterparts in their respective tutorial categories, making it easy to explore both versions.
 
 ## Getting started
 
@@ -427,7 +427,7 @@ len(container) # TypeError: object of type 'MyContainer' has no len()
 # pythonize MyClass by adding `__len__` and binding it to `GetSize`
 from ROOT import pythonization
 @pythonization("MyContainer")
-def pythonize_two_classes(klass):
+def pythonize_length(klass):
     klass.__len__ = klass.GetSize
 
 container = ROOT.MyContainer()
@@ -436,7 +436,7 @@ len(container) # 0
 
 The very same mechanism is used internally in ROOT to pythonize ROOT classes, and it can be applied to user classes too since ROOT v6.26.
 
-A more thorough explanation of the `@pythonization` decorator, its parameters and more examples of usage can be found in the tutorial {% include tutorial_py name="pyroot002_pythonizationDecorator" %}.
+A more thorough explanation of the `@pythonization` decorator, its parameters and more examples of usage can be found in the [Python interface documentation](https://root.cern/doc/master/group__Pythonizations.html).
 
 
 ## TPython: running Python from C++
@@ -483,7 +483,7 @@ Two kernels (or language flavours) allow to use ROOT from Jupyter: *Python* (2 a
 
 - SWAN: CERN provides an online service to create and run Jupyter notebooks, called [SWAN](https://swan.cern.ch){:target="_blank"}. With this option no installation is required: a browser and a working Internet connection are enough. Both the Python and C++ kernels are available in SWAN.
 
-Many ROOT tutorials are available as Jupyter notebooks. For example, most [PyROOT tutorials](https://root.cern/doc/master/group__tutorial__pyroot.html){:target="_blank"} are listed with two buttons below to obtain their notebook version and to open them in SWAN, respectively.
+Many ROOT [tutorials]({{'tutorials' | relative_url }}){:target="_blank"} are available as Jupyter notebooks than can accessed with two buttons below each tutorial to download their notebook version or open them in SWAN, respectively.
 
 ### JavaScript graphics
 

--- a/manual/root_architecture_and_components/index.md
+++ b/manual/root_architecture_and_components/index.md
@@ -154,7 +154,7 @@ _**Example**_
 {% endhighlight %}
 
 
-{% include ref class="TRandomRanluxpp" %} is another generator based on [Ranlux++]( {{ 'blog/ranluxpp' | relative_url }} ).
+[TRandomRanluxpp](https://root.cern/doc/master/TRandomGen_8h.html#a2ff32c3c0c95530bafbb80ca5116b679) is another generator based on [Ranlux++]( {{ 'blog/ranluxpp' | relative_url }} ).
 
 ### gEnv
 

--- a/manual/tmva/index.md
+++ b/manual/tmva/index.md
@@ -29,7 +29,7 @@ above mentioned machine learning techniques. The package includes:
 - Rectangular cut optimisation
 - Support Vector Machine (SVM)
 
-{% include tutorials name="TMVA" url="tmva" %}
+{% include tutorials name="Machine learning" url="ml" %}
 
 ### Ingesting a dataset for training in TMVA
 

--- a/manual/trees/index.md
+++ b/manual/trees/index.md
@@ -23,7 +23,7 @@ In addition to the documentation in this manual, we recommend to take a look at 
 
 > **RNTuple**
 >
-> [RNTuple](https://root.cern/doc/master/md_tree_2ntuple_2v7_2doc_2README.html){:target="_blank"} is the experimental evolution of {% include ref class="TTree" %} columnar data storage. {% include ref class="RNTuple" namespace="ROOT::Experimental" %} introduces robust interfaces, a high-performance storage layout, and an asynchronous, thread-safe scheduling.
+> [RNTuple](https://root.cern/doc/master/md_tree_2ntuple_2v7_2doc_2README.html){:target="_blank"} is the experimental evolution of {% include ref class="TTree" %} columnar data storage. {% include ref class="RNTuple" namespace="ROOT" %} introduces robust interfaces, a high-performance storage layout, and an asynchronous, thread-safe scheduling.
 
 > **RDataFrame**
 >

--- a/tutorials/index.md
+++ b/tutorials/index.md
@@ -6,7 +6,7 @@ sidebar:
 ---
 
 ROOT offers a rich set of tutorials that allow you to see ROOT's building blocks "in action",
-as part of more complex programs. They are separated in two categories: C++ or Python scripts
+as part of more complex programs. They are provided in flavours: C++ or Python scripts
 and Jupyter Notebooks.
 
 The tutorials are available for all major ROOT releases.


### PR DESCRIPTION
Fix a few broken links in manual and developer guide. Most of them comes from changes in ROOT repo:
- renaming or moving tutorials
- splitting PyROOT tutorials to other categories
- moving classes out of `Experimental` namespace