### PR TITLE
Fix an histogramming example

### DIFF
--- a/manual/histograms/index.md
+++ b/manual/histograms/index.md
@@ -128,8 +128,8 @@ For creating variable bins histograms:
 
 {% highlight C++ %}
    double binEdges[] = { 0.0, 0.2, 0.5, 1., 2., 4. };
-   TH1* h1 = new TH1D("h1", "h1 title", 6, binEdges );
-   TH2* h2 = new TH2D("h2", "h2 title", 6, binEdges , 30, -1.5, 3.5);
+   TH1* h1 = new TH1D("h1", "h1 title", 5, binEdges );
+   TH2* h2 = new TH2D("h2", "h2 title", 5, binEdges , 30, -1.5, 3.5);
 {% endhighlight %}
 note that the array of bin edges should be of size `nbins+1` , since it contains the lower and upper range axis values.
 


### PR DESCRIPTION
The number of bins was incorrect in one of the histogramming example.
It was mentionned in this forum post:
https://root-forum.cern.ch/t/root-manual-website-example-for-creating-variable-bins-histogram/64246/2